### PR TITLE
No more analysis modules in report localStorage

### DIFF
--- a/src/js/report/report.js
+++ b/src/js/report/report.js
@@ -895,13 +895,6 @@ const runAnalysis = function runAnalysis (params, feature) {
   const { settings } = params;
   const language = params.lang;
 
-  let analysisModules;
-  const stringMods = localStorage.getItem('analysisMods');
-  analysisModules = stringMods ? JSON.parse(stringMods) : '';
-
-  if (!analysisModules) {
-    analysisModules = settings.analysisModules;
-  }
 
   const { geostoreId } = feature;
   const resultsContainer = document.getElementById('results-container');
@@ -911,7 +904,7 @@ const runAnalysis = function runAnalysis (params, feature) {
   // and call a separate function that makes an esriRequest (like below) but with the updated
   // params that were passed into the report
 
-  analysisModules.forEach((module) => {
+  settings.analysisModules.forEach((module) => {
     let uiParamsToAppend = {};
 
     if (Array.isArray(module.uiParams) && module.uiParams.length > 0) {


### PR DESCRIPTION
https://github.com/wri/gfw-mapbuilder/issues/246#issuecomment-502263769

Now the report no longer inherits old `analysisModules`! You can test this on previously-deployed apps: 

https://my.gfw-mapbuilder.org/v1.4.0/ and http://blueraster.teaches-yoga.com/CMR?l=en