### PR TITLE
use correct base when opening report

### DIFF
--- a/src/js/utils/AppUtils.js
+++ b/src/js/utils/AppUtils.js
@@ -192,7 +192,10 @@ const utils = {
     if (window._app.base === window._app.cache) {
       window.open(`report.html?${path}`);
     } else {
-      const appBase = window._app.base.split(window._app.cache)[0];
+      let appBase = window._app.base;
+      if (appBase.substr(-1) !== '/') {
+        appBase += '/';
+      }
       window.open(`${appBase}report.html?${path}`);
     }
   },


### PR DESCRIPTION
When we switch the build process to webpack we changed up the file structure of our hosted files. It used to be `.../v1.1.x/1.1.x/`, we dropped the redundantly named file and it is now just `.../v1.1.x/`.