### PR TITLE
436 smaller max width

### DIFF
--- a/src/css/report.styl
+++ b/src/css/report.styl
@@ -20,7 +20,12 @@ body
 .vega-chart-container,
 .vega-chart > canvas {
   min-width: 250px !important;
-  max-height: 600px !important;
+  margin: 1rem 2rem;
+}
+
+.vega-chart-badge-container {
+  min-width: 250px !important;
+  max-width: 500px;
   margin: 1rem 2rem;
 }
 

--- a/src/external.pug
+++ b/src/external.pug
@@ -6,7 +6,7 @@ html
 	body.tundra
 		#root
 		div#share-modal.modal-wrapper.hidden
-		script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/396-resizing-widgets/1.4.0.js' version='1.4.0')
+		script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/436-smaller-max-width/1.4.0.js' version='1.4.0')
 		//- script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/246-report-build-merge/1.4.0.js')
 		//- script(id='library-load' src='js/library.js')
 		script.

--- a/src/externalReport.pug
+++ b/src/externalReport.pug
@@ -5,7 +5,7 @@ html
     div#report.report
     div#share-modal.share-modal.hidden
     
-    script(id='report-load' src='http://alpha.blueraster.io/gfw-mapbuilder/396-resizing-widgets/reportLib.1.4.0.js')
+    script(id='report-load' src='http://alpha.blueraster.io/gfw-mapbuilder/436-smaller-max-width/reportLib.1.4.0.js')
     meta(charset='utf-8')
     script.
       var customApp = new MapBuilderReport({

--- a/src/js/components/AnalysisPanel/VegaChart.js
+++ b/src/js/components/AnalysisPanel/VegaChart.js
@@ -125,7 +125,10 @@ export default class VegaChart extends Component {
     const { isError, errorMsg, showDownloadOptions, downloadOptions, chartDownloadTitle, chartImgDownloadUrl, toggle, description } = this.state;
     const {width, height} = this.state.dimensions;
     const { results, component, reportLabel, module } = this.props;
-    const analysisId = module.analysisId;
+    let analysisId = null;
+    if (module && module.analysisId){
+      analysisId = module.analysisId;
+    }
 
     if (isError) {
       return (

--- a/src/js/components/AnalysisPanel/VegaChart.js
+++ b/src/js/components/AnalysisPanel/VegaChart.js
@@ -65,8 +65,6 @@ export default class VegaChart extends Component {
             }
           ]
         };
-        config.width = config.width * 2;
-        config.height = config.height * 2;
         config.autosize = {type: 'fit', resize: true};
         config.signals.push(widthSignal);
         config.signals.push(heightSignal);
@@ -153,7 +151,9 @@ export default class VegaChart extends Component {
   render() {
     const { isError, errorMsg, showDownloadOptions, downloadOptions, chartDownloadTitle, chartImgDownloadUrl, toggle, description } = this.state;
     const {width, height} = this.state.dimensions;
-    const { results, component, reportLabel } = this.props;
+    const { results, component, reportLabel, module } = this.props;
+    const analysisId = module.analysisId;
+    
     if (isError) {
       return (
         <div className='data-error'>
@@ -213,7 +213,7 @@ export default class VegaChart extends Component {
                 }}
               >
                 {({ measureRef }) => (
-                  <div className="vega-chart-container" ref={measureRef}>
+                  <div className={`${analysisId === 'TC_LOSS_GAIN' || analysisId === 'GLAD_ALERTS_Badge' || analysisId === 'VIIRS_FIRES' ? 'vega-chart-badge-container' : 'vega-chart-container'}`} ref={measureRef}>
                     <div width={width} height={height} className={`vega-chart ${toggle && 'vega-chart-hide'}`} id='AnalysisVegaChart' ref={(chart) => { this.chart = chart; }}></div>
                   </div>
                 )}

--- a/src/js/components/AnalysisPanel/VegaChart.js
+++ b/src/js/components/AnalysisPanel/VegaChart.js
@@ -186,7 +186,7 @@ export default class VegaChart extends Component {
                 }}
               >
                 {({ measureRef }) => (
-                  <div className={`${analysisId === 'TC_LOSS_GAIN' || analysisId === 'GLAD_ALERTS_Badge' || analysisId === 'VIIRS_FIRES' ? 'vega-chart-badge-container' : 'vega-chart-container'}`} ref={measureRef}>
+                  <div className={`${analysisId && (analysisId === 'TC_LOSS_GAIN' || analysisId === 'GLAD_ALERTS_Badge' || analysisId === 'VIIRS_FIRES') ? 'vega-chart-badge-container' : 'vega-chart-container'}`} ref={measureRef}>
                     <div width={width} height={height} className={`vega-chart ${toggle && 'vega-chart-hide'}`} id='AnalysisVegaChart' ref={(chart) => { this.chart = chart; }}></div>
                   </div>
                 )}

--- a/src/js/report/ReportAnalysis.js
+++ b/src/js/report/ReportAnalysis.js
@@ -52,7 +52,7 @@ export default class ReportAnalysis extends Component {
                 <div className="vega-chart-wrapper">
                     <Loader active={isLoading} />
                     {!results.data && results.error && this.handleReportAnalysisError(module.analysisId)}
-                    {results.data && <VegaChart reportLabel={reportLabel} component='Report' results={results} language={language} setLoading={() => this.setState({isLoading: false})} />}
+                    {results.data && <VegaChart module={module} reportLabel={reportLabel} component='Report' results={results} language={language} setLoading={() => this.setState({isLoading: false})} />}
                 </div>
             </div>
         );


### PR DESCRIPTION
#436 

http://alpha.blueraster.io/gfw-mapbuilder/436-smaller-max-width/

@SwampGuzzler This is more than likely still a WIP. Once Richard updates the signals by not hardcoding heights and widths, then I can adjust the max-width on the div container wrapping each of the chart widgets accordingly to make it look nice. Right now, I just chose a `max-width` value of 500px for the badge charts to demonstrate that `max-width` works (see my conversation with Richard in the ticket!)

Also, this will need to be merged into #396 which has now become the base branch for all resizing tickets!