### PR TITLE
Reverted share-modal id

### DIFF
--- a/src/external.pug
+++ b/src/external.pug
@@ -4,7 +4,7 @@ html
 
   body.tundra
     #root
-    div#share-modal-wrapper.hidden
+    div#share-modal.modal-wrapper.hidden
     script(id='library-load' src='https://library.gfw-mapbuilder.org/1.3.3.js')
     script.
       var customApp = new MapBuilder({


### PR DESCRIPTION
Test this fix [here](http://alpha.blueraster.io/gfw-mapbuilder/333-share-break/external.html?appid=277b92455c6c49059a95c9129be7baf9) and see why this is broken via [this](url) commit (we changed our `id` and now our `domClass.remove` call won't work!