### PR TITLE
add min-width for legend-icon class

### DIFF
--- a/src/css/legendPanel.styl
+++ b/src/css/legendPanel.styl
@@ -41,6 +41,7 @@
       top 2px
       margin-right 10px
       height 15px
+      min-width 15px
       width 15px
       &.circle
         border-radius 50%


### PR DESCRIPTION
to prevent icon from shrinking with long text in IE.