### PR TITLE
Hot Fix: CSS fixes for Satellite Imagery

### DIFF
--- a/src/css/layerPanel.styl
+++ b/src/css/layerPanel.styl
@@ -269,12 +269,17 @@ div.legend-icon
     margin-right 40px
 
 .fa-button.sml.layer-edit
-  margin 0 10px
-  padding 5 10px
+  margin 0px 10px
   position absolute
   right 20px
-  line-height 10px
+  top 0
+  display flex
+  align-items center
+  justify-content center
   height 20px
+
+  .layer-edit-text
+    line-height initial
 
 .carto-loading
   width 17px

--- a/src/css/modal.styl
+++ b/src/css/modal.styl
@@ -32,7 +32,7 @@
     word-wrap break-word
 
   &.draggable
-    top 25%
+    top 250px
     cursor grab
     z-index 100
 

--- a/src/js/components/LayerPanel/LayerCheckbox.js
+++ b/src/js/components/LayerPanel/LayerCheckbox.js
@@ -138,7 +138,7 @@ export default class LayerCheckbox extends Component {
         <span onClick={this.toggleLayer.bind(this)} className='layer-checkbox-label pointer'>
           {label}
         </span>
-        {onEdit && this.props.checked && <span className='fa-button sml white layer-edit' onClick={onEdit}>Edit</span>}
+        {onEdit && this.props.checked && <div className='fa-button sml white layer-edit' onClick={onEdit}><span className='layer-edit-text'>Edit</span></div>}
 
         <span className={`info-icon pointer ${this.props.iconLoading === this.props.layer.id ? 'iconLoading' : ''}`} onClick={this.showInfo.bind(this)}>
           <SVGIcon id={'shape-info'} />


### PR DESCRIPTION
Satellite Imagery btn: https://github.com/wri/gfw-mapbuilder/issues/297
Change top of satellite imagery modal: https://github.com/wri/gfw-mapbuilder/issues/298

Can be tested here: http://alpha.blueraster.io/gfw-mapbuilder/297-298-imagery-css-fixes/external.html
