### PR TITLE
Unit test update

### DIFF
--- a/cypress/integration/test_spec.js
+++ b/cypress/integration/test_spec.js
@@ -2,7 +2,7 @@
 describe('An actual test on our app', function () {
   it('Ensures our external constructor has the correct properties', function () {
 
-    cy.visit('https://beta.blueraster.io/mapbuilder/external-debugging/index.html', {
+    cy.visit('https://my.gfw-mapbuilder.org/v1.latest/index.html', {
       onLoad: (winn) => {
         const app = winn.customApp;
         expect(app).to.not.be.an('undefined');
@@ -12,10 +12,6 @@ describe('An actual test on our app', function () {
 
         const el = config.el;
         expect(el).to.not.be.an('undefined');
-
-        const version = config.version;
-        expect(version).to.not.be.an('undefined');
-        expect(version).to.be.a('string');
 
         const cssPath = config.cssPath;
         if (cssPath) {
@@ -28,7 +24,7 @@ describe('An actual test on our app', function () {
 
   it('Tests our library constructor parameters', function () {
 
-    cy.visit('https://beta.blueraster.io/mapbuilder/external-debugging/index.html', {
+    cy.visit('https://my.gfw-mapbuilder.org/v1.latest/index.html', {
 
       onLoad: (winn) => {
 
@@ -123,14 +119,15 @@ describe('An actual test on our app', function () {
               expect(layer).to.have.property('layerName');
               expect(layer.layerName).to.be.a('string');
             }
-            if (layer.type !== 'imagery') {
-              expect(layer).to.have.property('url');
+
+            if (layer.type === 'remoteDataLayer') {
+              expect(layer).to.have.property('uuid');
             }
 
             expect(layer).to.have.property('id');
             expect(layer).to.have.property('type');
-            expect(layer).to.have.property('label');
-            expect(layer.label).to.have.property(config.language);
+            // expect(layer).to.have.property('label');
+            // expect(layer.label).to.have.property(config.language);
           });
         }
 

--- a/cypress/integration/ui-workflows.js
+++ b/cypress/integration/ui-workflows.js
@@ -5,7 +5,7 @@ describe('User workflows that have been known to fail', function () {
 
     let constructorParams, config;
 
-    cy.visit('https://beta.blueraster.io/mapbuilder/external-debugging/index.html')
+    cy.visit('https://my.gfw-mapbuilder.org/v1.latest/index.html')
     cy.title().should('include', 'GFW Mapbuilder')
     cy.wait(1000)
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "nodemon --watch webpack.config.js --exec \"webpack-dev-server --env development\"",
     "lint": "eslint src/js/**/*.js",
+    "unit": "jest --no-cache --runInBand --verbose",
     "test": "jest --no-cache --runInBand --verbose; $(npm bin)/cypress run --browser chrome",
     "e2e": "$(npm bin)/cypress open",
     "build": "npm run clean:build; webpack --env production",
@@ -31,6 +32,7 @@
   "homepage": "https://github.com/wri/forest_atlas_template#readme",
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/tests/setupTests.js",
+    "testURL": "http://localhost/",
     "verbose": true,
     "globals": {
       "NODE_ENV": "test"


### PR DESCRIPTION
Let's get our end-to-end tests up to date with our unit tests! One day, I want to have these `e2e` tests running the same logic/workflows across all of the deployed Mapbuilder apps that point to the latest version of our library: Georgia Atlas, Ethiopia Restoration Atlas, Cameroon Forest Atlas, Tierra Indigenous Platform, the V1 latest/base configuration, etc 