### PR TITLE
Legend fixes in highcharts

### DIFF
--- a/src/js/utils/charts.js
+++ b/src/js/utils/charts.js
@@ -226,8 +226,11 @@ export default {
 				title: { text: null }
 			},
 			legend: {
+				layout: 'vertical',
 				enabled: true,
 				verticalAlign: 'bottom',
+				// align: 'left',
+				// itemDistance: 100,
 				// Subtract a decent amount for padding
 				itemStyle: { width: `${legendWidth - 20}px` }
 			},


### PR DESCRIPTION
- This fixes the legend overlapping for the land cover loss png export of the chart