### PR TITLE
Add missing background css rule to tree-icon and forest-icon

### DIFF
--- a/src/css/modal.styl
+++ b/src/css/modal.styl
@@ -188,11 +188,13 @@
   height 41px
   float left
   width 25px
+  background: url('https://my.gfw-mapbuilder.org/img/tree.png') no-repeat center;
 
 .forest-icon
   float right
   height 60px
   width 91px
+  background: url('https://my.gfw-mapbuilder.org/img/forest.png') no-repeat center;
 
 .slider-container
   margin 5px 10px


### PR DESCRIPTION
#500 

http://alpha.blueraster.io/gfw-mapbuilder/500-add-tree-cover-density-svg/