### PR TITLE
Load css from app base instead of hardcoded relative path

### DIFF
--- a/src/index.pug
+++ b/src/index.pug
@@ -44,7 +44,7 @@ html
       var _app = {
         cache: %META_VERSION%,
         esri: %ESRI_VERSION%,
-        base: 'https://my.gfw-mapbuilder.org/v1.1.15'
+        base: ''
       };
 
       function loadCSS (url, head) {
@@ -71,8 +71,7 @@ html
         return path.indexOf('/', position) === position ? path.slice(0, -1) : path;
       }
       // Change this to '' if _app.base is a remote url
-      //- var base = location.href.replace(/\/[^/]+$/, '');
-      var base = '';
+      var base = location.href.replace(/\/[^/]+$/, '');
       // Add trailing slash if it is not present
       base = makePath(base);
 

--- a/src/index.pug
+++ b/src/index.pug
@@ -3,8 +3,6 @@ html
   head
     title %DEFAULT_TITLE%
     include jade/meta.pug
-    link(rel='stylesheet', href='%CRITICAL_CSS%')
-    link(rel='stylesheet', href='%APP_CSS%')
     style(type="text/css").
       @font-face {
         font-family: 'Fira Sans';
@@ -46,8 +44,18 @@ html
       var _app = {
         cache: %META_VERSION%,
         esri: %ESRI_VERSION%,
-        base: ''
+        base: 'https://my.gfw-mapbuilder.org/v1.1.15'
       };
+
+      function loadCSS (url, head) {
+        var link = document.createElement('link');
+        link.type = 'text/css';
+        link.rel = 'stylesheet';
+
+        head.appendChild(link);
+
+        link.href = url;
+      }
 
       function makePath (base, path) {
         var position = base.length - 1;
@@ -63,12 +71,19 @@ html
         return path.indexOf('/', position) === position ? path.slice(0, -1) : path;
       }
       // Change this to '' if _app.base is a remote url
-      var base = location.href.replace(/\/[^/]+$/, '');
+      //- var base = location.href.replace(/\/[^/]+$/, '');
+      var base = '';
       // Add trailing slash if it is not present
       base = makePath(base);
 
       // Add _app.base if it is present
       if (_app.base) { base = makePath(base, _app.base); }
+
+      // load styles
+      var head = document.head;
+      loadCSS(makePath(base, '%CRITICAL_CSS%'), head);
+      loadCSS(makePath(base, '%APP_CSS%'), head);
+
       var dojoConfig = {
         parseOnLoad: false,
         async: true,


### PR DESCRIPTION
This is so users would only have to change the `_app.base` url instead of also having to change the linked css files in the `<head>`