### PR TITLE
Allowing any spatialRefs when registering geoms w/ the geostore

### DIFF
--- a/src/js/stores/MapStore.js
+++ b/src/js/stores/MapStore.js
@@ -348,9 +348,11 @@ class MapStore {
           mapActions.toggleAnalysisTab.defer(true);
 
           analysisUtils.getExactGeom(selectedFeature).then(exactGeom => {
+            //If the geometry we got back from the server is in the wrong spatialRef, let's just use the original geometry!
+            const geomToRegister = exactGeom.spatialReference.isWebMercator() ? exactGeom : selectedFeature.geometry;
             analysisUtils.registerGeom(exactGeom).then(res => {
               selectedFeature.attributes.geostoreId = res.data.id;
-              selectedFeature.setGeometry(exactGeom);
+              selectedFeature.setGeometry(geomToRegister);
               mapActions.toggleAnalysisTab(false);
               isRegistering = false;
             });


### PR DESCRIPTION
Porting [this](https://github.com/wri/gfw-mapbuilder/commit/f1aac1acfb0defe95d7e66400cbdca597a143e73) error-check over from WCS - if the geometry that the User has selected is in a different spatial reference, the GFW API's `geostore` won't play nicely with an exact version of that geometry that we get back from the Server, so instead let's just use the original geometry.