### PR TITLE
Handling satellite errors w/ no mouseover

### DIFF
--- a/src/js/actions/MapActions.js
+++ b/src/js/actions/MapActions.js
@@ -241,6 +241,10 @@ class MapActions {
     return bool;
   }
 
+  imageryFetchUpdate(bool) {
+    return bool;
+  }
+
   getSatelliteImagery(params) {
     return params;
   }

--- a/src/js/components/Map.js
+++ b/src/js/components/Map.js
@@ -874,7 +874,9 @@ export default class Map extends Component {
       map,
       activeLayers,
       imageryModalVisible,
-      imageryError
+      imageryFetchFailed,
+      imageryError,
+      imageryData
     } = this.state;
 
     const { settings } = this.context;
@@ -955,14 +957,14 @@ export default class Map extends Component {
         </div>
         <div className={`imagery-modal-container ${imageryModalVisible ? '' : 'collapse'}`}>
           <ImageryModal
-            imageryData={this.state.imageryData}
+            imageryData={imageryData}
             loadingImagery={this.state.loadingImagery}
             imageryModalVisible={imageryModalVisible}
             imageryError={imageryError}
             imageryHoverVisible={this.state.imageryHoverVisible}
           />
         </div>
-        { this.state.imageryHoverInfo && this.state.imageryHoverInfo.visible && zoomLevel < 10 &&
+        { this.state.imageryHoverInfo && this.state.imageryHoverInfo.visible && zoomLevel < 10 && !imageryFetchFailed &&
             <ImageryHoverModal
               selectedImagery={this.state.selectedImagery}
               top={this.state.imageryHoverInfo.top}

--- a/src/js/components/Modals/ImageryModal.js
+++ b/src/js/components/Modals/ImageryModal.js
@@ -56,6 +56,8 @@ export default class ImageryModal extends Component {
       // Select first tile in the filteredImageryData array to display.
       if (filteredImageryData[0]) {
         this.selectThumbnail(filteredImageryData[0], 0);
+      } else {
+        mapActions.imageryFetchUpdate(true);
       }
     }
   }
@@ -64,12 +66,15 @@ export default class ImageryModal extends Component {
     const { map } = this.context;
     let imageryLayer = map.getLayer(layerKeys.RECENT_IMAGERY);
 
-    if (imageryLayer && (tileObj.tileUrl || tileObj.attributes.tile_url)) {
-      imageryLayer.setUrl(tileObj.tileUrl || tileObj.attributes.tile_url);
+    const layerUrl = tileObj.tileUrl ? tileObj.tileUrl : tileObj.attributes.tile_url;
+
+    if (imageryLayer && layerUrl) {
+      imageryLayer.setUrl(layerUrl);
+      mapActions.imageryFetchUpdate(false);
     } else {
       const options = {
         id: layerKeys.RECENT_IMAGERY,
-        url: tileObj.tileUrl || tileObj.attributes.tile_url,
+        url: layerUrl,
         visible: true
       };
 
@@ -78,6 +83,9 @@ export default class ImageryModal extends Component {
         map.addLayer(imageryLayer);
         map.reorderLayer(layerKeys.RECENT_IMAGERY, 1); // Should be underneath all other layers
         imageryLayer._extentChanged();
+        mapActions.imageryFetchUpdate(false);
+      } else {
+        mapActions.imageryFetchUpdate(true);
       }
 
     }

--- a/src/js/stores/MapStore.js
+++ b/src/js/stores/MapStore.js
@@ -80,6 +80,7 @@ class MapStore {
     this.analysisSliderIndices = {};
     this.drawButtonActive = false;
     this.imageryModalVisible = false;
+    this.imageryFetchFailed = false;
     this.imageryData = [];
     this.loadingImagery = false;
     this.imageryError = false;
@@ -148,6 +149,7 @@ class MapStore {
       updateAnalysisSliderIndices: mapActions.updateAnalysisSliderIndices,
       activateDrawButton: mapActions.activateDrawButton,
       toggleImageryVisible: mapActions.toggleImageryVisible,
+      imageryFetchUpdate: mapActions.imageryFetchUpdate,
       getSatelliteImagery: mapActions.getSatelliteImagery,
       setSelectedImagery: mapActions.setSelectedImagery,
       setImageryHoverInfo: mapActions.setImageryHoverInfo,
@@ -632,6 +634,10 @@ class MapStore {
   toggleImageryVisible(bool) {
     this.imageryModalVisible = bool;
     this.imageryError = false;
+  }
+
+  imageryFetchUpdate(bool) {
+    this.imageryFetchFailed = bool;
   }
 
   getSatelliteImagery(params) {


### PR DESCRIPTION
This fix removes the Tooltip that provides data on-hover when the image does not display properly --> https://github.com/wri/gfw-mapbuilder/issues/483#issuecomment-527633970

Test [here!](http://alpha.blueraster.io/gfw-mapbuilder/483-satellite-mouseover/)