### PR TITLE
Updated our mapLoaded to show legend when switching maps

### DIFF
--- a/src/js/components/Map.js
+++ b/src/js/components/Map.js
@@ -179,6 +179,9 @@ export default class Map extends Component {
       });
 
       on.once(response.map, 'update-end', () => {
+        if (response.map.id !== 'esri.Map_0') {
+          mapLoaded = false;
+        }
         mapActions.createLayers(response.map, settings.layerPanel, this.state.activeLayers, language);
         const cDensityFromHash = this.applyLayerStateFromUrl(response.map, itemData);
         //- Apply the mask layer defintion if present


### PR DESCRIPTION
Addresses #257 and can be tested here: [https://beta.blueraster.io/mapbuilder/257-legend-visible/external.html?l=en](https://beta.blueraster.io/mapbuilder/257-legend-visible/external.html?l=en)

This fixes the hidden legend issue when loading an app from its alternate language via url hash