### PR TITLE
Updated catch on geometry registration

### DIFF
--- a/src/js/utils/analysisUtils.js
+++ b/src/js/utils/analysisUtils.js
@@ -565,6 +565,11 @@ export default {
   getExactGeom: (selectedFeature) => {
     const promise = new Deferred();
     const url = selectedFeature._layer.url;
+
+    if (!url) {
+      return promise.resolve(selectedFeature.geometry);
+    }
+
     const queryTask = new QueryTask(url);
     const query = new Query();
 


### PR DESCRIPTION
Addresses the old #316 in certain use cases, testable (with proper `appid`) [here](https://alpha.blueraster.io.s3.amazonaws.com/gfw-mapbuilder/316-geometry-catch/external.html?appid=0bdf18459d5544e881a06577805f2b8f)