### PR TITLE
Add max width onto vega-chart_container

### DIFF
--- a/src/css/report.styl
+++ b/src/css/report.styl
@@ -332,6 +332,7 @@ body
 
 .vega-chart_container
   width 100%
+  max-width 60rem
   .vega-chart-separator
     border-bottom 1px solid #ccc
     height 1rem


### PR DESCRIPTION
https://github.com/wri/gfw-mapbuilder/issues/494

http://alpha.blueraster.io/gfw-mapbuilder/494-download-buttons-not-in-right-location/