### PR TITLE
Share modal dom removal

### DIFF
--- a/src/css/modal.styl
+++ b/src/css/modal.styl
@@ -90,8 +90,8 @@
       margin 5px 0
 
 //- Share Modal
-#share-modal
-  & .modal-content
+.share-modal-wrap
+  &.modal-content
     width 300px
   & .share-instructions
     padding-bottom 10px

--- a/src/external.pug
+++ b/src/external.pug
@@ -41,13 +41,12 @@ html
 			}
 	body.tundra
 		#root
-		div#share-modal.modal-wrapper.hidden
 		div.landing-loader__active.hidden
 			div.landing-loader__spinner
 				svg(width="50", height="50")
 					<g transform="translate(25,25) rotate(-90)"><path d="M0,25A25,25 0 1,1 0,-25A25,25 0 1,1 0,25M0,20A20,20 0 1,0 0,-20A20,20 0 1,0 0,20Z" style="fill: rgb(255, 255, 255); stroke: rgb(204, 204, 204);"></path><path class="foreground" d="M1.5308084989341915e-15,-25A25,25 0 0,1 25,0L20,0A20,20 0 0,0 1.2246467991473533e-15,-20Z" style="fill: rgb(85, 85, 85);" transform="rotate(709.287459262793)"></path></g>
 		script(id='library-load' src='https://library.gfw-mapbuilder.org/1.4.0.js' version='1.4.0')
