### PR TITLE
No duplicate symbols in featureLayer legends

### DIFF
--- a/src/js/components/LegendPanel/WebMapFeatureLayerLegend.js
+++ b/src/js/components/LegendPanel/WebMapFeatureLayerLegend.js
@@ -51,9 +51,14 @@ export default class WebMapFeatureLayerLegend extends React.Component {
     const infos = renderer.infos;
 
     if (infos && infos.length > 0) {
+      const labels = [];
+
       infos.forEach((info, idx) => {
-        const symbol = info.symbol;
+        if (labels.indexOf(info.label) === -1) {
+          const symbol = info.symbol;
           this.createSymbolStyles(symbol, container, idx, info);
+          labels.push(info.label);
+        }
       });
       return container;
     }


### PR DESCRIPTION
# **Tickets Addressed**
- [Duplicate AGOL Legend Items](https://blueraster.assembla.com/spaces/WRI_Forest_Atlas/tickets/realtime_list?ticket=788) --> Testable on [beta](https://beta.blueraster.io/mapbuilder/788-agol-duplicate-legends/?appid=277b92455c6c49059a95c9129be7baf9)