-		//- script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/246-report-build-merge/1.4.0.js')
+		//- script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/updated-share-modal/1.4.0.js')
 		//- script(id='library-load' src='./1.4.0.js')
 		script.
 			var customApp = new MapBuilder({

--- a/src/external.pug
+++ b/src/external.pug
@@ -4,9 +4,9 @@ html
 		meta(charset='utf-8')
 	body.tundra
 		#root
-		//- script(id='library-load' src='https://library.gfw-mapbuilder.org/1.4.0.js' version='1.4.0')
+		script(id='library-load' src='https://library.gfw-mapbuilder.org/1.4.0.js' version='1.4.0')
 		//- script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/smoother-loading-v2/1.4.0.js')
-		script(id='library-load' src='./1.4.0.js')
+		//- script(id='library-load' src='./1.4.0.js')
 		script.
 			var customApp = new MapBuilder({
 				el: 'root',

--- a/src/index.pug
+++ b/src/index.pug
@@ -52,7 +52,6 @@ html
   body.tundra
     #root
     div#layer-modal.modal-wrapper.hidden
-    div#share-modal.modal-wrapper.hidden
     script.
       var _app = {
         esri: %ESRI_VERSION%,

--- a/src/js/actions/MapActions.js
+++ b/src/js/actions/MapActions.js
@@ -46,6 +46,7 @@ class MapActions {
   toggleSubscriptionsModal = (data) => data;
   toggleSubscribeModal = (data) => data;
   toggleConfirmModal = (data) => data;
+  toggleShareModal = (data) => data;
   toggleTOCVisible = (data) => data;
   showLayerInfo = (layer) => layer;
   updateTimeExtent = (timeExtent) => timeExtent;

--- a/src/js/actions/ModalActions.js
+++ b/src/js/actions/ModalActions.js
@@ -6,7 +6,6 @@ class ModalActions {
   showShareModal (params) {
     //TODO: Generate a url from bitly that includes Map Store state, this way we can share params
     const url = document.location.href.split('?')[0];
-    domClass.remove('share-modal', 'hidden');
     return `${url}?${params}`;
   }
 

--- a/src/js/components/Map.js
+++ b/src/js/components/Map.js
@@ -10,6 +10,8 @@ import LayerModal from 'components/Modals/LayerModal';
 import SubscriptionsModal from 'components/Modals/SubscriptionsModal';
 import SubscribeModal from 'components/Modals/SubscribeModal';
 import ConfirmModal from 'components/Modals/ConfirmModal';
+import ShareModal from 'components/Modals/ShareModal';
+
 import Legend from 'components/LegendPanel/LegendPanel';
 import TabButtons from 'components/TabPanel/TabButtons';
 import SearchModal from 'components/Modals/SearchModal';
@@ -869,6 +871,7 @@ export default class Map extends Component {
       subscriptionsModalVisible,
       subscribeModalVisible,
       confirmModalVisible,
+      shareModalVisible,
       subscriptionToDelete,
       modalLayerInfo,
       webmapInfo,
@@ -907,6 +910,7 @@ export default class Map extends Component {
 
     return (
       <div className={`map-container ${!timeSlider ? 'noSlider' : ''}`}>
+
         <div ref='map' className='map'>
           <Controls {...this.state} timeEnabled={!!timeSlider} />
 
@@ -927,6 +931,9 @@ export default class Map extends Component {
             <SVGIcon id={'shape-crosshairs'} />
 
           </svg>
+        </div>
+        <div className={`share-modal-container modal-wrapper ${shareModalVisible ? '' : 'hidden'}`}>
+          <ShareModal />
         </div>
         <div className={`analysis-modal-container modal-wrapper ${analysisModalVisible ? '' : 'hidden'}`}>
           <AnalysisModal drawButtonActive={this.state.drawButtonActive} />

--- a/src/js/components/MapControls/ControlPanel.js
+++ b/src/js/components/MapControls/ControlPanel.js
@@ -82,6 +82,8 @@ export default class ControlPanel extends Component {
       modisEndDate: this.formatDate(modisEndDate),
       canopyDensity: canopyDensity
     })));
+
+    mapActions.toggleShareModal({ visible: true });
   };
 
   showAnalysisTools = () => {

--- a/src/js/components/Modals/ModalWrapper.js
+++ b/src/js/components/Modals/ModalWrapper.js
@@ -1,4 +1,5 @@
 import modalActions from 'actions/ModalActions';
+import mapActions from 'actions/MapActions';
 import modalStore from 'stores/ModalStore';
 import ReactDOM from 'react-dom';
 import React from 'react';
@@ -23,6 +24,7 @@ export default class ModalWrapper extends React.Component {
 
   close () {
     modalActions.hideModal(ReactDOM.findDOMNode(this).parentElement);
+    mapActions.toggleShareModal({ visible: false });
   }
 
   render() {

--- a/src/js/components/Modals/ShareModal.js
+++ b/src/js/components/Modals/ShareModal.js
@@ -61,8 +61,9 @@ export default class ShareModal extends React.Component {
   }
 
   render () {
+
     return (
-      <ModalWrapper>
+      <ModalWrapper theme='share-modal-wrap'>
         <div className='modal-title'>{modalText.share.title}</div>
         <div className='share-instructions'>{modalText.share.linkInstructions}</div>
         <div className='share-input'>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,5 @@
 /* eslint no-unused-vars: 0 */
 import App from 'components/App';
-import ShareModal from 'components/Modals/ShareModal';
 import { corsServers } from 'js/config';
 import { loadCSS } from 'utils/loaders';
 import esriConfig from 'esri/config';
@@ -46,8 +45,8 @@ const lazyloadAssets = () => {
 };
 
 const initializeApp = () => {
+
   ReactDOM.render(<App />, document.getElementById('root'));
-  ReactDOM.render(<ShareModal />, document.getElementById('share-modal'));
 };
 
 configureApp();

--- a/src/js/stores/MapStore.js
+++ b/src/js/stores/MapStore.js
@@ -59,6 +59,7 @@ class MapStore {
     this.subscriptionsModalVisible = false;
     this.subscribeModalVisible = false;
     this.confirmModalVisible = false;
+    this.shareModalVisible = false;
     this.isLoggedIn = false;
     this.canopyDensity = 30;
     this.activeSlopeClass = null;
@@ -103,6 +104,7 @@ class MapStore {
       toggleSubscriptionsModal: mapActions.toggleSubscriptionsModal,
       toggleSubscribeModal: mapActions.toggleSubscribeModal,
       toggleConfirmModal: mapActions.toggleConfirmModal,
+      toggleShareModal: mapActions.toggleShareModal,
       toggleLogin: mapActions.toggleLogin,
       deleteSubscription: mapActions.deleteSubscription,
       updateCanopyDensity: mapActions.updateCanopyDensity,
@@ -430,6 +432,10 @@ class MapStore {
 
   toggleConfirmModal (payload) {
     this.confirmModalVisible = payload.visible;
+  }
+
+  toggleShareModal (payload) {
+    this.shareModalVisible = payload.visible;
   }
 
   toggleLogin (loggedIn) {


### PR DESCRIPTION
Our initial `index.pug` and (more importantly) our `external.pug` used to have this weird `div#share-modal` html next to our **root** dom node. Since there is nothing special about the Share Modal, I brought that into our app as a more generic modal and changed its visibility to rely on **alt** via the `ModalActions` and the `MapStore`.

I want the `external.pug`, which turns into the `index.html` that the client sees to be as clean as possible!