### PR TITLE
Custom color theme refactor

### DIFF
--- a/config-panels/simplePanel.json
+++ b/config-panels/simplePanel.json
@@ -13,7 +13,7 @@
 		"downloadLinkUrl": "",
 		
 		"customColorTheme": "",
-		"defaultColorTheme": "#F0AB00",
+		"'#F0AB00'": "#F0AB00",
 
 		"useAlternativeLanguage": false,
 		"alternativeLanguage": "fr",

--- a/config-panels/simplePanel.json
+++ b/config-panels/simplePanel.json
@@ -11,10 +11,7 @@
 		"logoLinkUrl": "http://developers.globalforestwatch.org/map-builder/",
 		"aboutLinkUrl": "",
 		"downloadLinkUrl": "",
-		
 		"customColorTheme": "",
-		"'#F0AB00'": "#F0AB00",
-
 		"useAlternativeLanguage": false,
 		"alternativeLanguage": "fr",
 		"alternativeWebmap": "",

--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -73,9 +73,10 @@ h1, h2, h3, h4, h5, h6
   border-radius 35px
   text-align center
   cursor pointer
-  padding 0 0.25rem
+  padding 0rem 0.5rem
   color white
-  height 36px
+  height 35px
+  line-height 35px
   &.sml
     line-height 24px
     font-size 10px

--- a/src/css/infoWindow.styl
+++ b/src/css/infoWindow.styl
@@ -88,6 +88,7 @@
   .edit-save-button
     height 30px !important 
     line-height 30px !important
+    padding 0 1rem !important
 
 .custom-feature__input
   -webkit-appearance none

--- a/src/external.pug
+++ b/src/external.pug
@@ -265,7 +265,7 @@ html
 								"sublabel": {
 									"en": ""
 								}
-							],
+							]
 						},
 						{
 							analysisId: 'IFL',

--- a/src/external.pug
+++ b/src/external.pug
@@ -6,7 +6,7 @@ html
 	body.tundra
 		#root
 		div#share-modal.modal-wrapper.hidden
-		script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/460-custom-color-theme/1.4.1.js' version='1.4.1')
+		script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/custom-color-theme-refactor/1.4.1.js' version='1.4.1')
 		//- script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/246-report-build-merge/1.4.1.js')
 		//- script(id='library-load' src='js/library.js')
 		script.

--- a/src/external.pug
+++ b/src/external.pug
@@ -6,7 +6,7 @@ html
 	body.tundra
 		#root
 		div#share-modal.modal-wrapper.hidden
-		script(id='library-load' src='https://library.gfw-mapbuilder.org/1.4.1.js' version='1.4.1')
+		script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/custom-color-theme-refactor/1.4.1.js' version='1.4.1')
 		//- script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/246-report-build-merge/1.4.1.js')
 		//- script(id='library-load' src='js/library.js')
 		script.
@@ -35,6 +35,7 @@ html
 					hideFooter: false,
 					includeMyGFWLogin: true,
 					navLinksInNewTab: false,
+					customColorTheme: '#17eae7',
 					//- Language Settings
 					language: 'en',
 					useAlternativeLanguage: false,

--- a/src/external.pug
+++ b/src/external.pug
@@ -6,7 +6,7 @@ html
 	body.tundra
 		#root
 		div#share-modal.modal-wrapper.hidden
-		script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/custom-color-theme-refactor/1.4.1.js' version='1.4.1')
+		script(id='library-load' src='https://library.gfw-mapbuilder.org/1.4.1.js' version='1.4.1')
 		//- script(id='library-load' src='http://alpha.blueraster.io/gfw-mapbuilder/246-report-build-merge/1.4.1.js')
 		//- script(id='library-load' src='js/library.js')
 		script.
@@ -35,7 +35,6 @@ html
 					hideFooter: false,
 					includeMyGFWLogin: true,
 					navLinksInNewTab: false,
-					customColorTheme: '#17eae7',
 					//- Language Settings
 					language: 'en',
 					useAlternativeLanguage: false,
@@ -115,11 +114,23 @@ html
 							zh: '总森林覆盖减少/增加面积量',
 							ka: 'ხის ვარჯის საერთო კარგვა / მატება'
 						},
-						"title": {
-							"en": "Total area with combined potential"
+						title: {
+							en: 'Total tree cover loss/ gain',
+							fr: 'Perte/gain total de la couverture arborée',
+							es: 'Pérdida/ganancia de cobertura arbórea total',
+							pt: 'Perda/ganho total de cobertura arbórea',
+							id: 'Total kehilangan/perolehan tutupan pohon ',
+							zh: '总森林覆盖减少/增加面积量',
+							ka: 'ხის ვარჯის საერთო კარგვა / მატება'
 						},
-						"description": {
-							"en": "Note: The boundaries of large areas of interest are simplified to enhance calculation performance. Area statistics were rounded down to the nearest hundred."
+						description: {
+							en: 'Select range and tree cover density for loss data then click the run analysis button to see results. Gain data is currently only available for 2000 – 2012 and the gain analysis will always reflect the full 12-year time-period.',
+							fr: 'Sélectionner la plage et la densité de couverture arborée pour les données de perte, puis cliquer sur le bouton « lancer l’analyse » pour voir les résultats. Les données de gain ne sont actuellement disponibles que pour 2000 – 2012 et l’analyse de gain reflétera toujours la plage de 12 ans entière.',
+							es: 'Para obtener los datos sobre pérdida, seleccione el rango y la densidad de la cobertura arbórea, después haga clic en el botón ejecutar análisis para ver los resultados. Los datos sobre ganancia actualmente solo están disponibles para los años 2000 a 2012 y el análisis de la ganancia siempre reflejará el periodo de 12 años completo.',
+							pt: 'Selecione o período e a densidade de cobertura arbórea para dados de perda; em seguida, clique no botão para executar a análise e ver os resultados. Os dados de ganho estão disponíveis atualmente apenas para o período 2000 – 2012 e a análise de ganho sempre refletirá o período completo de 12 anos.',
+							id: 'Pilih rentang dan kerapatan tutupan pohon untuk data yang hilang, kemudian klik tombol mulai analisis untuk melihat hasilnya. Data perolehan saat ini hanya tersedia untuk periode 2000 – 2012 dan analisis perolehan akan selalu mencerminkan periode waktu 12 tahun penuh.',
+							zh: '选择要考察减少量数据的范围和森林覆盖密度，然后点击“运行分析”按钮查看结果。目前仅有 2000 – 2012 年的增加量数据，增加分析始终反映这 12 年的完整情况。',
+							ka: 'შეარჩიეთ საზღვრები და ხის ვარჯის სიხშირე კარგვის მონაცემებისთვის, შემდეგ დააჭირეთ ღილაკს ანალიზის  ჩატარება შედეგების სანახავად. მატების მონაცემები ამჟამად ხელმისაწვდომია 2000-2012 წლებისთვის და მატების ანალიზი ყოველთვის ასახავს სრულ 12-წლიან დროის პერიოდს.'
 						},
 						useGfwWidget: true,
 						widgetId: '95c2c559-ca78-4b7a-b18b-7b2bca14ce83',
@@ -139,70 +150,21 @@ html
 								zh: '选择分析范围:',
 								ka: 'საზღვრების შერჩევა ანალიზისთვის:'
 							}
-						},
-						{
-							"name": "thresh",
-							"inputType": "tcd",
-							"label": {
-								"en": "Select tree cover density: ",
-								"fr": "Sélectionner la densité de couverture arborée: ",
-								"es": "Seleccione la densidad de la cobertura arbórea: ",
-								"pt": "Selecione a densidade de cobertura arbórea: ",
-								"id": "Pilih kerapatan tutupan pohon: ",
-								"zh": "选择森林覆盖密度: ",
-								"ka": "ხის ვარჯის სიხშირის შერჩევა: "
+							},
+							{
+								name: 'thresh',
+								inputType: 'tcd',
+								label: {
+									en: 'Select tree cover density: ',
+									fr: 'Sélectionner la densité de couverture arborée: ',
+									es: 'Seleccione la densidad de la cobertura arbórea: ',
+									pt: 'Selecione a densidade de cobertura arbórea: ',
+									id: 'Pilih kerapatan tutupan pohon: ',
+									zh: '选择森林覆盖密度: ',
+									ka: 'ხის ვარჯის სიხშირის შერჩევა: '
+								}
 							}
-						}]
-					},
-					{
-						"analysisId": "TC_LOSS",
-						"chartType": "bar",
-						"label": {
-							"en": "Annual Tree cover loss",
-							"fr": "Pertes de la couverture arborée annuelles",
-							"es": "Pérdida de cobertura arbórea anual",
-							"pt": "Perda anual de cobertura arbórea",
-							"id": "Kehilangan tutupan pohon tahunan",
-							"zh": "年度森林覆盖减少量面积",
-							"ka": "წლიური ხის ვარჯის კარგვა"
-						},
-						"title": {
-							"en": "Annual Tree cover loss",
-							"fr": "Pertes de la couverture arborée annuelles",
-							"es": "Pérdida de cobertura arbórea anual",
-							"pt": "Perda anual de cobertura arbórea",
-							"id": "Kehilangan tutupan pohon tahunan",
-							"zh": "年度森林覆盖减少量面积",
-							"ka": "წლიური ხის ვარჯის კარგვა"
-						},
-						"description": {
-							"en": "Select range and tree cover density then click the run analysis button to see results.",
-							"fr": "Sélectionner la plage et la densité de couverture arborée, puis cliquer sur le bouton « Exécuter l’analyse » pour voir les résultats.",
-							"es": "Para ver los resultados, seleccione el rango y la densidad de la cobertura arbórea, después haga clic en el botón ejecutar análisis.",
-							"pt": "Para ver os resultados, selecione o período e a densidade de cobertura arbórea; em seguida, clique no botão para executar a análise.",
-							"id": "Pilih rentang dan kerapatan tutupan pohon kemudian klik tombol mulai analisis untuk melihat hasil.",
-							"zh": "选择范围和森林覆盖密度，然后点击“运行分析”按钮查看结果。",
-							"ka": "შეარჩიეთ საზღვრები და ხის ვარჯის სიხშირე, შემდეგ დააჭირეთ ღილაკს ანალიზის ჩატარება შედეგებს სანახავად."
-						},
-						"useGfwWidget": true,
-						"widgetId": "e53e541c-92cd-4b00-9aa7-2c7bb36d4697",
-						"uiParams": [{
-							"inputType": "rangeSlider",
-							"startParamName": "period",
-							"combineParams": true,
-							"valueSeparator": ",",
-							"bounds": [2001,
-							2018],
-							"valueType": "date",
-							"label": {
-								"en": "Select range for analysis",
-								"fr": "Sélectionner une plage pour l’analyse:",
-								"es": "Seleccione un rango para el análisis:",
-								"pt": "Selecione o período para análise:",
-								"id": "Pilih rentang untuk analisis:",
-								"zh": "选择分析范围:",
-								"ka": "საზღვრების შერჩევა ანალიზისთვის:"
-							}
+						]
 						},
 						{
 							analysisId: 'TC_LOSS',
@@ -252,20 +214,21 @@ html
 									zh: '选择分析范围:',
 									ka: 'საზღვრების შერჩევა ანალიზისთვის:'
 								}
-							}, {
-								"order": 2,
-								"id": "LCCP",
-								"type": "dynamic",
-								"url": "https://gis.forest-atlas.org/server/rest/services/eth/00_AllPotOptions/MapServer",
-								"layerIds": [299],
-								"technicalName": "eth_landcover_combinedpotential",
-								"label": {
-									"en": "Land use-land cover in areas with combined potential"
 								},
-								"sublabel": {
-									"en": ""
+								{
+									name: 'thresh',
+									inputType: 'tcd',
+									label: {
+										en: 'Select tree cover density: ',
+										fr: 'Sélectionner la densité de couverture arborée: ',
+										es: 'Seleccione la densidad de la cobertura arbórea: ',
+										pt: 'Selecione a densidade de cobertura arbórea: ',
+										id: 'Pilih kerapatan tutupan pohon: ',
+										zh: '选择森林覆盖密度: ',
+										ka: 'ხის ვარჯის სიხშირის შერჩევა: '
+									}
 								}
-							]
+							],
 						},
 						{
 							analysisId: 'IFL',
@@ -319,18 +282,19 @@ html
 									zh: '选择分析范围:',
 									ka: 'საზღვრების შერჩევა ანალიზისთვის:'
 								}
-							}, {
-								"order": 4,
-								"id": "PDCP",
-								"type": "dynamic",
-								"url": "https://gis.forest-atlas.org/server/rest/services/eth/00_AllPotOptions/MapServer",
-								"layerIds": [297],
-								"technicalName": "eth_population_combinedpotential",
-								"label": {
-									"en": "Population density in areas with combined potential"
 								},
-								"sublabel": {
-									"en": ""
+								{
+									name: 'thresh',
+									inputType: 'tcd',
+									label: {
+										en: 'Select tree cover density: ',
+										fr: 'Sélectionner la densité de couverture arborée: ',
+										es: 'Seleccione la densidad de la cobertura arbórea: ',
+										pt: 'Selecione a densidade de cobertura arbórea: ',
+										id: 'Pilih kerapatan tutupan pohon: ',
+										zh: '选择森林覆盖密度: ',
+										ka: 'ხის ვარჯის სიხშირის შერჩევა: '
+									}
 								}
 							]
 						},
@@ -386,217 +350,51 @@ html
 									zh: '选择分析范围:',
 									ka: 'საზღვრების შერჩევა ანალიზისთვის:'
 								}
-							}, {
-								"order": 6,
-								"id": "RCP",
-								"type": "dynamic",
-								"url": "https://gis.forest-atlas.org/server/rest/services/eth/00_AllPotOptions/MapServer",
-								"layerIds": [295],
-								"technicalName": "eth_rainfall_combinedpotential",
-								"label": {
-									"en": "Average annual rainfall in areas with combined potential"
 								},
-								"sublabel": {
-									"en": ""
+								{
+									name: 'thresh',
+									inputType: 'tcd',
+									label: {
+										en: 'Select tree cover density: ',
+										fr: 'Sélectionner la densité de couverture arborée: ',
+										es: 'Seleccione la densidad de la cobertura arbórea: ',
+										pt: 'Selecione a densidade de cobertura arbórea: ',
+										id: 'Pilih kerapatan tutupan pohon: ',
+										zh: '选择森林覆盖密度: ',
+										ka: 'ხის ვარჯის სიხშირის შერჩევა: '
+									}
 								}
-							}]
+							]
 						},
 						{
-							"name": "thresh",
-							"inputType": "tcd",
-							"label": {
-								"en": "Select tree cover density: ",
-								"fr": "Sélectionner la densité de couverture arborée: ",
-								"es": "Seleccione la densidad de la cobertura arbórea: ",
-								"pt": "Selecione a densidade de cobertura arbórea: ",
-								"id": "Pilih kerapatan tutupan pohon: ",
-								"zh": "选择森林覆盖密度: ",
-								"ka": "ხის ვარჯის სიხშირის შერჩევა: "
-							}
-						}]
-					},
-					{
-						"analysisId": "GLAD_ALERTS",
-						"chartType": "line",
-						"label": {
-							"en": "GLAD alerts per month",
-							"fr": "Alertes GLAD par mois",
-							"es": "Alertas GLAD por mes",
-							"pt": "Alertas GLAD por mês",
-							"id": "Peringatan GLAD per bulan",
-							"zh": "每月 GLAD 预警",
-							"ka": "GLAD შეტყობინებები"
-						},
-						"title": {
-							"en": "GLAD alerts per month",
-							"fr": "Alertes GLAD par mois",
-							"es": "Alertas GLAD por mes",
-							"pt": "Alertas GLAD por mês",
-							"id": "Peringatan GLAD per bulan",
-							"zh": "每月 GLAD 预警",
-							"ka": "GLAD შეტყობინებები"
-						},
-						"description": {
-							"en": "Count the number of GLAD tree cover loss alerts per month over the past two years and compare to the historical average.",
-							"fr": "Compte le nombre d’alertes GLAD de perte de la couverture arborée par mois sur les deux dernières années et le compare à la moyenne historique.",
-							"es": "Cuente el número de alertas GLAD sobre pérdida de cobertura arbórea por mes en los últimos dos años y compárela con el promedio histórico.",
-							"pt": "Apresentação da quantidade de alertas GLAD de perda de cobertura arbórea por mês nos últimos dois anos e comparação com a média histórica.",
-							"id": "Hitung jumlah peringatan kehilangan tutupan pohon GLAD per bulan selama dua tahun terakhir dan bandingkan dengan rata-rata historis.",
-							"zh": "统计过去两年内每月 GLAD 森林覆盖减少预警次数，并与历史平均值比较。",
-							"ka": "Count the number of GLAD tree cover loss alerts per month over the past two years and compare to the historical average."
-						},
-						"useGfwWidget": true,
-						"widgetId": "b5e43ea3-2812-484e-bc31-1bf5d2fe8aa0",
-						"uiParams": "none"
-					},
-					{
-						"analysisId": "TOTAL_GLAD_ALERTS",
-						"chartType": "badge",
-						"label": {
-							"en": "Total GLAD Alerts",
-							"fr": "Total des alertes GLAD",
-							"es": "Alertas GLAD totales",
-							"pt": "Total de alertas GLAD",
-							"id": "Total Peringatan GLAD",
-							"zh": "GLAD 预警总数",
-							"ka": "GLAD შეტყობინებები"
-						},
-						"title": {
-							"en": "Total GLAD Alerts",
-							"fr": "Total des alertes GLAD",
-							"es": "Alertas GLAD totales",
-							"pt": "Total de alertas GLAD",
-							"id": "Total Peringatan GLAD",
-							"zh": "GLAD 预警总数",
-							"ka": "Total GLAD Alerts"
-						},
-						"description": {
-							"en": "Count the number of GLAD alerts which occurred within the selected time range.",
-							"fr": "Compte le nombre d’alertes GLAD durant la période sélectionnée.",
-							"es": "Cuente el número de alertas GLAD que ocurrieron en el rango de tiempo seleccionado.",
-							"pt": "Quantifica o número de alertas GLAD ocorridos em um período selecionado.",
-							"id": "Hitung jumlah peringatan GLAD yang terjadi dalam rentang waktu yang dipilih.",
-							"zh": "统计在所选时间范围内出现的 GLAD 预警次数。",
-							"ka": "Count the number of GLAD tree cover loss alerts per month."
-						},
-						"useGfwWidget": true,
-						"widgetId": "16ff6282-8ceb-4055-938a-43726a62b205",
-						"uiParams": [{
-							"inputType": "datepicker",
-							"startParamName": "period",
-							"combineParams": true,
-							"valueSeparator": ",",
-							"multi": true,
-							"defaultStartDate": "2015-01-01",
-							"minDate": "2015-01-01",
-							"label": {
-								"en": "Select range for analysis",
-								"fr": "Sélectionner une plage pour l’analyse",
-								"es": "Seleccione un rango para el análisis",
-								"pt": "Selecione o período para análise",
-								"id": "Pilih rentang untuk analisis",
-								"zh": "选择分析范围",
-								"ka": "საზღვრების შერჩევა ანალიზისთვის"
-							}
-						}]
-					},
-					{
-						"analysisId": "VIIRS_FIRES",
-						"chartType": "badge",
-						"label": {
-							"en": "VIIRS Active Fires",
-							"fr": "Feux actifs VIIRS",
-							"es": "Incendios activos VIIRS",
-							"pt": "Incêndios ativos VIIRS",
-							"id": "Kebakaran Aktif VIIRS",
-							"zh": "VIIRS 活跃火点",
-							"ka": "VIIRS აქტიური ხანძრები"
-						},
-						"title": {
-							"en": "VIIRS Active Fires",
-							"fr": "Feux actifs VIIRS",
-							"es": "Incendios activos VIIRS",
-							"pt": "Incêndios ativos VIIRS",
-							"id": "Kebakaran Aktif VIIRS",
-							"zh": "VIIRS 活跃火点",
-							"ka": "VIIRS აქტიური ხანძრები"
-						},
-						"description": {
-							"en": "This analysis counts the number of VIIRS fire alert detections during the past 7 days",
-							"fr": "Cette analyse compte le nombre d’alertes de détection d’incendies VIIRS durant les 7 derniers jours",
-							"es": "Este análisis cuenta el número de detecciones de alertas de incendios VIIRS durante los últimos siete días",
-							"pt": "Esta análise apresenta a quantidade de detecções de alertas de incêndio VIIRS nos últimos 7 dias",
-							"id": "Analisis ini menghitung jumlah deteksi peringatan kebakaran VIIRS selama 7 hari terakhir",
-							"zh": "此分析可统计过去 7 天 VIIRS 火警监测的次数。",
-							"ka": "ეს ანალიზი თვლის VIIRS ხანძრის შეტყობინებების გამოვლენის რაოდენობას ბოლო 7 დღის განმავლობაში."
-						},
-						"useGfwWidget": true,
-						"widgetId": "5d696f96-e6c7-4323-8bda-4c99cd6b0cb4",
-						"uiParams": "none"
-					},
-					{
-						"analysisId": "LCC",
-						"chartType": "pie",
-						"label": {
-							"en": "Land Cover Composition",
-							"fr": "Composition de la couverture terrestre",
-							"es": "Cobertura terrestre",
-							"pt": "Cobertura do Solo",
-							"id": "Komposisi tutupan lahan",
-							"zh": "土地覆盖构成",
-							"ka": "მიწის საფარის შემადგენლობა"
-						},
-						"title": {
-							"en": "Land Cover Composition",
-							"fr": "Composition de la couverture terrestre",
-							"es": "Composición de la cobertura de tierra",
-							"pt": "Composição da cobertura de terra",
-							"id": "Komposisi tutupan lahan",
-							"zh": "土地覆盖构成",
-							"ka": "მიწის საფარის შემადგენლობა"
-						},
-						"description": {
-							"en": "Land cover data is from 2015 and provided by the European Space Agency (ESA) and UCLouvain.",
-							"fr": "Les données de la couverture terrestre datent de 2015 et sont fournies par l’Agence Spatiale Européenne (European Space Agency, ESA) et UCLouvain.",
-							"es": "Los datos de la cobertura de tierra son de 2015 y fueron proporcionados por la Agencia Espacial Europea (European Space Agency, ESA) y UCLouvain. ",
-							"pt": "Dados de cobertura de terra relativos ao período posterior a 2015 e fornecidos pela Agência Espacial Europeia (ESA) e pela UCLouvain. ",
-							"id": "Data tutupan lahan dari tahun 2015 yang disediakan oleh Badan Antariksa Eropa () dan UCLouvain.",
-							"zh": "自 2015 年以来的土地覆盖数据，由欧洲空间局 (ESA) 和 UCLouvain 提供。 ",
-							"ka": "მიწის საფარის მონაცემები 2015 წლის შემდეგაა და მოწოდებულია ევროპული კოსმოსური სააგენტოს (ESA) და ლუვენის კათოლიკური უნივერსიტეტის (UCLouvain) მიერ."
-						},
-						"useGfwWidget": true,
-						"widgetId": "1b84364d-0efd-4d60-81ef-870f7d13ee7b",
-						"uiParams": "none",
-						"params": [{
-							"name": "layer",
-							"value": "gfw-landcover-2015"
-						}]
-					}],
-					"layerPanel": {
-						"GROUP_WEBMAP": {
-							"order": 2,
-							"label": {
-								
+							analysisId: 'BIO_LOSS',
+							chartType: 'bar',
+							label: {
+								en: 'CO2 emissions from biomass loss',
+								fr: 'Émissions de Co2 de la perte de biomasse',
+								es: 'Emisiones de CO2 provenientes de la pérdida de biomasa',
+								pt: 'Emissões de CO₂ por perda de biomassa',
+								id: 'Emisi CO2 dari kehilangan biomassa',
+								zh: '生物量损失导致的二氧化碳排放量',
+								ka: 'CO2 ემისია ბიომასის კარგვის გამო'
 							},
-							"layers": []
-						},
-						"GROUP_LCD": {
-							"grouptype": "default",
-							"order": 1,
-							"label": {
-								"en": "Land Cover Dynamics",
-								"fr": "Evolution de la couverture des sols",
-								"es": "Dinámica de la Cobertura del Suelo",
-								"pt": "Dinâmica de cobertura da terra",
-								"id": "Land Cover Dynamics",
-								"zh": "土地覆盖动态数据",
-								"ka": "მიწის საფარის დინამიკა"
+							title: {
+								en: 'Carbon Dioxide Emissions from Above Ground Live Woody Biomass Loss',
+								fr: 'Émissions de dioxyde de carbone de la perte de biomasse ligneuse vivante aérienne',
+								es: 'Emisiones de dióxido de carbono provenientes de la pérdida de biomasa leñosa viva en superficie',
+								pt: 'Emissões de dióxido de carbono por perda de biomassa de vegetação lenhosa viva acima do solo',
+								id: 'Emisi Karbon Dioksida dari kehilangan biomassa vegetasi berkayu di atas permukaan tanah',
+								zh: '地上活木生物量损失导致的二氧化碳排放',
+								ka: 'ნახშირორჟანგის ემისია მიწისზედა ცოცხალი ბიომასის კარგვის გამო'
 							},
-							"layers": [{
-								"order": 1,
-								"id": "TREE_COVER_LOSS",
-								"type": "remoteDataLayer",
-								"uuid": "2aed67b3-3643-40d3-9c1e-8af9afb5d9e2"
+							description: {
+								en: 'Emissions do not include carbon emissions from other sources besides woody biomass (tree cover) loss. Select range and tree cover density then click the run analysis button to see results.',
+								fr: 'Les émissions n’incluent pas les émissions de carbone d’autres sources que la perte de biomasse (couverture arborée). Sélectionner la plage et la densité de couverture arborée, puis cliquer sur le bouton « Lancer l’analyse » pour voir les résultats.',
+								es: 'Las emisiones no incluyen las emisiones de carbono de otras fuentes además de la pérdida de biomasa leñosa (cobertura arbórea). Para ver los resultados, seleccione el rango y la densidad de la cobertura arbórea, después haga clic en el botón ejecutar análisis.',
+								pt: 'As estimativas não incluem emissões de carbono geradas por fontes diferentes de perda (de cobertura arbórea) de biomassa de material lenhoso. Para ver os resultados, selecione o período e a densidade de cobertura arbórea; em seguida, clique no botão para executar a análise.',
+								id: 'Emisi tidak termasuk emisi karbon dari sumber lain selain kehilangan biomasa kayu (tutupan pohon). Pilih rentang dan kerapatan tutupan pohon kemudian klik tombol mulai analisis untuk melihat hasil.',
+								zh: '排放量不包括除树木生物量（森林覆盖）损失之外的其他来源导致的碳排放量。选择范围和森林覆盖密度，然后点击“运行分析”按钮查看结果。总碳排放量 (吨 二氧化碳)',
+								ka: 'ემისიები არ შეიცავენ ნახშირის ემისიებს სხვა წყაროებიდან, გარდა ცოცხალი ბიომასის (ხის ვარჯი) კარგვის. შეარჩიეთ საზღვრები და ხის ვარჯის სიხშირე, შემდეგ დააჭირეთ ღილაკს ანალიზის ჩატარება შედეგების სანახავად.'
 							},
 							useGfwWidget: true,
 							widgetId: 'ac38fdbd-fdb1-4d8e-9109-674013fb51a2',
@@ -616,32 +414,18 @@ html
 									zh: '选择分析范围:',
 									ka: 'საზღვრების შერჩევა ანალიზისთვის:'
 								}
-							}, {
-								"order": 2,
-								"id": "ADM-ZONAL",
-								"type": "dynamic",
-								"url": "https://gis.forest-atlas.org/server/rest/services/eth/AdminBoundaries/MapServer",
-								"layerIds": [185],
-								"technicalName": "eth_zones",
-								"label": {
-									"en": "Zonal boundaries"
 								},
-								"sublabel": {
-									"en": "(census boundaries 2007 - not authoritative)"
-								},
-								"visible": false,
-								"popup": {
-									"title": {
-										"en": "Zonal (2007 census) boundaries"
-									},
-									"content": {
-										"en": [{
-											"label": "Region (2007 census) name",
-											"fieldExpression": "R_NAME"
-										}, {
-											"label": "Zone (2007 census) name",
-											"fieldExpression": "Z_NAME"
-										}]
+								{
+									name: 'thresh',
+									inputType: 'tcd',
+									label: {
+										en: 'Select tree cover density: ',
+										fr: 'Sélectionner la densité de couverture arborée: ',
+										es: 'Seleccione la densidad de la cobertura arbórea: ',
+										pt: 'Selecione a densidade de cobertura arbórea: ',
+										id: 'Pilih kerapatan tutupan pohon: ',
+										zh: '选择森林覆盖密度: ',
+										ka: 'ხის ვარჯის სიხშირის შერჩევა: '
 									}
 								}
 							]
@@ -658,244 +442,437 @@ html
 								zh: '每月 GLAD 预警',
 								ka: 'GLAD შეტყობინებები'
 							},
-							{
-								"order": 3,
-								"type": "remoteDataLayer",
-								"id": "IMAZON_SAD",
-								"uuid": "3e9e86ae-e38d-4c59-8484-c8214ca5186a"
+							title: {
+								en: 'GLAD alerts per month',
+								fr: 'Alertes GLAD par mois',
+								es: 'Alertas GLAD por mes',
+								pt: 'Alertas GLAD por mês',
+								id: 'Peringatan GLAD per bulan',
+								zh: '每月 GLAD 预警',
+								ka: 'GLAD შეტყობინებები'
 							},
-							{
-								"order": 4,
-								"id": "GLAD_ALERTS",
-								"type": "remoteDataLayer",
-								"uuid": "356f862b-3e70-493a-997b-dc2a193410e9"
+							description: {
+								en: 'Count the number of GLAD tree cover loss alerts per month.',
+								fr: 'Compte le nombre d’alertes GLAD de perte de la couverture arborée par mois.',
+								es: 'Cuente el número de alertas GLAD sobre pérdida de cobertura arbórea por mes.',
+								pt: 'Quantificação de alertas GLAD de perda de cobertura arbórea por mês.',
+								id: 'Hitung jumlah peringatan kehilangan tutupan pohon GLAD per bulan.',
+								zh: 'Count the number of GLAD tree cover loss alerts per month.',
+								ka: 'Count the number of GLAD tree cover loss alerts per month.'
 							},
-							{
-								"order": 5,
-								"id": "FORMA_ALERTS",
-								"type": "remoteDataLayer",
-								"uuid": "56aa7e57-0ac4-446c-a82d-7713904b17c3"
+							useGfwWidget: true,
+							widgetId: '0734ba0a-3a6c-4388-aa4a-5871791b1d1f',
+							uiParams: 'none'
+						},
+						{
+							analysisId: 'TOTAL_GLAD_ALERTS',
+							chartType: 'badge',
+							label: {
+								en: 'Total GLAD Alerts',
+								fr: 'Total des alertes GLAD',
+								es: 'Alertas GLAD totales',
+								pt: 'Total de alertas GLAD',
+								id: 'Total Peringatan GLAD',
+								zh: 'GLAD 预警总数',
+								ka: 'GLAD შეტყობინებები'
 							},
-							{
-								"order": 6,
-								"id": "TERRA_I_ALERTS",
-								"type": "remoteDataLayer",
-								"uuid": "1fc7b0c5-259a-4685-8665-b2f1ed3f808f"
+							title: {
+								en: 'Total GLAD Alerts',
+								fr: 'Total des alertes GLAD',
+								es: 'Alertas GLAD totales',
+								pt: 'Total de alertas GLAD',
+								id: 'Total Peringatan GLAD',
+								zh: 'GLAD 预警总数',
+								ka: 'Total GLAD Alerts'
 							},
-							{
-								"order": 7,
-								"id": "VIIRS_ACTIVE_FIRES",
-								"type": "remoteDataLayer",
-								"uuid": "15cb32c9-874f-4552-afdc-8a35ef70682f"
+							description: {
+								en: 'Count the number of GLAD alerts which occurred within the selected time range.',
+								fr: 'Compte le nombre d’alertes GLAD durant la période sélectionnée.',
+								es: 'Cuente el número de alertas GLAD que ocurrieron en el rango de tiempo seleccionado.',
+								pt: 'Quantifica o número de alertas GLAD ocorridos em um período selecionado.',
+								id: 'Hitung jumlah peringatan GLAD yang terjadi dalam rentang waktu yang dipilih.',
+								zh: '统计在所选时间范围内出现的 GLAD 预警次数。',
+								ka: 'Count the number of GLAD tree cover loss alerts per month.'
 							},
-							{
-								"order": 8,
-								"id": "MODIS_ACTIVE_FIRES",
-								"type": "remoteDataLayer",
-								"uuid": "8ae39d34-a5e5-4742-b06e-6e913a8f1eb8"
+							useGfwWidget: true,
+							widgetId: '16ff6282-8ceb-4055-938a-43726a62b205',
+							uiParams: [{
+								inputType: 'datepicker',
+								startParamName: 'period',
+								combineParams: true,
+								valueSeparator: ',',
+								multi: true,
+								defaultStartDate: '2018-01-01',
+								minDate: '2015-01-01',
+								label: {
+									en: 'Select range for analysis',
+									fr: 'Sélectionner une plage pour l’analyse',
+									es: 'Seleccione un rango para el análisis',
+									pt: 'Selecione o período para análise',
+									id: 'Pilih rentang untuk analisis',
+									zh: '选择分析范围',
+									ka: 'საზღვრების შერჩევა ანალიზისთვის'
+								}
 							}]
 						},
-						"GROUP_LC": {
-							"groupttype": "default",
-							"order": 3,
-							"label": {
-								"en": "Land Cover",
-								"fr": "Couverture des sols",
-								"es": "Cobertura terrestre",
-								"pt": "Cobertura do Solo",
-								"id": "Land Cover",
-								"zh": "土地覆盖",
-								"ka": "მიწის საფარი"
+						{
+							analysisId: 'VIIRS_FIRES',
+							chartType: 'badge',
+							label: {
+								en: 'VIIRS Active Fires',
+								fr: 'Feux actifs VIIRS',
+								es: 'Incendios activos VIIRS',
+								pt: 'Incêndios ativos VIIRS',
+								id: 'Kebakaran Aktif VIIRS',
+								zh: 'VIIRS 活跃火点',
+								ka: 'VIIRS აქტიური ხანძრები'
 							},
-							"layers": [{
-								"order": 1,
-								"id": "GLOB_MANGROVE",
-								"type": "remoteDataLayer",
-								"uuid": "533cbe18-22a6-46ac-99ca-027c96f33ac3"
+							title: {
+								en: 'VIIRS Active Fires',
+								fr: 'Feux actifs VIIRS',
+								es: 'Incendios activos VIIRS',
+								pt: 'Incêndios ativos VIIRS',
+								id: 'Kebakaran Aktif VIIRS',
+								zh: 'VIIRS 活跃火点',
+								ka: 'VIIRS აქტიური ხანძრები'
 							},
-							{
-								"order": 2,
-								"id": "IFL",
-								"type": "remoteDataLayer",
-								"uuid": "5f815a7d-457e-4eae-a8e5-8864a60696ad"
+							description: {
+								en: 'This analysis counts the number of VIIRS fire alert detections during the past 7 days',
+								fr: 'Cette analyse compte le nombre d’alertes de détection d’incendies VIIRS durant les 7 derniers jours',
+								es: 'Este análisis cuenta el número de detecciones de alertas de incendios VIIRS durante los últimos siete días',
+								pt: 'Incêndios ativos VIIRS',
+								id: 'Analisis ini menghitung jumlah deteksi peringatan kebakaran VIIRS selama 7 hari terakhir',
+								zh: '此分析可统计过去 7 天 VIIRS 火警监测的次数。',
+								ka: 'ეს ანალიზი თვლის VIIRS ხანძრის შეტყობინებების გამოვლენის რაოდენობას ბოლო 7 დღის განმავლობაში.'
 							},
-							{
-								"order": 3,
-								"id": "PRIMARY_FORESTS",
-								"type": "remoteDataLayer",
-								"uuid": "edffb745-e523-462d-ad1e-3052006a3dbc"
+							useGfwWidget: true,
+							widgetId: '5d696f96-e6c7-4323-8bda-4c99cd6b0cb4',
+							uiParams: 'none'
+						},
+						{
+							analysisId: 'LCC',
+							chartType: 'pie',
+							label: {
+								en: 'Land Cover Composition',
+								fr: 'Composition de la couverture terrestre',
+								es: 'Cobertura terrestre',
+								pt: 'Cobertura do Solo',
+								id: 'Komposisi tutupan lahan',
+								zh: '土地覆盖构成',
+								ka: 'მიწის საფარის შემადგენლობა'
 							},
-							{
-								"order": 4,
-								"id": "AG_BIOMASS",
-								"type": "remoteDataLayer",
-								"uuid": "04526d47-f3f5-4f76-a939-e5f7861fd085"
+							title: {
+								en: 'Land Cover Composition',
+								fr: 'Composition de la couverture terrestre',
+								es: 'Composición de la cobertura de tierra',
+								pt: 'Composição da cobertura de terra',
+								id: 'Komposisi tutupan lahan',
+								zh: '土地覆盖构成',
+								ka: 'მიწის საფარის შემადგენლობა'
 							},
-							{
-								"order": 5,
-								"id": "LAND_COVER",
-								"type": "remoteDataLayer",
-								"uuid": "b8d3f175-0565-443f-839a-49eb890a4b3d"
+							description: {
+								en: 'Land cover data is from 2015 and provided by the European Space Agency (ESA) and UCLouvain.',
+								fr: 'Les données de la couverture terrestre datent de 2015 et sont fournies par l’Agence Spatiale Européenne (European Space Agency, ESA) et UCLouvain.',
+								es: 'Los datos de la cobertura de tierra son de 2015 y fueron proporcionados por la Agencia Espacial Europea (European Space Agency, ESA) y UCLouvain. ',
+								pt: 'Dados de cobertura de terra relativos ao período posterior a 2015 e fornecidos pela Agência Espacial Europeia (ESA) e pela UCLouvain. ',
+								id: 'Data tutupan lahan dari tahun 2015 yang disediakan oleh Badan Antariksa Eropa () dan UCLouvain.',
+								zh: '自 2015 年以来的土地覆盖数据，由欧洲空间局 (ESA) 和 UCLouvain 提供。 ',
+								ka: 'მიწის საფარის მონაცემები 2015 წლის შემდეგაა და მოწოდებულია ევროპული კოსმოსური სააგენტოს (ESA)  და ლუვენის კათოლიკური უნივერსიტეტის (UCLouvain) მიერ.'
 							},
-							{
-								"order": 6,
-								"id": "TREE_COVER",
-								"type": "remoteDataLayer",
-								"uuid": "2569adca-ef87-42c4-a153-57c5e8ba0ef7"
+							useGfwWidget: true,
+							widgetId: '1b84364d-0efd-4d60-81ef-870f7d13ee7b',
+							uiParams: 'none',
+							params: [{
+								name: 'layer',
+								value: 'gfw-landcover-2015'
 							}]
 						},
-						"GROUP_REF": {
-							"order": 5,
-							"groupType": "radio",
-							"label": {
-								"en": "Reference Layers"
+					],
+
+					/**
+					* Layer panel configuration, anything with an = is optional, {object=}
+					* Order at the group level controls the order of the accordions, the top most accordion's layers
+					* will also be the top most layers on the map. The order in the layer level controls how those layers
+					* are organized within their own group
+					** @name layerPanel
+					** Both labels and sublabels are objects whose properties are ISO codes for supported languages
+					** and values are string labels
+					* @property {object=} label - Label for the group in the layer panel
+					* @property {number} order - Order the accordions, and their layers, appear in the UI and the map, MUST START AT 1
+					* @property {object[]=} layers - Layers placed in the various accordions
+					* @property {object[]=} extraLayers - Layers not placed in the Layer panel but are on the map
+					* @property {number} layers[].order - Order of this layer in this section only
+					* @property {string} layers[].id - Must be a unique id for the layer
+					* @property {string} layers[].type - The type of the layer, valid values are currently one of the following:
+					** tiled | webtiled | image | dynamic | feature | graphic | glad | terra
+					* @property {boolean=} layers[].visible - Default visibility of the layer, default is false
+					* @property {string} layers[].technicalName - Technical name for the GFW Metadata API
+					* @property {number=} layers[].legendLayer - Optional layer id for an extra legend
+					* @property {string} layers[].url - URL for the service
+					* @property {object=} layers[].label - Label for the layer in the UI
+					* @property {object=} layers[].sublabel - Sublabel for the layer in the UI
+					* @property {boolean=} layers[].{ANY} - Any additional layer params that need to be passed through
+					* @property {object=} popup - Popup configuration for the layer if it is available
+					*/
+					layerPanel: {
+						GROUP_WEBMAP: {
+							order: 2,
+							label: {}, // Configurable via alternativeWebmapMenuName and webmapMenuName above
+							layers: [] // Will get filled in with layers from the webmap
+						},
+						GROUP_LCD: {
+							groupType: 'default',
+							order: 1,
+							label: {
+								en: 'Land Cover Dynamics',
+								fr: 'Evolution de la couverture des sols',
+								es: 'Dinámica de la Cobertura del Suelo',
+								pt: 'Dinâmica de cobertura da terra ',
+								id: 'Land Cover Dynamics',
+								zh: '土地覆盖动态数据',
+								ka: 'მიწის საფარის დინამიკა'
 							},
-							"layers": [{
-								"order": 1,
-								"id": "LULC",
-								"type": "dynamic",
-								"url": "https://gis.forest-atlas.org/server/rest/services/eth/BiophysicalData/MapServer",
-								"layerIds": [192],
-								"technicalName": "eth_landcover",
-								"label": {
-									"en": "Land use-land cover (2013)"
+							layers: [{
+								id: 'TREE_COVER_LOSS',
+								order: 1,
+								type: 'remoteDataLayer',
+								uuid: '2aed67b3-3643-40d3-9c1e-8af9afb5d9e2'
+								}, {
+									id: 'TREE_COVER_GAIN',
+									order: 2,
+									type: 'remoteDataLayer',
+									uuid: 'cb016f17-f12d-463a-9dc2-aabcf5db566c'
+								}, {
+									id: 'IMAZON_SAD',
+									order: 3,
+									type: 'remoteDataLayer',
+									uuid: '3e9e86ae-e38d-4c59-8484-c8214ca5186a'
 								},
-								"sublabel": {
-									"en": ""
+								{
+									id: 'FORMA_ALERTS',
+									order: 4,
+									type: 'remoteDataLayer',
+									uuid: '56aa7e57-0ac4-446c-a82d-7713904b17c3'
+								},
+								{
+									id: 'GLAD_ALERTS',
+									order: 5,
+									type: 'remoteDataLayer',
+									uuid: '356f862b-3e70-493a-997b-dc2a193410e9'
+								}, {
+									id: 'TERRA_I_ALERTS',
+									order: 6,
+									type: 'remoteDataLayer',
+									uuid: '1fc7b0c5-259a-4685-8665-b2f1ed3f808f'
+								}, {
+									id: 'VIIRS_ACTIVE_FIRES',
+									order: 7,
+									type: 'remoteDataLayer',
+									uuid: '15cb32c9-874f-4552-afdc-8a35ef70682f'
+								}, {
+									id: 'MODIS_ACTIVE_FIRES',
+									order: 8,
+									type: 'remoteDataLayer',
+									uuid: '8ae39d34-a5e5-4742-b06e-6e913a8f1eb8'
+								}
+							]
+						},
+						GROUP_LC: {
+							groupType: 'default',
+							order: 3,
+							label: {
+								en: 'Land Cover',
+								fr: 'Couverture des sols',
+								es: 'Cobertura terrestre',
+								pt: 'Cobertura do Solo',
+								id: 'Land Cover',
+								zh: '土地覆盖',
+								ka: 'მიწის საფარი'
+							},
+							layers: [{
+								id: 'GLOB_MANGROVE',
+								order: 1,
+								type: 'remoteDataLayer',
+								uuid: '533cbe18-22a6-46ac-99ca-027c96f33ac3'
+							}, {
+								id: 'IFL',
+								order: 2,
+								type: 'remoteDataLayer',
+								uuid: '5f815a7d-457e-4eae-a8e5-8864a60696ad'
+							}, {
+								id: 'PRIMARY_FORESTS',
+								order: 3,
+								type: 'remoteDataLayer',
+								uuid: 'edffb745-e523-462d-ad1e-3052006a3dbc'
+							}, {
+								id: 'AG_BIOMASS',
+								order: 4,
+								type: 'remoteDataLayer',
+								uuid: '04526d47-f3f5-4f76-a939-e5f7861fd085'
+							}, {
+								id: 'LAND_COVER',
+								order: 5,
+								type: 'remoteDataLayer',
+								uuid: 'b8d3f175-0565-443f-839a-49eb890a4b3d'
+							}, {
+								id: 'TREE_COVER',
+								order: 6,
+								type: 'remoteDataLayer',
+								uuid: '2569adca-ef87-42c4-a153-57c5e8ba0ef7'
+							}]
+						},
+						GROUP_IMAGERY: {
+							groupType: 'imagery',
+							order: 4,
+							label: {
+								en: 'Recent Imagery',
+								fr: 'Recent Imagery',
+								es: 'Recent Imagery',
+								pt: 'Recent Imagery',
+								id: 'Recent Imagery',
+								zh: 'Recent Imagery',
+								ka: 'Recent Imagery'
+							},
+							layers: [{
+								order: 1,
+								id: 'RECENT_IMAGERY',
+								type: 'imagery',
+								technicalName: 'recent_satellite_imagery',
+								visible: false,
+								label: {
+									en: 'Recent Imagery',
+									fr: 'Recent Imagery',
+									es: 'Recent Imagery',
+									pt: 'Recent Imagery',
+									id: 'Recent Imagery',
+									zh: 'Recent Imagery',
+									ka: 'Recent Imagery'
+								},
+								dynamicSublabel: {
+									en: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+									fr: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+									es: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+									pt: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+									id: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+									zh: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+									ka: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})'
+								}
+							}]
+						},
+						GROUP_BASEMAP: {
+							groupType: 'basemap',
+							order: 200,
+							label: {
+								en: 'Basemap',
+								fr: 'Basemap',
+								es: 'Basemap',
+								pt: 'Basemap',
+								id: 'Basemap',
+								zh: 'Basemap',
+								ka: 'საბაზო რუკა'
+							},
+							layers: [{
+								id: 'landsat',
+								thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/basemaps-sdd18a411a3-5bf18f445e58b8766f773184b7741c67.png',
+								templateUrl: 'https://d2h71bpqsyf4vw.cloudfront.net/2016/${level}/${col}/${row}.png',
+								years: ['2000', '2001', '2002', '2003', '2004', '2005', '2006', '2007', '2008', '2009', '2010', '2011', '2012', '2013', '2014', '2015', '2016'],
+								title: {
+									en: 'Landsat',
+									fr: 'Landsat',
+									es: 'Landsat',
+									pt: 'Landsat',
+									id: 'Landsat',
+									zh: 'Landsat',
+									ka: 'Landsat'
 								}
 							}, {
-								"order": 2,
-								"id": "SLOPE",
-								"type": "dynamic",
-								"url": "https://gis.forest-atlas.org/server/rest/services/eth/BiophysicalData/MapServer",
-								"layerIds": [199],
-								"technicalName": "eth_slope",
-								"label": {
-									"en": "Slope"
-								},
-								"sublabel": {
-									"en": ""
+								id: 'wri_mono',
+								thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/wri_mono.png',
+								// thumbnailUrl: './css/images/wri_mono.png',
+								title: {
+									en: 'WRI Mono',
+									fr: 'WRI Mono',
+									es: 'WRI Mono',
+									pt: 'WRI Mono',
+									id: 'WRI Mono',
+									zh: 'WRI Mono',
+									ka: 'WRI Mono'
 								}
 							}, {
-								"order": 3,
-								"id": "POP-DENSITY",
-								"type": "dynamic",
-								"url": "https://gis.forest-atlas.org/server/rest/services/eth/BiophysicalData/MapServer",
-								"layerIds": [196],
-								"technicalName": "eth_population",
-								"label": {
-									"en": "Population density (2007)"
-								},
-								"sublabel": {
-									"en": ""
-								}
-							}, {
-								"order": 4,
-								"id": "TREECOVER",
-								"type": "dynamic",
-								"url": "https://gis.forest-atlas.org/server/rest/services/eth/BiophysicalData/MapServer",
-								"layerIds": [193],
-								"technicalName": "eth_treecover",
-								"label": {
-									"en": "Tree cover (2010)"
-								},
-								"sublabel": {
-									"en": ""
-								}
-							}, {
-								"order": 5,
-								"id": "RAINFALL",
-								"type": "dynamic",
-								"url": "https://gis.forest-atlas.org/server/rest/services/eth/BiophysicalData/MapServer",
-								"layerIds": [194],
-								"technicalName": "eth_rainfall",
-								"label": {
-									"en": "Average annual rainfall"
-								},
-								"sublabel": {
-									"en": ""
+								id: 'wri_contextual',
+								thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/wri_contextual.png',
+								// thumbnailUrl: './css/images/wri_contextual.png',
+								title: {
+									en: 'WRI Contextual',
+									fr: 'WRI Contextual',
+									es: 'WRI Contextual',
+									pt: 'WRI Contextual',
+									id: 'WRI Contextual',
+									zh: 'WRI Contextual',
+									ka: 'WRI Contextual'
 								}
 							}]
 						},
-						"GROUP_IMAGERY": {
-							"grouptype": "imagery",
-							"order": 4,
-							"label": {
-								"en": "Recent Imagery",
-								"fr": "Imagerie récente",
-								"es": "Imágenes recientes",
-								"pt": "Imagens recentes",
-								"id": "Citra Satelit Terbaru",
-								"zh": "Recent Imagery",
-								"ka": "ბოლო გამოსახულება"
+
+						/**
+						* CUSTOM GROUPS
+						* Add your custom groups below. The custom groups are similar to the groups defined above.
+						* They are an object defined with a unique key (this key MUST be unique).
+						* There are three (3) group types that you may choose from:
+						*    checkbox - This is a standard group type with checkboxes to turn layers on and off.
+						*               With this group type, more than one layer may be on at a time
+						*
+						*    radio - This group contains raio buttons instead of checkboxes for the layer toggles
+						*            Only one layer may be on at a time within the same group
+						*            You may optionally choose to turn this group off when any other radio group is selected
+						*
+						*    nested - This group allows for layers to be grouped further within a layer panel
+						*
+						* COMMON GROUP PROPERTIES
+						* @property {string} groupType - the group type, one of checkbox, radio, nested
+						* @property {number} order - the order of the group in the layer panel
+						* @property {object} label - the label for the group in the layer panel
+						* @property {object[]} layers - the layers to be placed in the group
+						* @property {string} layers[].id - the id of the layer as generated by your AGOL webmap
+						* @property {number} layers[].order - the order of the layer within the group
+						* @property {object=} layers[].sublabel - the sublabel displayed under the layer name
+						*
+						* RADIO GROUP PROPERTIES
+						* @property {object[]} layers[].includedSublayers - for a dynamic layer, this is which
+						* sublayers you would like to include in the group. This property is required, so if you
+						* wish to include all sublayers, you must still provide this property with all sublayers
+						* @property {object} sublabel - for a dynamic layer the sublabel property must specify
+						* which sublayer the sublabel belongs to
+						*
+						* NESTED GROUP PROPERTIES
+						* @property {number} layers[].order - the order of the nested group within the panel group
+						* @property {object} layers[].label - the label for the nested group
+						* @property {object[]} layers[].nestedLayers - the layers for the nested group
+						*/
+
+						extraLayers: [{
+							id: 'MASK',
+							type: 'dynamic',
+							order: 10000,
+							url: 'https://gis.forest-atlas.org/server/rest/services/country_masks/country_mask_global/MapServer',
+							opacity: 0.35,
+							layerIds: [0]
 							},
-							"layers": [{
-								"order": 1,
-								"id": "RECENT_IMAGERY",
-								"type": "imagery",
-								"technicalName": "recent_satellite_imagery",
-								"visible": false,
-								"label": {
-									"en": "Recent Imagery",
-									"fr": "Imagerie récente",
-									"es": "Imágenes recientes",
-									"pt": "Imagens recentes",
-									"id": "Citra Satelit Terbaru",
-									"zh": "云层覆盖",
-									"ka": "ბოლო გამოსახულება"
-								},
-								"dynamicSublabel": {
-									"en": "({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})",
-									"fr": "({DATE_TIME}, {CLOUD_COVERAGE}% Imagerie récente, {INSTRUMENT})",
-									"es": "({DATE_TIME}, {CLOUD_COVERAGE}% Cobertura de nubes, {INSTRUMENT})",
-									"pt": "({DATE_TIME}, {CLOUD_COVERAGE}% Cobertura de nuvens, {INSTRUMENT})",
-									"id": "({DATE_TIME}, {CLOUD_COVERAGE}% Tutupan Awan, {INSTRUMENT})",
-									"zh": "({DATE_TIME}, {CLOUD_COVERAGE}% 近期图像, {INSTRUMENT})",
-									"ka": "({DATE_TIME}, {CLOUD_COVERAGE}% ღრუბლიანობა, {INSTRUMENT})"
-								}
-							}]
-						},
-						"GROUP_BASEMAP": {
-							"groupType": "basemap",
-							"order": 7,
-							"label": {
-								"en": "Basemap",
-								"fr": "Basemap",
-								"es": "Basemap",
-								"pt": "Basemap",
-								"id": "Basemap",
-								"zh": "Basemap",
-								"ka": "საბაზო რუკა"
+							{
+								id: 'LEGEND_LAYER',
+								type: 'dynamic',
+								url: 'https://gis-gfw.wri.org/arcgis/rest/services/legends/MapServer',
+								visible: false,
+								opacity: 0,
+								layerIds: []
 							},
-							"layers": [{
-								"id": "wri_mono",
-								"thumbnailUrl": "https://my.gfw-mapbuilder.org/img/wri_mono.png",
-								"title": {
-									"en": "Grey Basemap"
-								}
-							}]
-						},
-						"extraLayers": [{
-							"id": "MASK",
-							"type": "dynamic",
-							"order": 10000,
-							"url": "https://gis.forest-atlas.org/server/rest/services/country_masks/country_mask_global/MapServer",
-							"opacity": 0.35,
-							"layerIds": [3]
-						}, {
-							"id": "LEGEND_LAYER",
-							"type": "dynamic",
-							"url": "https://gis-gfw.wri.org/arcgis/rest/services/legends/MapServer",
-							"visible": false,
-							"opacity": 0,
-							"layerIds": []
-						}, {
-							"id": "USER_FEATURES",
-							"type": "graphic",
-							"visible": true
-						}]
-					},
-					"otherFieldsModules": ""
+							{
+								id: 'USER_FEATURES',
+								type: 'graphic',
+								visible: true
+							}
+						]
+					}
 				},
 				version: '1.4.1'
 			});

--- a/src/external.pug
+++ b/src/external.pug
@@ -36,7 +36,6 @@ html
 					includeMyGFWLogin: true,
 					navLinksInNewTab: false,
 					customColorTheme: '#17eae7',
-					defaultColorTheme: '#F0AB00', //Default gold theme
 					//- Language Settings
 					language: 'en',
 					useAlternativeLanguage: false,

--- a/src/externalReport.pug
+++ b/src/externalReport.pug
@@ -32,7 +32,6 @@ html
           includeMyGFWLogin: true,
           navLinksInNewTab: false,
           customColorTheme: '#17eae7',
-          defaultColorTheme: '#F0AB00', //Default gold theme
           //- Language Settings
           language: 'en',
           useAlternativeLanguage: false,

--- a/src/externalReport.pug
+++ b/src/externalReport.pug
@@ -5,7 +5,7 @@ html
   body
     div#report.report
     div#share-modal.share-modal.hidden
-    script(id='report-load' src='http://alpha.blueraster.io/gfw-mapbuilder/custom-color-theme-refactor/reportLib.1.4.1.js')
+    script(id='report-load' src='https://library.gfw-mapbuilder.org/reportLib.1.4.1.js')
     script.
       var customApp = new MapBuilderReport({
         config: {
@@ -31,7 +31,6 @@ html
           hideFooter: false,
           includeMyGFWLogin: true,
           navLinksInNewTab: false,
-          customColorTheme: '#17eae7',
           //- Language Settings
           language: 'en',
           useAlternativeLanguage: false,
@@ -147,561 +146,445 @@ html
                 zh: '选择分析范围:',
                 ka: 'საზღვრების შერჩევა ანალიზისთვის:'
               }
+              },
+              {
+                name: 'thresh',
+                inputType: 'tcd',
+                label: {
+                  en: 'Select tree cover density: ',
+                  fr: 'Sélectionner la densité de couverture arborée: ',
+                  es: 'Seleccione la densidad de la cobertura arbórea: ',
+                  pt: 'Selecione a densidade de cobertura arbórea: ',
+                  id: 'Pilih kerapatan tutupan pohon: ',
+                  zh: '选择森林覆盖密度: ',
+                  ka: 'ხის ვარჯის სიხშირის შერჩევა: '
+                }
+              }
+            ]
             },
             {
-              "name": "thresh",
-              "inputType": "tcd",
-              "label": {
-                "en": "Select tree cover density: ",
-                "fr": "Sélectionner la densité de couverture arborée: ",
-                "es": "Seleccione la densidad de la cobertura arbórea: ",
-                "pt": "Selecione a densidade de cobertura arbórea: ",
-                "id": "Pilih kerapatan tutupan pohon: ",
-                "zh": "选择森林覆盖密度: ",
-                "ka": "ხის ვარჯის სიხშირის შერჩევა: "
-              }
-            }]
-          },
-          {
-            "analysisId": "TC_LOSS",
-            "chartType": "bar",
-            "label": {
-              "en": "Annual Tree cover loss",
-              "fr": "Pertes de la couverture arborée annuelles",
-              "es": "Pérdida de cobertura arbórea anual",
-              "pt": "Perda anual de cobertura arbórea",
-              "id": "Kehilangan tutupan pohon tahunan",
-              "zh": "年度森林覆盖减少量面积",
-              "ka": "წლიური ხის ვარჯის კარგვა"
-            },
-            "title": {
-              "en": "Annual Tree cover loss",
-              "fr": "Pertes de la couverture arborée annuelles",
-              "es": "Pérdida de cobertura arbórea anual",
-              "pt": "Perda anual de cobertura arbórea",
-              "id": "Kehilangan tutupan pohon tahunan",
-              "zh": "年度森林覆盖减少量面积",
-              "ka": "წლიური ხის ვარჯის კარგვა"
-            },
-            "description": {
-              "en": "Select range and tree cover density then click the run analysis button to see results.",
-              "fr": "Sélectionner la plage et la densité de couverture arborée, puis cliquer sur le bouton « Exécuter l’analyse » pour voir les résultats.",
-              "es": "Para ver los resultados, seleccione el rango y la densidad de la cobertura arbórea, después haga clic en el botón ejecutar análisis.",
-              "pt": "Para ver os resultados, selecione o período e a densidade de cobertura arbórea; em seguida, clique no botão para executar a análise.",
-              "id": "Pilih rentang dan kerapatan tutupan pohon kemudian klik tombol mulai analisis untuk melihat hasil.",
-              "zh": "选择范围和森林覆盖密度，然后点击“运行分析”按钮查看结果。",
-              "ka": "შეარჩიეთ საზღვრები და ხის ვარჯის სიხშირე, შემდეგ დააჭირეთ ღილაკს ანალიზის ჩატარება შედეგებს სანახავად."
-            },
-            "useGfwWidget": true,
-            "widgetId": "e53e541c-92cd-4b00-9aa7-2c7bb36d4697",
-            "uiParams": [{
-              "inputType": "rangeSlider",
-              "startParamName": "period",
-              "combineParams": true,
-              "valueSeparator": ",",
-              "bounds": [2001,
-              2018],
-              "valueType": "date",
-              "label": {
-                "en": "Select range for analysis",
-                "fr": "Sélectionner une plage pour l’analyse:",
-                "es": "Seleccione un rango para el análisis:",
-                "pt": "Selecione o período para análise:",
-                "id": "Pilih rentang untuk analisis:",
-                "zh": "选择分析范围:",
-                "ka": "საზღვრების შერჩევა ანალიზისთვის:"
-              }
+              analysisId: 'TC_LOSS',
+              chartType: 'bar',
+              label: {
+                en: 'Annual Tree cover loss',
+                fr: 'Pertes de la couverture arborée annuelles',
+                es: 'Pérdida de cobertura arbórea anual',
+                pt: 'Perda anual de cobertura arbórea',
+                id: 'Kehilangan tutupan pohon tahunan',
+                zh: '年度森林覆盖减少量面积',
+                ka: 'წლიური ხის ვარჯის კარგვა'
+              },
+              title: {
+                en: 'Annual Tree cover loss',
+                fr: 'Pertes de la couverture arborée annuelles',
+                es: 'Pérdida de cobertura arbórea anual',
+                pt: 'Perda anual de cobertura arbórea',
+                id: 'Kehilangan tutupan pohon tahunan',
+                zh: '年度森林覆盖减少量面积',
+                ka: 'წლიური ხის ვარჯის კარგვა'
+              },
+              description: {
+                en: 'Select range and tree cover density then click the run analysis button to see results.',
+                fr: 'Sélectionner la plage et la densité de couverture arborée, puis cliquer sur le bouton « Lancer l’analyse » pour voir les résultats.',
+                es: 'Para ver los resultados, seleccione el rango y la densidad de la cobertura arbórea, después haga clic en el botón ejecutar análisis.',
+                pt: 'Para ver os resultados, selecione o período e a densidade de cobertura arbórea; em seguida, clique no botão para executar a análise.',
+                id: 'Pilih rentang dan kerapatan tutupan pohon kemudian klik tombol mulai analisis untuk melihat hasil.',
+                zh: '选择范围和森林覆盖密度，然后点击“运行分析”按钮查看结果。',
+                ka: 'შეარჩიეთ საზღვრები და ხის ვარჯის სიხშირე, შემდეგ დააჭირეთ ღილაკს ანალიზის ჩატარება შედეგებს სანახავად.'
+              },
+              useGfwWidget: true,
+              widgetId: 'e53e541c-92cd-4b00-9aa7-2c7bb36d4697',
+              uiParams: [{
+                inputType: 'rangeSlider',
+                startParamName: 'period',
+                combineParams: true,
+                valueSeparator: ',',
+                bounds: [2001, 2018],
+                valueType: 'date',
+                label: {
+                  en: 'Select range for analysis',
+                  fr: 'Sélectionner une plage pour l’analyse:',
+                  es: 'Seleccione un rango para el análisis:',
+                  pt: 'Selecione o período para análise:',
+                  id: 'Pilih rentang untuk analisis:',
+                  zh: '选择分析范围:',
+                  ka: 'საზღვრების შერჩევა ანალიზისთვის:'
+                }
+                },
+                {
+                  name: 'thresh',
+                  inputType: 'tcd',
+                  label: {
+                    en: 'Select tree cover density: ',
+                    fr: 'Sélectionner la densité de couverture arborée: ',
+                    es: 'Seleccione la densidad de la cobertura arbórea: ',
+                    pt: 'Selecione a densidade de cobertura arbórea: ',
+                    id: 'Pilih kerapatan tutupan pohon: ',
+                    zh: '选择森林覆盖密度: ',
+                    ka: 'ხის ვარჯის სიხშირის შერჩევა: '
+                  }
+                }
+              ],
             },
             {
-              "name": "thresh",
-              "inputType": "tcd",
-              "label": {
-                "en": "Select tree cover density: ",
-                "fr": "Sélectionner la densité de couverture arborée: ",
-                "es": "Seleccione la densidad de la cobertura arbórea: ",
-                "pt": "Selecione a densidade de cobertura arbórea: ",
-                "id": "Pilih kerapatan tutupan pohon: ",
-                "zh": "选择森林覆盖密度: ",
-                "ka": "ხის ვარჯის სიხშირის შერჩევა: "
-              }
-            }]
-          },
-          {
-            "analysisId": "IFL",
-            "chartType": "bar",
-            "label": {
-              "en": "Annual tree cover loss in IFL",
-              "fr": "Perte annuelle de la couverture arborée en PFI",
-              "es": "Pérdida de cobertura arbórea anual en IFL",
-              "pt": "Perda anual de cobertura arbórea em IFL",
-              "id": "Kehilangan tutupan pohon tahunan di IFL",
-              "zh": "年度原生森林（IFL）覆盖减面积",
-              "ka": "ყოველწლიური ხის ვარჯის კარგვა ხტლ-ში"
-            },
-            "title": {
-              "en": "Annual Tree Cover Loss in Intact Forest Landscapes (IFL)",
-              "fr": "Perte annuelle de la couverture arborée en Paysage Forestier Intact (PFI)",
-              "es": "Pérdida de cobertura arbórea anual en Paisajes Forestales Intactos (Intact Forest Landscapes, IFL)",
-              "pt": "Perda anual de cobertura arbórea em paisagens florestais intactas (IFL)",
-              "id": "Kehilangan Tutupan Pohon Tahunan di Lanskap Hutan Utuh (IFL)",
-              "zh": "年度原生森林（IFL）树木覆盖减面积",
-              "ka": "ყოველწლიური ხის ვარჯის კარგვა ხელუხლებელი ტყის ლანდშაფტებში (ხტლ)"
-            },
-            "description": {
-              "en": "Results will not be available if the area you selected does not include IFL. Select range and tree cover density then click the run analysis button to see results.",
-              "fr": "Les résultats ne seront pas disponibles si la zone que vous avez sélectionnée n’inclut pas de PFI. Sélectionner la plage et la densité de couverture arborée, puis cliquer sur le bouton « Exécuter l’analyse » pour voir les résultats.",
-              "es": "Los resultados no estarán disponibles si el área que seleccionó no incluye IFL. Para ver los resultados, seleccione el rango y la densidad de la cobertura arbórea, después haga clic en el botón ejecutar análisis.",
-              "pt": "Os resultados não estarão disponíveis se a área selecionada não for considerada IFL. Para ver os resultados, selecione o período e a densidade de cobertura arbórea; em seguida, clique no botão para executar a análise.",
-              "id": "Hasil tidak akan tersedia jika kawasan yang Anda pilih tidak mencakup Lanskap Hutan Utuh (IFL). Pilih rentang dan kerapatan tutupan pohon kemudian klik tombol mulai analisis untuk melihat hasil.",
-              "zh": "如果您选择的区域不包括原生森林，将不会提供结果。选择范围和森林覆盖密度，然后点击“运行分析”按钮查看结果。",
-              "ka": "შედეგები არ იქნება ხელმისაწვდომი, თუკი თქვენ მიერ შერჩეული ფართობი არ შეიცავს ხტლ-ს. შეარჩიეთ საზღვრები და ხის ვარჯის სიხშირე, შემდეგ დააჭირეთ ღილაკს ანალიზის ჩატარება შედეგების სანახავად."
-            },
-            "useGfwWidget": true,
-            "widgetId": "2083a1bc-440d-43fe-8b50-ff9918a37c57",
-            "params": [{
-              "name": "layer",
-              "value": "ifl2000"
-            }],
-            "uiParams": [{
-              "inputType": "rangeSlider",
-              "startParamName": "period",
-              "combineParams": true,
-              "valueSeparator": ",",
-              "bounds": [2001,
-              2018],
-              "valueType": "date",
-              "label": {
-                "en": "Select range for analysis",
-                "fr": "Sélectionner une plage pour l’analyse:",
-                "es": "Seleccione un rango para el análisis:",
-                "pt": "Selecione o período para análise:",
-                "id": "Pilih rentang untuk analisis:",
-                "zh": "选择分析范围:",
-                "ka": "საზღვრების შერჩევა ანალიზისთვის:"
-              }
+              analysisId: 'IFL',
+              chartType: 'bar',
+              label: {
+                en: 'Annual tree cover loss in IFL',
+                fr: 'Perte annuelle de la couverture arborée en PFI',
+                es: 'Pérdida de cobertura arbórea anual en IFL',
+                pt: 'Perda anual de cobertura arbórea em IFL',
+                id: 'Kehilangan tutupan pohon tahunan di IFL',
+                zh: '年度原生森林（IFL）覆盖减面积',
+                ka: 'ყოველწლიური ხის ვარჯის კარგვა ხტლ-ში'
+              },
+              title: {
+                en: 'Annual Tree Cover Loss in Intact Forest Landscapes (IFL)',
+                fr: 'Perte annuelle de la couverture arborée en Paysage Forestier Intact (PFI)',
+                es: 'Pérdida de cobertura arbórea anual en Paisajes Forestales Intactos (Intact Forest Landscapes, IFL)',
+                pt: 'Perda anual de cobertura arbórea em paisagens florestais intactas (IFL)',
+                id: 'Kehilangan Tutupan Pohon Tahunan di Lanskap Hutan Utuh (IFL)',
+                zh: '年度原生森林（IFL）树木覆盖减面积',
+                ka: 'ყოველწლიური ხის ვარჯის კარგვა ხელუხლებელი ტყის ლანდშაფტებში (ხტლ)'
+              },
+              description: {
+                en: 'Results will not be available if the area you selected does not include IFL. Select range and tree cover density then click the run analysis button to see results.',
+                fr: 'Les résultats ne seront pas disponibles si la zone que vous avez sélectionnée n’inclut pas de PFI. Sélectionner la plage et la densité de couverture arborée, puis cliquer sur le bouton « Lancer l’analyse » pour voir les résultats.',
+                es: 'Los resultados no estarán disponibles si el área que seleccionó no incluye IFL. Para ver los resultados, seleccione el rango y la densidad de la cobertura arbórea, después haga clic en el botón ejecutar análisis.',
+                pt: 'Os resultados não estarão disponíveis se a área selecionada não for considerada IFL. Para ver os resultados, selecione o período e a densidade de cobertura arbórea; em seguida, clique no botão para executar a análise.',
+                id: 'Hasil tidak akan tersedia jika kawasan yang Anda pilih tidak mencakup Lanskap Hutan Utuh (IFL). Pilih rentang dan kerapatan tutupan pohon kemudian klik tombol mulai analisis untuk melihat hasil.',
+                zh: '如果您选择的区域不包括原生森林，将不会提供结果。选择范围和森林覆盖密度，然后点击“运行分析”按钮查看结果。',
+                ka: 'შედეგები არ იქნება ხელმისაწვდომი, თუკი თქვენ მიერ შერჩეული ფართობი არ შეიცავს ხტლ-ს. შეარჩიეთ საზღვრები და ხის ვარჯის სიხშირე, შემდეგ დააჭირეთ ღილაკს ანალიზის ჩატარება შედეგების სანახავად.'
+              },
+              "useGfwWidget": true,
+              "widgetId": "2083a1bc-440d-43fe-8b50-ff9918a37c57",
+              params: [{
+                name: 'layer',
+                value: 'ifl2000'
+              }],
+              uiParams: [{
+                inputType: 'rangeSlider',
+                startParamName: 'period',
+                combineParams: true,
+                valueSeparator: ',',
+                bounds: [2001, 2018],
+                valueType: 'date',
+                label: {
+                  en: 'Select range for analysis',
+                  fr: 'Sélectionner une plage pour l’analyse:',
+                  es: 'Seleccione un rango para el análisis:',
+                  pt: 'Selecione o período para análise:',
+                  id: 'Pilih rentang untuk analisis:',
+                  zh: '选择分析范围:',
+                  ka: 'საზღვრების შერჩევა ანალიზისთვის:'
+                }
+                },
+                {
+                  name: 'thresh',
+                  inputType: 'tcd',
+                  label: {
+                    en: 'Select tree cover density: ',
+                    fr: 'Sélectionner la densité de couverture arborée: ',
+                    es: 'Seleccione la densidad de la cobertura arbórea: ',
+                    pt: 'Selecione a densidade de cobertura arbórea: ',
+                    id: 'Pilih kerapatan tutupan pohon: ',
+                    zh: '选择森林覆盖密度: ',
+                    ka: 'ხის ვარჯის სიხშირის შერჩევა: '
+                  }
+                }
+              ]
             },
             {
-              "name": "thresh",
-              "inputType": "tcd",
-              "label": {
-                "en": "Select tree cover density: ",
-                "fr": "Sélectionner la densité de couverture arborée: ",
-                "es": "Seleccione la densidad de la cobertura arbórea: ",
-                "pt": "Selecione a densidade de cobertura arbórea: ",
-                "id": "Pilih kerapatan tutupan pohon: ",
-                "zh": "选择森林覆盖密度: ",
-                "ka": "ხის ვარჯის სიხშირის შერჩევა: "
-              }
-            }]
-          },
-          {
-            "analysisId": "Loss_LandCover",
-            "chartType": "bar",
-            "label": {
-              "en": "Annual tree cover loss by land cover class",
-              "fr": "Perte annuelle de la couverture arborée par catégorie de couverture terrestre",
-              "es": "Pérdida de cobertura arbórea anual por clase de cobertura de tierra",
-              "pt": "Perda anual de cobertura arbórea por classe de cobertura de terra",
-              "id": "Kehilangan tutupan pohon tahunan berdasarkan kelas tutupan lahan",
-              "zh": "年度森林覆盖减少量（按土地覆盖分类）",
-              "ka": "ყოველწლიური ხის ვარჯის კარგვა მიწის საფარის კლასის მიხედვით"
-            },
-            "title": {
-              "en": "Annual tree cover loss by land cover class",
-              "fr": "Perte annuelle de la couverture arborée par catégorie de couverture terrestre",
-              "es": "Pérdida de cobertura arbórea anual por clase de cobertura de tierra",
-              "pt": "Perda anual de cobertura arbórea por classe de cobertura de terra",
-              "id": "Kehilangan tutupan pohon tahunan berdasarkan kelas tutupan lahan",
-              "zh": "年度森林覆盖减少量（按土地覆盖分类）",
-              "ka": "ყოველწლიური ხის ვარჯის კარგვა მიწის საფარის კლასის მიხედვით"
-            },
-            "description": {
-              "en": "Land cover data from 2000 and provided by the European Space Agency (ESA) and UCLouvain. Select range and tree cover density then click the run analysis button to see results.",
-              "fr": "Données de couverture du sol datant de 2000 et fournies par l’Agence Spatiale Européenne (European Space Agency, ESA) et UCLouvain. Sélectionner la plage et la densité de couverture arborée, puis cliquer sur le bouton « Exécuter l’analyse » pour voir les résultats.",
-              "es": "Los datos de la cobertura de tierra son de 2000 y fueron proporcionados por la Agencia Espacial Europea (European Space Agency, ESA) y UCLouvain. Para ver los resultados, seleccione el rango y la densidad de la cobertura arbórea, después haga clic en el botón ejecutar análisis.",
-              "pt": "Dados de cobertura de terra relativos ao período posterior a 2000 e fornecidos pela Agência Espacial Europeia (ESA) e pela Universidade Católica da Lovaina (UCLouvain). Para ver os resultados, selecione o período e a densidade de cobertura arbórea; em seguida, clique no botão para executar a análise.",
-              "id": "Data tutupan lahan dari tahun 2000 dan disediakan oleh Badan Antariksa Eropa –(ESA) dan UCLouvain. Pilih rentang dan kerapatan tutupan pohon kemudian klik tombol mulai analisis untuk melihat hasil.",
-              "zh": "自 2000 年以来的土地覆盖数据，由欧洲空间局 (ESA) 和 UCLouvain 提供。选择范围和森林覆盖密度，然后点击“运行分析”按钮查看结果。",
-              "ka": "მიწის საფარის მონაცემები 2000 წლიდან მოწოდებულია ევროპული კოსმოსური სააგენტოს (ESA) და ლუვენის კათოლიკური უნივერსიტეტის (UCLouvain) მიერ. შეარჩიეთ საზღვრები და ხის ვარჯის სიხშირე, შემდეგ დააჭირეთ ღილაკს ანალიზის ჩატარება შედეგების სანახავად."
-            },
-            "useGfwWidget": true,
-            "widgetId": "31f78466-fc0b-42f9-a7ae-bea8559740d8",
-            "params": [{
-              "name": "layer",
-              "value": "gfw-landcover-2000"
-            }],
-            "uiParams": [{
-              "inputType": "rangeSlider",
-              "startParamName": "period",
-              "combineParams": true,
-              "valueSeparator": ",",
-              "bounds": [2001,
-              2018],
-              "valueType": "date",
-              "label": {
-                "en": "Select range for analysis",
-                "fr": "Sélectionner une plage pour l’analyse:",
-                "es": "Seleccione un rango para el análisis:",
-                "pt": "Selecione o período para análise:",
-                "id": "Pilih rentang untuk analisis:",
-                "zh": "选择分析范围:",
-                "ka": "საზღვრების შერჩევა ანალიზისთვის:"
-              }
+              analysisId: 'Loss_LandCover',
+              chartType: 'bar',
+              label: {
+                en: 'Annual tree cover loss by land cover class',
+                fr: 'Perte annuelle de la couverture arborée par catégorie de couverture terrestre',
+                es: 'Pérdida de cobertura arbórea anual por clase de cobertura de tierra',
+                pt: 'Perda anual de cobertura arbórea por classe de cobertura de terra',
+                id: 'Kehilangan tutupan pohon tahunan berdasarkan  kelas tutupan lahan',
+                zh: '年度森林覆盖减少量（按土地覆盖分类）',
+                ka: 'ყოველწლიური ხის ვარჯის კარგვა მიწის საფარის კლასის მიხედვით'
+              },
+              title: {
+                en: 'Annual tree cover loss by land cover class',
+                fr: 'Perte annuelle de la couverture arborée par catégorie de couverture terrestre',
+                es: 'Pérdida de cobertura arbórea anual por clase de cobertura de tierra',
+                pt: 'Perda anual de cobertura arbórea por classe de cobertura de terra',
+                id: 'Kehilangan tutupan pohon tahunan berdasarkan  kelas tutupan lahan',
+                zh: '年度森林覆盖减少量（按土地覆盖分类）',
+                ka: 'ყოველწლიური ხის ვარჯის კარგვა მიწის საფარის კლასის მიხედვით'
+              },
+              description: {
+                en: 'Land cover data from 2000 and provided by the European Space Agency (ESA) and UCLouvain. Select range and tree cover density then click the run analysis button to see results.',
+                fr: 'Données de couverture du sol datant de 2000 et fournies par l’Agence Spatiale Européenne (European Space Agency, ESA) et UCLouvain. Sélectionner la plage et la densité de couverture arborée, puis cliquer sur le bouton « Lancer l’analyse » pour voir les résultats.',
+                es: 'Los datos de la cobertura de tierra son de 2000 y fueron proporcionados por la Agencia Espacial Europea (European Space Agency, ESA) y UCLouvain. Para ver los resultados, seleccione el rango y la densidad de la cobertura arbórea, después haga clic en el botón ejecutar análisis.',
+                pt: 'Dados de cobertura de terra relativos ao período posterior a 2000 e fornecidos pela Agência Espacial Europeia (ESA) e pela Universidade Católica da Lovaina (UCLouvain). Para ver os resultados, selecione o período e a densidade de cobertura arbórea; em seguida, clique no botão para executar a análise.',
+                id: 'Data tutupan lahan dari tahun 2000 dan disediakan oleh Badan Antariksa Eropa –(ESA) dan UCLouvain. Pilih rentang dan kerapatan tutupan pohon kemudian klik tombol mulai analisis untuk melihat hasil.',
+                zh: '自 2000 年以来的土地覆盖数据，由欧洲空间局 (ESA) 和 UCLouvain 提供。选择范围和森林覆盖密度，然后点击“运行分析”按钮查看结果。',
+                ka: 'მიწის საფარის მონაცემები 2000 წლიდან მოწოდებულია ევროპული კოსმოსური სააგენტოს (ESA) და ლუვენის კათოლიკური უნივერსიტეტის (UCLouvain) მიერ. შეარჩიეთ საზღვრები და ხის ვარჯის სიხშირე, შემდეგ დააჭირეთ ღილაკს ანალიზის ჩატარება შედეგების სანახავად.'
+              },
+              useGfwWidget: true,
+              widgetId: '31f78466-fc0b-42f9-a7ae-bea8559740d8',
+              params: [{
+                name: 'layer',
+                value: 'gfw-landcover-2000'
+              }],
+              uiParams: [{
+                inputType: 'rangeSlider',
+                startParamName: 'period',
+                combineParams: true,
+                valueSeparator: ',',
+                bounds: [2001, 2018],
+                valueType: 'date',
+                label: {
+                  en: 'Select range for analysis',
+                  fr: 'Sélectionner une plage pour l’analyse:',
+                  es: 'Seleccione un rango para el análisis:',
+                  pt: 'Selecione o período para análise:',
+                  id: 'Pilih rentang untuk analisis:',
+                  zh: '选择分析范围:',
+                  ka: 'საზღვრების შერჩევა ანალიზისთვის:'
+                }
+                },
+                {
+                  name: 'thresh',
+                  inputType: 'tcd',
+                  label: {
+                    en: 'Select tree cover density: ',
+                    fr: 'Sélectionner la densité de couverture arborée: ',
+                    es: 'Seleccione la densidad de la cobertura arbórea: ',
+                    pt: 'Selecione a densidade de cobertura arbórea: ',
+                    id: 'Pilih kerapatan tutupan pohon: ',
+                    zh: '选择森林覆盖密度: ',
+                    ka: 'ხის ვარჯის სიხშირის შერჩევა: '
+                  }
+                }
+              ]
             },
             {
-              "name": "thresh",
-              "inputType": "tcd",
-              "label": {
-                "en": "Select tree cover density: ",
-                "fr": "Sélectionner la densité de couverture arborée: ",
-                "es": "Seleccione la densidad de la cobertura arbórea: ",
-                "pt": "Selecione a densidade de cobertura arbórea: ",
-                "id": "Pilih kerapatan tutupan pohon: ",
-                "zh": "选择森林覆盖密度: ",
-                "ka": "ხის ვარჯის სიხშირის შერჩევა: "
-              }
-            }]
-          },
-          {
-            "analysisId": "BIO_LOSS",
-            "chartType": "bar",
-            "label": {
-              "en": "CO2 emissions from biomass loss",
-              "fr": "Émissions de Co2 de la perte de biomasse",
-              "es": "Emisiones de CO2 provenientes de la pérdida de biomasa",
-              "pt": "Emissões de CO₂ por perda de biomassa",
-              "id": "Emisi CO2 dari kehilangan biomassa",
-              "zh": "生物量损失导致的二氧化碳排放量",
-              "ka": "CO2 ემისია ბიომასის კარგვის გამო"
-            },
-            "title": {
-              "en": "Carbon Dioxide Emissions from Above Ground Live Woody Biomass Loss",
-              "fr": "Émissions de dioxyde de carbone de la perte de biomasse ligneuse vivante aérienne",
-              "es": "Emisiones de dióxido de carbono provenientes de la pérdida de biomasa leñosa viva en superficie",
-              "pt": "Emissões de dióxido de carbono por perda de biomassa de vegetação lenhosa viva acima do solo",
-              "id": "Emisi Karbon Dioksida dari kehilangan biomassa vegetasi berkayu di atas permukaan tanah",
-              "zh": "地上活木生物量损失导致的二氧化碳排放",
-              "ka": "ნახშირორჟანგის ემისია მიწისზედა ცოცხალი ბიომასის კარგვის გამო"
-            },
-            "description": {
-              "en": "Emissions do not include carbon emissions from other sources besides woody biomass (tree cover) loss. Select range and tree cover density then click the run analysis button to see results.",
-              "fr": "Les émissions n’incluent pas les émissions de carbone d’autres sources que la perte de biomasse (couverture arborée). Sélectionner la plage et la densité de couverture arborée, puis cliquer sur le bouton « Exécuter l’analyse » pour voir les résultats.",
-              "es": "Las emisiones no incluyen las emisiones de carbono de otras fuentes además de la pérdida de biomasa leñosa (cobertura arbórea). Para ver los resultados, seleccione el rango y la densidad de la cobertura arbórea, después haga clic en el botón ejecutar análisis.",
-              "pt": "As estimativas não incluem emissões de carbono geradas por fontes diferentes de perda (de cobertura arbórea) de biomassa de material lenhoso. Para ver os resultados, selecione o período e a densidade de cobertura arbórea; em seguida, clique no botão para executar a análise.",
-              "id": "Emisi tidak termasuk emisi karbon dari sumber lain selain kehilangan biomasa kayu (tutupan pohon). Pilih rentang dan kerapatan tutupan pohon kemudian klik tombol mulai analisis untuk melihat hasil.",
-              "zh": "排放量不包括除树木生物量（森林覆盖）损失之外的其他来源导致的碳排放量。选择范围和森林覆盖密度，然后点击“运行分析”按钮查看结果。总碳排放量 (吨 二氧化碳)",
-              "ka": "ემისიები არ შეიცავენ ნახშირის ემისიებს სხვა წყაროებიდან, გარდა ცოცხალი ბიომასის (ხის ვარჯი) კარგვის. შეარჩიეთ საზღვრები და ხის ვარჯის სიხშირე, შემდეგ დააჭირეთ ღილაკს ანალიზის ჩატარება შედეგების სანახავად."
-            },
-            "useGfwWidget": true,
-            "widgetId": "ac38fdbd-fdb1-4d8e-9109-674013fb51a2",
-            "uiParams": [{
-              "inputType": "rangeSlider",
-              "startParamName": "period",
-              "combineParams": true,
-              "valueSeparator": ",",
-              "bounds": [2001,
-              2018],
-              "valueType": "date",
-              "label": {
-                "en": "Select range for analysis",
-                "fr": "Sélectionner une plage pour l’analyse:",
-                "es": "Seleccione un rango para el análisis:",
-                "pt": "Selecione o período para análise:",
-                "id": "Pilih rentang untuk analisis:",
-                "zh": "选择分析范围:",
-                "ka": "საზღვრების შერჩევა ანალიზისთვის:"
-              }
+              analysisId: 'BIO_LOSS',
+              chartType: 'bar',
+              label: {
+                en: 'CO2 emissions from biomass loss',
+                fr: 'Émissions de Co2 de la perte de biomasse',
+                es: 'Emisiones de CO2 provenientes de la pérdida de biomasa',
+                pt: 'Emissões de CO₂ por perda de biomassa',
+                id: 'Emisi CO2 dari kehilangan biomassa',
+                zh: '生物量损失导致的二氧化碳排放量',
+                ka: 'CO2 ემისია ბიომასის კარგვის გამო'
+              },
+              title: {
+                en: 'Carbon Dioxide Emissions from Above Ground Live Woody Biomass Loss',
+                fr: 'Émissions de dioxyde de carbone de la perte de biomasse ligneuse vivante aérienne',
+                es: 'Emisiones de dióxido de carbono provenientes de la pérdida de biomasa leñosa viva en superficie',
+                pt: 'Emissões de dióxido de carbono por perda de biomassa de vegetação lenhosa viva acima do solo',
+                id: 'Emisi Karbon Dioksida dari kehilangan biomassa vegetasi berkayu di atas permukaan tanah',
+                zh: '地上活木生物量损失导致的二氧化碳排放',
+                ka: 'ნახშირორჟანგის ემისია მიწისზედა ცოცხალი ბიომასის კარგვის გამო'
+              },
+              description: {
+                en: 'Emissions do not include carbon emissions from other sources besides woody biomass (tree cover) loss. Select range and tree cover density then click the run analysis button to see results.',
+                fr: 'Les émissions n’incluent pas les émissions de carbone d’autres sources que la perte de biomasse (couverture arborée). Sélectionner la plage et la densité de couverture arborée, puis cliquer sur le bouton « Lancer l’analyse » pour voir les résultats.',
+                es: 'Las emisiones no incluyen las emisiones de carbono de otras fuentes además de la pérdida de biomasa leñosa (cobertura arbórea). Para ver los resultados, seleccione el rango y la densidad de la cobertura arbórea, después haga clic en el botón ejecutar análisis.',
+                pt: 'As estimativas não incluem emissões de carbono geradas por fontes diferentes de perda (de cobertura arbórea) de biomassa de material lenhoso. Para ver os resultados, selecione o período e a densidade de cobertura arbórea; em seguida, clique no botão para executar a análise.',
+                id: 'Emisi tidak termasuk emisi karbon dari sumber lain selain kehilangan biomasa kayu (tutupan pohon). Pilih rentang dan kerapatan tutupan pohon kemudian klik tombol mulai analisis untuk melihat hasil.',
+                zh: '排放量不包括除树木生物量（森林覆盖）损失之外的其他来源导致的碳排放量。选择范围和森林覆盖密度，然后点击“运行分析”按钮查看结果。总碳排放量 (吨 二氧化碳)',
+                ka: 'ემისიები არ შეიცავენ ნახშირის ემისიებს სხვა წყაროებიდან, გარდა ცოცხალი ბიომასის (ხის ვარჯი) კარგვის. შეარჩიეთ საზღვრები და ხის ვარჯის სიხშირე, შემდეგ დააჭირეთ ღილაკს ანალიზის ჩატარება შედეგების სანახავად.'
+              },
+              useGfwWidget: true,
+              widgetId: 'ac38fdbd-fdb1-4d8e-9109-674013fb51a2',
+              uiParams: [{
+                inputType: 'rangeSlider',
+                startParamName: 'period',
+                combineParams: true,
+                valueSeparator: ',',
+                bounds: [2001, 2018],
+                valueType: 'date',
+                label: {
+                  en: 'Select range for analysis',
+                  fr: 'Sélectionner une plage pour l’analyse:',
+                  es: 'Seleccione un rango para el análisis:',
+                  pt: 'Selecione o período para análise:',
+                  id: 'Pilih rentang untuk analisis:',
+                  zh: '选择分析范围:',
+                  ka: 'საზღვრების შერჩევა ანალიზისთვის:'
+                }
+                },
+                {
+                  name: 'thresh',
+                  inputType: 'tcd',
+                  label: {
+                    en: 'Select tree cover density: ',
+                    fr: 'Sélectionner la densité de couverture arborée: ',
+                    es: 'Seleccione la densidad de la cobertura arbórea: ',
+                    pt: 'Selecione a densidade de cobertura arbórea: ',
+                    id: 'Pilih kerapatan tutupan pohon: ',
+                    zh: '选择森林覆盖密度: ',
+                    ka: 'ხის ვარჯის სიხშირის შერჩევა: '
+                  }
+                }
+              ]
             },
             {
-              "name": "thresh",
-              "inputType": "tcd",
-              "label": {
-                "en": "Select tree cover density: ",
-                "fr": "Sélectionner la densité de couverture arborée: ",
-                "es": "Seleccione la densidad de la cobertura arbórea: ",
-                "pt": "Selecione a densidade de cobertura arbórea: ",
-                "id": "Pilih kerapatan tutupan pohon: ",
-                "zh": "选择森林覆盖密度: ",
-                "ka": "ხის ვარჯის სიხშირის შერჩევა: "
-              }
-            }]
-          },
-          {
-            "analysisId": "GLAD_ALERTS",
-            "chartType": "line",
-            "label": {
-              "en": "GLAD alerts per month",
-              "fr": "Alertes GLAD par mois",
-              "es": "Alertas GLAD por mes",
-              "pt": "Alertas GLAD por mês",
-              "id": "Peringatan GLAD per bulan",
-              "zh": "每月 GLAD 预警",
-              "ka": "GLAD შეტყობინებები"
-            },
-            "title": {
-              "en": "GLAD alerts per month",
-              "fr": "Alertes GLAD par mois",
-              "es": "Alertas GLAD por mes",
-              "pt": "Alertas GLAD por mês",
-              "id": "Peringatan GLAD per bulan",
-              "zh": "每月 GLAD 预警",
-              "ka": "GLAD შეტყობინებები"
-            },
-            "description": {
-              "en": "Count the number of GLAD tree cover loss alerts per month over the past two years and compare to the historical average.",
-              "fr": "Compte le nombre d’alertes GLAD de perte de la couverture arborée par mois sur les deux dernières années et le compare à la moyenne historique.",
-              "es": "Cuente el número de alertas GLAD sobre pérdida de cobertura arbórea por mes en los últimos dos años y compárela con el promedio histórico.",
-              "pt": "Apresentação da quantidade de alertas GLAD de perda de cobertura arbórea por mês nos últimos dois anos e comparação com a média histórica.",
-              "id": "Hitung jumlah peringatan kehilangan tutupan pohon GLAD per bulan selama dua tahun terakhir dan bandingkan dengan rata-rata historis.",
-              "zh": "统计过去两年内每月 GLAD 森林覆盖减少预警次数，并与历史平均值比较。",
-              "ka": "Count the number of GLAD tree cover loss alerts per month over the past two years and compare to the historical average."
-            },
-            "useGfwWidget": true,
-            "widgetId": "b5e43ea3-2812-484e-bc31-1bf5d2fe8aa0",
-            "uiParams": "none"
-          },
-          {
-            "analysisId": "TOTAL_GLAD_ALERTS",
-            "chartType": "badge",
-            "label": {
-              "en": "Total GLAD Alerts",
-              "fr": "Total des alertes GLAD",
-              "es": "Alertas GLAD totales",
-              "pt": "Total de alertas GLAD",
-              "id": "Total Peringatan GLAD",
-              "zh": "GLAD 预警总数",
-              "ka": "GLAD შეტყობინებები"
-            },
-            "title": {
-              "en": "Total GLAD Alerts",
-              "fr": "Total des alertes GLAD",
-              "es": "Alertas GLAD totales",
-              "pt": "Total de alertas GLAD",
-              "id": "Total Peringatan GLAD",
-              "zh": "GLAD 预警总数",
-              "ka": "Total GLAD Alerts"
-            },
-            "description": {
-              "en": "Count the number of GLAD alerts which occurred within the selected time range.",
-              "fr": "Compte le nombre d’alertes GLAD durant la période sélectionnée.",
-              "es": "Cuente el número de alertas GLAD que ocurrieron en el rango de tiempo seleccionado.",
-              "pt": "Quantifica o número de alertas GLAD ocorridos em um período selecionado.",
-              "id": "Hitung jumlah peringatan GLAD yang terjadi dalam rentang waktu yang dipilih.",
-              "zh": "统计在所选时间范围内出现的 GLAD 预警次数。",
-              "ka": "Count the number of GLAD tree cover loss alerts per month."
-            },
-            "useGfwWidget": true,
-            "widgetId": "16ff6282-8ceb-4055-938a-43726a62b205",
-            "uiParams": [{
-              "inputType": "datepicker",
-              "startParamName": "period",
-              "combineParams": true,
-              "valueSeparator": ",",
-              "multi": true,
-              "defaultStartDate": "2015-01-01",
-              "minDate": "2015-01-01",
-              "label": {
-                "en": "Select range for analysis",
-                "fr": "Sélectionner une plage pour l’analyse",
-                "es": "Seleccione un rango para el análisis",
-                "pt": "Selecione o período para análise",
-                "id": "Pilih rentang untuk analisis",
-                "zh": "选择分析范围",
-                "ka": "საზღვრების შერჩევა ანალიზისთვის"
-              }
-            }]
-          },
-          {
-            "analysisId": "VIIRS_FIRES",
-            "chartType": "badge",
-            "label": {
-              "en": "VIIRS Active Fires",
-              "fr": "Feux actifs VIIRS",
-              "es": "Incendios activos VIIRS",
-              "pt": "Incêndios ativos VIIRS",
-              "id": "Kebakaran Aktif VIIRS",
-              "zh": "VIIRS 活跃火点",
-              "ka": "VIIRS აქტიური ხანძრები"
-            },
-            "title": {
-              "en": "VIIRS Active Fires",
-              "fr": "Feux actifs VIIRS",
-              "es": "Incendios activos VIIRS",
-              "pt": "Incêndios ativos VIIRS",
-              "id": "Kebakaran Aktif VIIRS",
-              "zh": "VIIRS 活跃火点",
-              "ka": "VIIRS აქტიური ხანძრები"
-            },
-            "description": {
-              "en": "This analysis counts the number of VIIRS fire alert detections during the past 7 days",
-              "fr": "Cette analyse compte le nombre d’alertes de détection d’incendies VIIRS durant les 7 derniers jours",
-              "es": "Este análisis cuenta el número de detecciones de alertas de incendios VIIRS durante los últimos siete días",
-              "pt": "Esta análise apresenta a quantidade de detecções de alertas de incêndio VIIRS nos últimos 7 dias",
-              "id": "Analisis ini menghitung jumlah deteksi peringatan kebakaran VIIRS selama 7 hari terakhir",
-              "zh": "此分析可统计过去 7 天 VIIRS 火警监测的次数。",
-              "ka": "ეს ანალიზი თვლის VIIRS ხანძრის შეტყობინებების გამოვლენის რაოდენობას ბოლო 7 დღის განმავლობაში."
-            },
-            "useGfwWidget": true,
-            "widgetId": "5d696f96-e6c7-4323-8bda-4c99cd6b0cb4",
-            "uiParams": "none"
-          },
-          {
-            "analysisId": "LCC",
-            "chartType": "pie",
-            "label": {
-              "en": "Land Cover Composition",
-              "fr": "Composition de la couverture terrestre",
-              "es": "Cobertura terrestre",
-              "pt": "Cobertura do Solo",
-              "id": "Komposisi tutupan lahan",
-              "zh": "土地覆盖构成",
-              "ka": "მიწის საფარის შემადგენლობა"
-            },
-            "title": {
-              "en": "Land Cover Composition",
-              "fr": "Composition de la couverture terrestre",
-              "es": "Composición de la cobertura de tierra",
-              "pt": "Composição da cobertura de terra",
-              "id": "Komposisi tutupan lahan",
-              "zh": "土地覆盖构成",
-              "ka": "მიწის საფარის შემადგენლობა"
-            },
-            "description": {
-              "en": "Land cover data is from 2015 and provided by the European Space Agency (ESA) and UCLouvain.",
-              "fr": "Les données de la couverture terrestre datent de 2015 et sont fournies par l’Agence Spatiale Européenne (European Space Agency, ESA) et UCLouvain.",
-              "es": "Los datos de la cobertura de tierra son de 2015 y fueron proporcionados por la Agencia Espacial Europea (European Space Agency, ESA) y UCLouvain. ",
-              "pt": "Dados de cobertura de terra relativos ao período posterior a 2015 e fornecidos pela Agência Espacial Europeia (ESA) e pela UCLouvain. ",
-              "id": "Data tutupan lahan dari tahun 2015 yang disediakan oleh Badan Antariksa Eropa () dan UCLouvain.",
-              "zh": "自 2015 年以来的土地覆盖数据，由欧洲空间局 (ESA) 和 UCLouvain 提供。 ",
-              "ka": "მიწის საფარის მონაცემები 2015 წლის შემდეგაა და მოწოდებულია ევროპული კოსმოსური სააგენტოს (ESA) და ლუვენის კათოლიკური უნივერსიტეტის (UCLouvain) მიერ."
-            },
-            "useGfwWidget": true,
-            "widgetId": "1b84364d-0efd-4d60-81ef-870f7d13ee7b",
-            "uiParams": "none",
-            "params": [{
-              "name": "layer",
-              "value": "gfw-landcover-2015"
-            }]
-          }],
-          "layerPanel": {
-            "GROUP_WEBMAP": {
-              "order": 2,
-              "label": {
-
+              analysisId: 'GLAD_ALERTS',
+              chartType: 'line',
+              label: {
+                en: 'GLAD alerts per month',
+                fr: 'Alertes GLAD par mois',
+                es: 'Alertas GLAD por mes',
+                pt: 'Alertas GLAD por mês',
+                id: 'Peringatan GLAD per bulan',
+                zh: '每月 GLAD 预警',
+                ka: 'GLAD შეტყობინებები'
               },
-              "layers": []
+              title: {
+                en: 'GLAD alerts per month',
+                fr: 'Alertes GLAD par mois',
+                es: 'Alertas GLAD por mes',
+                pt: 'Alertas GLAD por mês',
+                id: 'Peringatan GLAD per bulan',
+                zh: '每月 GLAD 预警',
+                ka: 'GLAD შეტყობინებები'
+              },
+              description: {
+                en: 'Count the number of GLAD tree cover loss alerts per month.',
+                fr: 'Compte le nombre d’alertes GLAD de perte de la couverture arborée par mois.',
+                es: 'Cuente el número de alertas GLAD sobre pérdida de cobertura arbórea por mes.',
+                pt: 'Quantificação de alertas GLAD de perda de cobertura arbórea por mês.',
+                id: 'Hitung jumlah peringatan kehilangan tutupan pohon GLAD per bulan.',
+                zh: 'Count the number of GLAD tree cover loss alerts per month.',
+                ka: 'Count the number of GLAD tree cover loss alerts per month.'
+              },
+              useGfwWidget: true,
+              widgetId: '0734ba0a-3a6c-4388-aa4a-5871791b1d1f',
+              uiParams: 'none'
             },
-            "GROUP_LCD": {
-              "grouptype": "default",
-              "order": 1,
-              "label": {
-                "en": "Land Cover Dynamics",
-                "fr": "Evolution de la couverture des sols",
-                "es": "Dinámica de la Cobertura del Suelo",
-                "pt": "Dinâmica de cobertura da terra",
-                "id": "Land Cover Dynamics",
-                "zh": "土地覆盖动态数据",
-                "ka": "მიწის საფარის დინამიკა"
+            {
+              analysisId: 'TOTAL_GLAD_ALERTS',
+              chartType: 'badge',
+              label: {
+                en: 'Total GLAD Alerts',
+                fr: 'Total des alertes GLAD',
+                es: 'Alertas GLAD totales',
+                pt: 'Total de alertas GLAD',
+                id: 'Total Peringatan GLAD',
+                zh: 'GLAD 预警总数',
+                ka: 'GLAD შეტყობინებები'
               },
-              "layers": [{
-                "order": 1,
-                "id": "TREE_COVER_LOSS",
-                "type": "remoteDataLayer",
-                "uuid": "2aed67b3-3643-40d3-9c1e-8af9afb5d9e2"
+              title: {
+                en: 'Total GLAD Alerts',
+                fr: 'Total des alertes GLAD',
+                es: 'Alertas GLAD totales',
+                pt: 'Total de alertas GLAD',
+                id: 'Total Peringatan GLAD',
+                zh: 'GLAD 预警总数',
+                ka: 'Total GLAD Alerts'
               },
-              {
-                "order": 2,
-                "type": "remoteDataLayer",
-                "id": "TREE_COVER_GAIN",
-                "uuid": "cb016f17-f12d-463a-9dc2-aabcf5db566c"
+              description: {
+                en: 'Count the number of GLAD alerts which occurred within the selected time range.',
+                fr: 'Compte le nombre d’alertes GLAD durant la période sélectionnée.',
+                es: 'Cuente el número de alertas GLAD que ocurrieron en el rango de tiempo seleccionado.',
+                pt: 'Quantifica o número de alertas GLAD ocorridos em um período selecionado.',
+                id: 'Hitung jumlah peringatan GLAD yang terjadi dalam rentang waktu yang dipilih.',
+                zh: '统计在所选时间范围内出现的 GLAD 预警次数。',
+                ka: 'Count the number of GLAD tree cover loss alerts per month.'
               },
-              {
-                "order": 3,
-                "type": "remoteDataLayer",
-                "id": "IMAZON_SAD",
-                "uuid": "3e9e86ae-e38d-4c59-8484-c8214ca5186a"
-              },
-              {
-                "order": 4,
-                "id": "GLAD_ALERTS",
-                "type": "remoteDataLayer",
-                "uuid": "356f862b-3e70-493a-997b-dc2a193410e9"
-              },
-              {
-                "order": 5,
-                "id": "FORMA_ALERTS",
-                "type": "remoteDataLayer",
-                "uuid": "56aa7e57-0ac4-446c-a82d-7713904b17c3"
-              },
-              {
-                "order": 6,
-                "id": "TERRA_I_ALERTS",
-                "type": "remoteDataLayer",
-                "uuid": "1fc7b0c5-259a-4685-8665-b2f1ed3f808f"
-              },
-              {
-                "order": 7,
-                "id": "VIIRS_ACTIVE_FIRES",
-                "type": "remoteDataLayer",
-                "uuid": "15cb32c9-874f-4552-afdc-8a35ef70682f"
-              },
-              {
-                "order": 8,
-                "id": "MODIS_ACTIVE_FIRES",
-                "type": "remoteDataLayer",
-                "uuid": "8ae39d34-a5e5-4742-b06e-6e913a8f1eb8"
+              useGfwWidget: true,
+              widgetId: '16ff6282-8ceb-4055-938a-43726a62b205',
+              uiParams: [{
+                inputType: 'datepicker',
+                startParamName: 'period',
+                combineParams: true,
+                valueSeparator: ',',
+                multi: true,
+                defaultStartDate: '2018-01-01',
+                minDate: '2015-01-01',
+                label: {
+                  en: 'Select range for analysis',
+                  fr: 'Sélectionner une plage pour l’analyse',
+                  es: 'Seleccione un rango para el análisis',
+                  pt: 'Selecione o período para análise',
+                  id: 'Pilih rentang untuk analisis',
+                  zh: '选择分析范围',
+                  ka: 'საზღვრების შერჩევა ანალიზისთვის'
+                }
               }]
             },
-            "GROUP_LC": {
-              "groupttype": "default",
-              "order": 3,
-              "label": {
-                "en": "Land Cover",
-                "fr": "Couverture des sols",
-                "es": "Cobertura terrestre",
-                "pt": "Cobertura do Solo",
-                "id": "Land Cover",
-                "zh": "土地覆盖",
-                "ka": "მიწის საფარი"
+            {
+              analysisId: 'VIIRS_FIRES',
+              chartType: 'badge',
+              label: {
+                en: 'VIIRS Active Fires',
+                fr: 'Feux actifs VIIRS',
+                es: 'Incendios activos VIIRS',
+                pt: 'Incêndios ativos VIIRS',
+                id: 'Kebakaran Aktif VIIRS',
+                zh: 'VIIRS 活跃火点',
+                ka: 'VIIRS აქტიური ხანძრები'
               },
-              "layers": [{
-                "order": 1,
-                "id": "GLOB_MANGROVE",
-                "type": "remoteDataLayer",
-                "uuid": "533cbe18-22a6-46ac-99ca-027c96f33ac3"
+              title: {
+                en: 'VIIRS Active Fires',
+                fr: 'Feux actifs VIIRS',
+                es: 'Incendios activos VIIRS',
+                pt: 'Incêndios ativos VIIRS',
+                id: 'Kebakaran Aktif VIIRS',
+                zh: 'VIIRS 活跃火点',
+                ka: 'VIIRS აქტიური ხანძრები'
               },
-              {
-                "order": 2,
-                "id": "IFL",
-                "type": "remoteDataLayer",
-                "uuid": "5f815a7d-457e-4eae-a8e5-8864a60696ad"
+              description: {
+                en: 'This analysis counts the number of VIIRS fire alert detections during the past 7 days',
+                fr: 'Cette analyse compte le nombre d’alertes de détection d’incendies VIIRS durant les 7 derniers jours',
+                es: 'Este análisis cuenta el número de detecciones de alertas de incendios VIIRS durante los últimos siete días',
+                pt: 'Incêndios ativos VIIRS',
+                id: 'Analisis ini menghitung jumlah deteksi peringatan kebakaran VIIRS selama 7 hari terakhir',
+                zh: '此分析可统计过去 7 天 VIIRS 火警监测的次数。',
+                ka: 'ეს ანალიზი თვლის VIIRS ხანძრის შეტყობინებების გამოვლენის რაოდენობას ბოლო 7 დღის განმავლობაში.'
               },
-              {
-                "order": 3,
-                "id": "PRIMARY_FORESTS",
-                "type": "remoteDataLayer",
-                "uuid": "edffb745-e523-462d-ad1e-3052006a3dbc"
+              useGfwWidget: true,
+              widgetId: '5d696f96-e6c7-4323-8bda-4c99cd6b0cb4',
+              uiParams: 'none'
+            },
+            {
+              analysisId: 'LCC',
+              chartType: 'pie',
+              label: {
+                en: 'Land Cover Composition',
+                fr: 'Composition de la couverture terrestre',
+                es: 'Cobertura terrestre',
+                pt: 'Cobertura do Solo',
+                id: 'Komposisi tutupan lahan',
+                zh: '土地覆盖构成',
+                ka: 'მიწის საფარის შემადგენლობა'
               },
-              {
-                "order": 4,
-                "id": "AG_BIOMASS",
-                "type": "remoteDataLayer",
-                "uuid": "04526d47-f3f5-4f76-a939-e5f7861fd085"
+              title: {
+                en: 'Land Cover Composition',
+                fr: 'Composition de la couverture terrestre',
+                es: 'Composición de la cobertura de tierra',
+                pt: 'Composição da cobertura de terra',
+                id: 'Komposisi tutupan lahan',
+                zh: '土地覆盖构成',
+                ka: 'მიწის საფარის შემადგენლობა'
               },
-              {
-                "order": 5,
-                "id": "LAND_COVER",
-                "type": "remoteDataLayer",
-                "uuid": "b8d3f175-0565-443f-839a-49eb890a4b3d"
+              description: {
+                en: 'Land cover data is from 2015 and provided by the European Space Agency (ESA) and UCLouvain.',
+                fr: 'Les données de la couverture terrestre datent de 2015 et sont fournies par l’Agence Spatiale Européenne (European Space Agency, ESA) et UCLouvain.',
+                es: 'Los datos de la cobertura de tierra son de 2015 y fueron proporcionados por la Agencia Espacial Europea (European Space Agency, ESA) y UCLouvain. ',
+                pt: 'Dados de cobertura de terra relativos ao período posterior a 2015 e fornecidos pela Agência Espacial Europeia (ESA) e pela UCLouvain. ',
+                id: 'Data tutupan lahan dari tahun 2015 yang disediakan oleh Badan Antariksa Eropa () dan UCLouvain.',
+                zh: '自 2015 年以来的土地覆盖数据，由欧洲空间局 (ESA) 和 UCLouvain 提供。 ',
+                ka: 'მიწის საფარის მონაცემები 2015 წლის შემდეგაა და მოწოდებულია ევროპული კოსმოსური სააგენტოს (ESA)  და ლუვენის კათოლიკური უნივერსიტეტის (UCLouvain) მიერ.'
               },
-              {
-                "order": 6,
-                "id": "TREE_COVER",
-                "type": "remoteDataLayer",
-                "uuid": "2569adca-ef87-42c4-a153-57c5e8ba0ef7"
+              useGfwWidget: true,
+              widgetId: '1b84364d-0efd-4d60-81ef-870f7d13ee7b',
+              uiParams: 'none',
+              params: [{
+                name: 'layer',
+                value: 'gfw-landcover-2015'
               }]
             },
           ],
+
           /**
           * Layer panel configuration, anything with an = is optional, {object=}
           * Order at the group level controls the order of the accordions, the top most accordion's layers
@@ -745,103 +628,188 @@ html
                 zh: '土地覆盖动态数据',
                 ka: 'მიწის საფარის დინამიკა'
               },
-              "layers": [{
-                "order": 1,
-                "id": "RECENT_IMAGERY",
-                "type": "imagery",
-                "technicalName": "recent_satellite_imagery",
-                "visible": false,
-                "label": {
-                  "en": "Recent Imagery",
-                  "fr": "Imagerie récente",
-                  "es": "Imágenes recientes",
-                  "pt": "Imagens recentes",
-                  "id": "Citra Satelit Terbaru",
-                  "zh": "云层覆盖",
-                  "ka": "ბოლო გამოსახულება"
+              layers: [{
+                id: 'TREE_COVER_LOSS',
+                order: 1,
+                type: 'remoteDataLayer',
+                uuid: '2aed67b3-3643-40d3-9c1e-8af9afb5d9e2'
+                }, {
+                  id: 'TREE_COVER_GAIN',
+                  order: 2,
+                  type: 'remoteDataLayer',
+                  uuid: 'cb016f17-f12d-463a-9dc2-aabcf5db566c'
+                }, {
+                  id: 'IMAZON_SAD',
+                  order: 3,
+                  type: 'remoteDataLayer',
+                  uuid: '3e9e86ae-e38d-4c59-8484-c8214ca5186a'
                 },
-                "dynamicSublabel": {
-                  "en": "({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})",
-                  "fr": "({DATE_TIME}, {CLOUD_COVERAGE}% Imagerie récente, {INSTRUMENT})",
-                  "es": "({DATE_TIME}, {CLOUD_COVERAGE}% Cobertura de nubes, {INSTRUMENT})",
-                  "pt": "({DATE_TIME}, {CLOUD_COVERAGE}% Cobertura de nuvens, {INSTRUMENT})",
-                  "id": "({DATE_TIME}, {CLOUD_COVERAGE}% Tutupan Awan, {INSTRUMENT})",
-                  "zh": "({DATE_TIME}, {CLOUD_COVERAGE}% 近期图像, {INSTRUMENT})",
-                  "ka": "({DATE_TIME}, {CLOUD_COVERAGE}% ღრუბლიანობა, {INSTRUMENT})"
+                {
+                  id: 'FORMA_ALERTS',
+                  order: 4,
+                  type: 'remoteDataLayer',
+                  uuid: '56aa7e57-0ac4-446c-a82d-7713904b17c3'
+                },
+                {
+                  id: 'GLAD_ALERTS',
+                  order: 5,
+                  type: 'remoteDataLayer',
+                  uuid: '356f862b-3e70-493a-997b-dc2a193410e9'
+                }, {
+                  id: 'TERRA_I_ALERTS',
+                  order: 6,
+                  type: 'remoteDataLayer',
+                  uuid: '1fc7b0c5-259a-4685-8665-b2f1ed3f808f'
+                }, {
+                  id: 'VIIRS_ACTIVE_FIRES',
+                  order: 7,
+                  type: 'remoteDataLayer',
+                  uuid: '15cb32c9-874f-4552-afdc-8a35ef70682f'
+                }, {
+                  id: 'MODIS_ACTIVE_FIRES',
+                  order: 8,
+                  type: 'remoteDataLayer',
+                  uuid: '8ae39d34-a5e5-4742-b06e-6e913a8f1eb8'
+                }
+              ]
+            },
+            GROUP_LC: {
+              groupType: 'default',
+              order: 3,
+              label: {
+                en: 'Land Cover',
+                fr: 'Couverture des sols',
+                es: 'Cobertura terrestre',
+                pt: 'Cobertura do Solo',
+                id: 'Land Cover',
+                zh: '土地覆盖',
+                ka: 'მიწის საფარი'
+              },
+              layers: [{
+                id: 'GLOB_MANGROVE',
+                order: 1,
+                type: 'remoteDataLayer',
+                uuid: '533cbe18-22a6-46ac-99ca-027c96f33ac3'
+              }, {
+                id: 'IFL',
+                order: 2,
+                type: 'remoteDataLayer',
+                uuid: '5f815a7d-457e-4eae-a8e5-8864a60696ad'
+              }, {
+                id: 'PRIMARY_FORESTS',
+                order: 3,
+                type: 'remoteDataLayer',
+                uuid: 'edffb745-e523-462d-ad1e-3052006a3dbc'
+              }, {
+                id: 'AG_BIOMASS',
+                order: 4,
+                type: 'remoteDataLayer',
+                uuid: '04526d47-f3f5-4f76-a939-e5f7861fd085'
+              }, {
+                id: 'LAND_COVER',
+                order: 5,
+                type: 'remoteDataLayer',
+                uuid: 'b8d3f175-0565-443f-839a-49eb890a4b3d'
+              }, {
+                id: 'TREE_COVER',
+                order: 6,
+                type: 'remoteDataLayer',
+                uuid: '2569adca-ef87-42c4-a153-57c5e8ba0ef7'
+              }]
+            },
+            GROUP_IMAGERY: {
+              groupType: 'imagery',
+              order: 4,
+              label: {
+                en: 'Recent Imagery',
+                fr: 'Recent Imagery',
+                es: 'Recent Imagery',
+                pt: 'Recent Imagery',
+                id: 'Recent Imagery',
+                zh: 'Recent Imagery',
+                ka: 'Recent Imagery'
+              },
+              layers: [{
+                order: 1,
+                id: 'RECENT_IMAGERY',
+                type: 'imagery',
+                technicalName: 'recent_satellite_imagery',
+                visible: false,
+                label: {
+                  en: 'Recent Imagery',
+                  fr: 'Recent Imagery',
+                  es: 'Recent Imagery',
+                  pt: 'Recent Imagery',
+                  id: 'Recent Imagery',
+                  zh: 'Recent Imagery',
+                  ka: 'Recent Imagery'
+                },
+                dynamicSublabel: {
+                  en: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+                  fr: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+                  es: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+                  pt: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+                  id: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+                  zh: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})',
+                  ka: '({DATE_TIME}, {CLOUD_COVERAGE}% cloud coverage, {INSTRUMENT})'
                 }
               }]
             },
-            "GROUP_BASEMAP": {
-              "groupType": "basemap",
-              "order": 6,
-              "label": {
-                "en": "Basemap",
-                "fr": "Basemap",
-                "es": "Basemap",
-                "pt": "Basemap",
-                "id": "Basemap",
-                "zh": "Basemap",
-                "ka": "საბაზო რუკა"
+            GROUP_BASEMAP: {
+              groupType: 'basemap',
+              order: 200,
+              label: {
+                en: 'Basemap',
+                fr: 'Basemap',
+                es: 'Basemap',
+                pt: 'Basemap',
+                id: 'Basemap',
+                zh: 'Basemap',
+                ka: 'საბაზო რუკა'
               },
-              "layers": [{
-                "id": "landsat",
-                "thumbnailUrl": "https://my.gfw-mapbuilder.org/img/basemaps-sdd18a411a3-5bf18f445e58b8766f773184b7741c67.png",
-                "templateUrl": "https://d2h71bpqsyf4vw.cloudfront.net/2016/${level}/${col}/${row}.png",
-                "years": ["2000",
-                "2001",
-                "2002",
-                "2003",
-                "2004",
-                "2005",
-                "2006",
-                "2007",
-                "2008",
-                "2009",
-                "2010",
-                "2011",
-                "2012",
-                "2013",
-                "2014",
-                "2015",
-                "2016",
-                "2017"],
-                "title": {
-                  "en": "Landsat",
-                  "fr": "Landsat",
-                  "es": "Landsat",
-                  "pt": "Landsat",
-                  "id": "Landsat",
-                  "zh": "Landsat",
-                  "ka": "Landsat"
+              layers: [{
+                id: 'landsat',
+                thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/basemaps-sdd18a411a3-5bf18f445e58b8766f773184b7741c67.png',
+                templateUrl: 'https://d2h71bpqsyf4vw.cloudfront.net/2016/${level}/${col}/${row}.png',
+                years: ['2000', '2001', '2002', '2003', '2004', '2005', '2006', '2007', '2008', '2009', '2010', '2011', '2012', '2013', '2014', '2015', '2016'],
+                title: {
+                  en: 'Landsat',
+                  fr: 'Landsat',
+                  es: 'Landsat',
+                  pt: 'Landsat',
+                  id: 'Landsat',
+                  zh: 'Landsat',
+                  ka: 'Landsat'
                 }
-              },
-              {
-                "id": "wri_mono",
-                "thumbnailUrl": "https://my.gfw-mapbuilder.org/img/wri_mono.png",
-                "title": {
-                  "en": "WRI Mono",
-                  "fr": "WRI Mono",
-                  "es": "WRI Mono",
-                  "pt": "WRI Mono",
-                  "id": "WRI Mono",
-                  "zh": "WRI Mono",
-                  "ka": "WRI Mono"
+              }, {
+                id: 'wri_mono',
+                thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/wri_mono.png',
+                // thumbnailUrl: './css/images/wri_mono.png',
+                title: {
+                  en: 'WRI Mono',
+                  fr: 'WRI Mono',
+                  es: 'WRI Mono',
+                  pt: 'WRI Mono',
+                  id: 'WRI Mono',
+                  zh: 'WRI Mono',
+                  ka: 'WRI Mono'
                 }
-              },
-              {
-                "id": "wri_contextual",
-                "thumbnailUrl": "https://my.gfw-mapbuilder.org/img/wri_contextual.png",
-                "title": {
-                  "en": "WRI Contextual",
-                  "fr": "WRI Contextual",
-                  "es": "WRI Contextual",
-                  "pt": "WRI Contextual",
-                  "id": "WRI Contextual",
-                  "zh": "WRI Contextual",
-                  "ka": "WRI Contextual"
+              }, {
+                id: 'wri_contextual',
+                thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/wri_contextual.png',
+                // thumbnailUrl: './css/images/wri_contextual.png',
+                title: {
+                  en: 'WRI Contextual',
+                  fr: 'WRI Contextual',
+                  es: 'WRI Contextual',
+                  pt: 'WRI Contextual',
+                  id: 'WRI Contextual',
+                  zh: 'WRI Contextual',
+                  ka: 'WRI Contextual'
                 }
               }]
             },
+
             /**
             * CUSTOM GROUPS
             * Add your custom groups below. The custom groups are similar to the groups defined above.

--- a/src/externalReport.pug
+++ b/src/externalReport.pug
@@ -5,7 +5,7 @@ html
   body
     div#report.report
     div#share-modal.share-modal.hidden
-    script(id='report-load' src='https://library.gfw-mapbuilder.org/reportLib.1.4.1.js')
+    script(id='report-load' src='http://alpha.blueraster.io/gfw-mapbuilder/custom-color-theme-refactor/reportLib.1.4.1.js')
     script.
       var customApp = new MapBuilderReport({
         config: {
@@ -31,6 +31,7 @@ html
           hideFooter: false,
           includeMyGFWLogin: true,
           navLinksInNewTab: false,
+          customColorTheme: '#17eae7',
           //- Language Settings
           language: 'en',
           useAlternativeLanguage: false,

--- a/src/externalReport.pug
+++ b/src/externalReport.pug
@@ -5,7 +5,7 @@ html
   body
     div#report.report
     div#share-modal.share-modal.hidden
-    script(id='report-load' src='http://alpha.blueraster.io/gfw-mapbuilder/460-custom-color-theme/reportLib.1.4.1.js')
+    script(id='report-load' src='http://alpha.blueraster.io/gfw-mapbuilder/custom-color-theme-refactor/reportLib.1.4.1.js')
     script.
       var customApp = new MapBuilderReport({
         config: {

--- a/src/js/components/AnalysisPanel/Analysis.js
+++ b/src/js/components/AnalysisPanel/Analysis.js
@@ -483,7 +483,7 @@ export default class Analysis extends Component {
       if (activeAnalysisItem.title) { activeItemTitle = activeAnalysisItem.title[language]; }
       if (activeAnalysisItem.description) { activeItemDescription = activeAnalysisItem.description[language]; }
     }
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     
     return (
       <div className='analysis-results'>
@@ -513,8 +513,8 @@ export default class Analysis extends Component {
           <div className='analysis-results__footer'>
             <div className='run-analysis-button-container'>
               <button
-                style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+                style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
                 className='run-analysis-button fa-button color pointer'
                 onClick={this.runAnalysis}
                 onMouseEnter={this.toggleHover}

--- a/src/js/components/AnalysisPanel/Analysis.js
+++ b/src/js/components/AnalysisPanel/Analysis.js
@@ -16,7 +16,7 @@ import AnalysisMultiDatePicker from './AnalysisFormElements/AnalysisMultiDatePic
 import DensityDisplay from 'components/LayerPanel/DensityDisplay';
 import analysisKeys from 'constants/AnalysisConstants';
 import {attributes} from 'constants/AppConstants';
-import {analysisConfig} from 'js/config';
+import {defaultColorTheme} from 'js/config';
 import mapActions from 'actions/MapActions';
 import layerActions from 'actions/LayerActions';
 import {formatters, getCustomAnalysis} from 'utils/analysisUtils';
@@ -513,8 +513,8 @@ export default class Analysis extends Component {
           <div className='analysis-results__footer'>
             <div className='run-analysis-button-container'>
               <button
-                style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+                style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
                 className='run-analysis-button fa-button color pointer'
                 onClick={this.runAnalysis}
                 onMouseEnter={this.toggleHover}

--- a/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisDatePicker.js
+++ b/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisDatePicker.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import moment from 'moment';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
+import {defaultColorTheme} from '../../../config';
 
 
 
@@ -98,7 +99,7 @@ const Button = ({ onClick, value, customColorTheme }) => {
   return (<div>
     <label className='analysis-datepicker-button-label'>Date: </label>
     <button
-    style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+    style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
     className='fa-button sml white pointer'
     onClick={onClick}
     >

--- a/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisDatePicker.js
+++ b/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisDatePicker.js
@@ -71,14 +71,14 @@ export default class AnalysisDatePicker extends Component {
   render() {
     const { label, minDate, maxDate } = this.props;
     const { dateSelected } = this.state;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     
     return (
       <div className='analysis-results__select-form-item-container'>
         <div className='select-form-item-label'>{label}</div>
         <div className="report-date-picker">
           <DatePicker
-            customInput={<Button customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+            customInput={<Button customColorTheme={customColorTheme} />}
             showMonthDropdown
             showYearDropdown
             dropdownMode="select"
@@ -94,11 +94,11 @@ export default class AnalysisDatePicker extends Component {
   }
 }
 
-const Button = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const Button = ({ onClick, value, customColorTheme }) => {
   return (<div>
     <label className='analysis-datepicker-button-label'>Date: </label>
     <button
-    style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+    style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
     className='fa-button sml white pointer'
     onClick={onClick}
     >

--- a/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisMultiDatePicker.js
+++ b/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisMultiDatePicker.js
@@ -83,20 +83,17 @@ export default class AnalysisMultiDatePicker extends Component {
     const { label, minDate, maxDate } = this.props;
     const { selectedStartDate, selectedEndDate } = this.state;
     let customColorTheme;
-    let defaultColorTheme;
     if (this.context.settings) {
       customColorTheme = this.context.settings.customColorTheme;
-      defaultColorTheme = this.context.settings.defaultColorTheme;
     } else {
       customColorTheme = resources.customColorTheme;
-      defaultColorTheme = resources.defaultColorTheme;
     }
     
     return (
       <div className='analysis-results__select-form-item-container'>
         <div className='select-form-item-label'>{label}</div>
         <DatePicker
-          customInput={<StartButton customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+          customInput={<StartButton customColorTheme={customColorTheme} />}
           showMonthDropdown
           showYearDropdown
           dropdownMode="select"
@@ -114,7 +111,7 @@ export default class AnalysisMultiDatePicker extends Component {
 
         />
         <DatePicker
-          customInput={<EndButton customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+          customInput={<EndButton customColorTheme={customColorTheme} />}
           showMonthDropdown
           showYearDropdown
           dropdownMode="select"
@@ -136,12 +133,12 @@ export default class AnalysisMultiDatePicker extends Component {
   }
 }
 
-const StartButton = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const StartButton = ({ onClick, value, customColorTheme }) => {
   return (
     <div>
       <label className='analysis-datepicker-button-label'>Start: </label>
       <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
       >
@@ -151,12 +148,12 @@ const StartButton = ({ onClick, value, customColorTheme, defaultColorTheme }) =>
   );
 };
 
-const EndButton = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const EndButton = ({ onClick, value, customColorTheme }) => {
   return (
     <div>
       <label className='analysis-datepicker-button-label'>End: </label>
       <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
       >

--- a/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisMultiDatePicker.js
+++ b/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisMultiDatePicker.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import moment from 'moment';
 import DatePicker from 'react-datepicker';
 import resources from '../../../../resources';
+import {defaultColorTheme} from '../../../config';
 
 export default class AnalysisMultiDatePicker extends Component {
   static contextTypes = {
@@ -138,7 +139,7 @@ const StartButton = ({ onClick, value, customColorTheme }) => {
     <div>
       <label className='analysis-datepicker-button-label'>Start: </label>
       <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
       >
@@ -153,7 +154,7 @@ const EndButton = ({ onClick, value, customColorTheme }) => {
     <div>
       <label className='analysis-datepicker-button-label'>End: </label>
       <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
       >

--- a/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisRangeSlider.js
+++ b/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisRangeSlider.js
@@ -104,13 +104,10 @@ export default class AnalysisRangeSlider extends Component {
     const { bounds, step } = this.props;
     const { rangeSliderValue, sliderMarks } = this.state;
     let customColorTheme;
-    let defaultColorTheme;
     if (this.context.settings) {
       customColorTheme = this.context.settings.customColorTheme;
-      defaultColorTheme = this.context.settings.defaultColorTheme;
     } else {
       customColorTheme = resources.customColorTheme;
-      defaultColorTheme = resources.defaultColorTheme;
     }
     
     return (
@@ -126,10 +123,10 @@ export default class AnalysisRangeSlider extends Component {
           step={step}
           marks={sliderMarks}
           dots={bounds[1] - bounds[0] <= 20}
-          trackStyle={[{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}]}
-          handleStyle={[{borderColor: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}]}
+          trackStyle={[{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}]}
+          handleStyle={[{borderColor: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}]}
           dotStyle={{border: '1px solid #e9e9e9'}}
-          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
         />
       </div>
     );

--- a/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisRangeSlider.js
+++ b/src/js/components/AnalysisPanel/AnalysisFormElements/AnalysisRangeSlider.js
@@ -4,6 +4,8 @@ import 'rc-slider/assets/index.css';
 import 'rc-tooltip/assets/bootstrap.css';
 import MapActions from 'actions/MapActions';
 import resources from '../../../../resources';
+import {defaultColorTheme} from '../../../config';
+
 const createSliderWithTooltip = Slider.createSliderWithTooltip;
 const Range = createSliderWithTooltip(Slider.Range);
 
@@ -123,10 +125,10 @@ export default class AnalysisRangeSlider extends Component {
           step={step}
           marks={sliderMarks}
           dots={bounds[1] - bounds[0] <= 20}
-          trackStyle={[{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}]}
-          handleStyle={[{borderColor: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}]}
+          trackStyle={[{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}]}
+          handleStyle={[{borderColor: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}]}
           dotStyle={{border: '1px solid #e9e9e9'}}
-          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
         />
       </div>
     );

--- a/src/js/components/AnalysisPanel/AnalysisTypeSelect.js
+++ b/src/js/components/AnalysisPanel/AnalysisTypeSelect.js
@@ -37,7 +37,7 @@ export default class AnalysisTypeSelect extends Component {
   render () {
     const { activeAnalysisType, analysisItems } = this.props;
     const { language } = this.context;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     return (
       <div className='analysis-results__container'>
         <div className='relative analysis-results__select-container'>
@@ -54,7 +54,7 @@ export default class AnalysisTypeSelect extends Component {
             </option>
             {analysisItems.map(this.createOptions)}
           </select>
-          <div style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='analysis-results__select-arrow' />
+          <div style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='analysis-results__select-arrow' />
         </div>
         {activeAnalysisType === 'default' &&
           <div className='analysis-results__none-selected'>

--- a/src/js/components/AnalysisPanel/AnalysisTypeSelect.js
+++ b/src/js/components/AnalysisPanel/AnalysisTypeSelect.js
@@ -3,6 +3,7 @@
 import mapActions from 'actions/MapActions';
 // import appUtils from 'utils/AppUtils';
 import text from 'js/languages';
+import {defaultColorTheme} from '../../config';
 import React, {
   Component,
   PropTypes
@@ -54,7 +55,7 @@ export default class AnalysisTypeSelect extends Component {
             </option>
             {analysisItems.map(this.createOptions)}
           </select>
-          <div style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='analysis-results__select-arrow' />
+          <div style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='analysis-results__select-arrow' />
         </div>
         {activeAnalysisType === 'default' &&
           <div className='analysis-results__none-selected'>

--- a/src/js/components/AnalysisPanel/CoordinatesTools.js
+++ b/src/js/components/AnalysisPanel/CoordinatesTools.js
@@ -4,6 +4,7 @@ import mapActions from 'actions/MapActions';
 import Draw from 'esri/toolbars/draw';
 import text from 'js/languages';
 import SVGIcon from 'utils/svgIcon';
+import {defaultColorTheme} from '../../config';
 
 import React, {
   Component,
@@ -96,8 +97,8 @@ export default class CoordinatesTools extends Component {
               {text[language].ANALYSIS_COORDINATES_INSTRUCTIONS.map(this.renderInstructionList)}
             </ol>
             <div
-              style={enterValuesButtonActive || buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-              {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+              style={enterValuesButtonActive || buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+              {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
               className="fa-button color analysis-instructions__enter-values-button"
               onClick={this.enterValues}
               onMouseEnter={this.toggleHover}
@@ -106,7 +107,7 @@ export default class CoordinatesTools extends Component {
               <span className="analysis-instructions__enter-values-icon"><SVGIcon id={'icon-enter-values'} /></span>
               <span className="analysis-instructions__enter-values">{text[language].ANALYSIS_COORDINATES_BUTTONS[0]}</span>
             </div>
-            <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='analysis-instructions__separator'>
+            <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='analysis-instructions__separator'>
               <span className='analysis-instructions__separator-text'>{text[language].ANALYSIS_OR}</span>
             </div>
           </div>

--- a/src/js/components/AnalysisPanel/CoordinatesTools.js
+++ b/src/js/components/AnalysisPanel/CoordinatesTools.js
@@ -84,7 +84,7 @@ export default class CoordinatesTools extends Component {
     
       render() {
         const {language} = this.context;
-        const { customColorTheme, defaultColorTheme } = this.context.settings;
+        const { customColorTheme } = this.context.settings;
         const {enterValuesButtonActive, buttonHover} = this.state;
         
         return (
@@ -96,8 +96,8 @@ export default class CoordinatesTools extends Component {
               {text[language].ANALYSIS_COORDINATES_INSTRUCTIONS.map(this.renderInstructionList)}
             </ol>
             <div
-              style={enterValuesButtonActive || buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-              {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+              style={enterValuesButtonActive || buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+              {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
               className="fa-button color analysis-instructions__enter-values-button"
               onClick={this.enterValues}
               onMouseEnter={this.toggleHover}
@@ -106,7 +106,7 @@ export default class CoordinatesTools extends Component {
               <span className="analysis-instructions__enter-values-icon"><SVGIcon id={'icon-enter-values'} /></span>
               <span className="analysis-instructions__enter-values">{text[language].ANALYSIS_COORDINATES_BUTTONS[0]}</span>
             </div>
-            <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='analysis-instructions__separator'>
+            <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='analysis-instructions__separator'>
               <span className='analysis-instructions__separator-text'>{text[language].ANALYSIS_OR}</span>
             </div>
           </div>

--- a/src/js/components/AnalysisPanel/CustomFeatureControl.js
+++ b/src/js/components/AnalysisPanel/CustomFeatureControl.js
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from 'react';
 import layerKeys from 'constants/LayerConstants';
 import mapActions from 'actions/MapActions';
 import text from 'js/languages';
+import {defaultColorTheme} from '../../config';
 
 const getFeatureName = (feature) => {
   return feature.attributes && feature.attributes.title || '';
@@ -63,8 +64,8 @@ export default class CustomFeatureControl extends Component {
         <input className='custom-feature__input' type='text' value={this.state.title} onChange={this.editName} />
         <div className='edit-delete-container'>
           <div
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='edit-save-button fa-button color pointer-custom'
             onClick={this.editPolygon}
             onMouseEnter={this.toggleHover}

--- a/src/js/components/AnalysisPanel/CustomFeatureControl.js
+++ b/src/js/components/AnalysisPanel/CustomFeatureControl.js
@@ -56,15 +56,15 @@ export default class CustomFeatureControl extends Component {
     const {language} = this.context;
     const {editingEnabled} = this.props;
     const {buttonHover} = this.state;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
 
     return (
       <div className='custom-feature__header'>
         <input className='custom-feature__input' type='text' value={this.state.title} onChange={this.editName} />
         <div className='edit-delete-container'>
           <div
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='edit-save-button fa-button color pointer-custom'
             onClick={this.editPolygon}
             onMouseEnter={this.toggleHover}

--- a/src/js/components/AnalysisPanel/DrawTools.js
+++ b/src/js/components/AnalysisPanel/DrawTools.js
@@ -4,6 +4,7 @@ import mapActions from 'actions/MapActions';
 import Draw from 'esri/toolbars/draw';
 import text from 'js/languages';
 import SVGIcon from 'utils/svgIcon';
+import {defaultColorTheme} from '../../config';
 
 import React, {
   Component,
@@ -130,8 +131,8 @@ export default class DrawTools extends Component {
           </svg>
         </div>
         <div
-          style={drawButtonActive || buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+          style={drawButtonActive || buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
           className={`fa-button color analysis-instructions__draw-button ${drawButtonActive ? 'active' : ''}`}
           onClick={this.draw}
           onMouseEnter={this.toggleHover}
@@ -140,7 +141,7 @@ export default class DrawTools extends Component {
           <span className="analysis-instructions__draw-upload-icon"><SVGIcon id={'icon-draw-upload-white'} /></span>
           <span className="analysis-instructions__draw-upload">{text[language].ANALYSIS_DRAW_BUTTON}</span>
         </div>
-        <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='analysis-instructions__separator'>
+        <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='analysis-instructions__separator'>
           <span className='analysis-instructions__separator-text'>{text[language].ANALYSIS_OR}</span>
         </div>
       </div>

--- a/src/js/components/AnalysisPanel/DrawTools.js
+++ b/src/js/components/AnalysisPanel/DrawTools.js
@@ -114,7 +114,7 @@ export default class DrawTools extends Component {
     const {embeddedInModal} = this.props;
     const {language} = this.context;
     const instructions = embeddedInModal ? text[language].ANALYSIS_DRAW_INSTRUCTIONS.slice(1) : text[language].ANALYSIS_DRAW_INSTRUCTIONS;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     const {drawButtonActive, buttonHover} = this.state;
     return (
       <div className='analysis-instructions__draw'>
@@ -130,8 +130,8 @@ export default class DrawTools extends Component {
           </svg>
         </div>
         <div
-          style={drawButtonActive || buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+          style={drawButtonActive || buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
           className={`fa-button color analysis-instructions__draw-button ${drawButtonActive ? 'active' : ''}`}
           onClick={this.draw}
           onMouseEnter={this.toggleHover}
@@ -140,7 +140,7 @@ export default class DrawTools extends Component {
           <span className="analysis-instructions__draw-upload-icon"><SVGIcon id={'icon-draw-upload-white'} /></span>
           <span className="analysis-instructions__draw-upload">{text[language].ANALYSIS_DRAW_BUTTON}</span>
         </div>
-        <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='analysis-instructions__separator'>
+        <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='analysis-instructions__separator'>
           <span className='analysis-instructions__separator-text'>{text[language].ANALYSIS_OR}</span>
         </div>
       </div>

--- a/src/js/components/AnalysisPanel/Instructions.js
+++ b/src/js/components/AnalysisPanel/Instructions.js
@@ -20,7 +20,7 @@ export default class Instructions extends Component {
 
   render () {
     const {language} = this.context;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     
     return (
       <div className='analysis-instructions'>
@@ -35,7 +35,7 @@ export default class Instructions extends Component {
             <SVGIcon id={'icon-analysis-poly'} />
           </svg>
         </div>
-        <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='analysis-instructions__separator'>
+        <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='analysis-instructions__separator'>
           <span className='analysis-instructions__separator-text'>{text[language].ANALYSIS_OR}</span>
         </div>
       </div>

--- a/src/js/components/AnalysisPanel/Instructions.js
+++ b/src/js/components/AnalysisPanel/Instructions.js
@@ -4,6 +4,7 @@ import React, {
   PropTypes
 } from 'react';
 import SVGIcon from 'utils/svgIcon';
+import {defaultColorTheme} from '../../config';
 
 export default class Instructions extends Component {
 
@@ -35,7 +36,7 @@ export default class Instructions extends Component {
             <SVGIcon id={'icon-analysis-poly'} />
           </svg>
         </div>
-        <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='analysis-instructions__separator'>
+        <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='analysis-instructions__separator'>
           <span className='analysis-instructions__separator-text'>{text[language].ANALYSIS_OR}</span>
         </div>
       </div>

--- a/src/js/components/AnalysisPanel/VegaChart.js
+++ b/src/js/components/AnalysisPanel/VegaChart.js
@@ -177,11 +177,11 @@ export default class VegaChart extends Component {
     const { results, component, reportLabel, module, params, language, analysisId, chartType, toggle, toggleChart} = this.props;
     
     let colorTheme;
-    const { customColorTheme, defaultColorTheme } = resources;
+    const { customColorTheme } = resources;
     if (!toggle && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (toggle && (!customColorTheme || customColorTheme === '')) {
-        colorTheme = defaultColorTheme;
+        colorTheme = '#F0AB00';
     } else {
         colorTheme = '#929292';
     }

--- a/src/js/components/AnalysisPanel/VegaChart.js
+++ b/src/js/components/AnalysisPanel/VegaChart.js
@@ -6,6 +6,7 @@ import ReportSettings from '../../report/ReportSettings';
 import Loader from '../Loader';
 import Measure from 'react-measure';
 import resources from '../../../resources';
+import {defaultColorTheme} from '../../config';
 
 export default class VegaChart extends Component {
   constructor(props) {
@@ -181,7 +182,7 @@ export default class VegaChart extends Component {
     if (!toggle && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (toggle && (!customColorTheme || customColorTheme === '')) {
-        colorTheme = '#F0AB00';
+        colorTheme = defaultColorTheme;
     } else {
         colorTheme = '#929292';
     }

--- a/src/js/components/LayerPanel/BasemapGroup.js
+++ b/src/js/components/LayerPanel/BasemapGroup.js
@@ -18,14 +18,14 @@ export default class BasemapGroup extends Component {
     const {activeTOCGroup, label} = this.props;
     const active = activeTOCGroup === layerKeys.GROUP_BASEMAP;
     const styles = { display: active ? 'block' : 'none' };
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
 
     return (
       <div className='layer-category'>
         <div className='layer-category-label-container pointer' onClick={this.toggle}>
           <div className='layer-category-label'>{label}</div>
           <span
-          style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme} !important`}}
+          style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'} !important`}}
           className='layer-category-caret'
           >
             {String.fromCharCode(active ? closeSymbolCode : openSymbolCode)}

--- a/src/js/components/LayerPanel/BasemapGroup.js
+++ b/src/js/components/LayerPanel/BasemapGroup.js
@@ -4,6 +4,7 @@ import React, {
   Component,
   PropTypes
 } from 'react';
+import {defaultColorTheme} from '../../config';
 
 const closeSymbolCode = 9660,
     openSymbolCode = 9650;
@@ -25,7 +26,7 @@ export default class BasemapGroup extends Component {
         <div className='layer-category-label-container pointer' onClick={this.toggle}>
           <div className='layer-category-label'>{label}</div>
           <span
-          style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'} !important`}}
+          style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme} !important`}}
           className='layer-category-caret'
           >
             {String.fromCharCode(active ? closeSymbolCode : openSymbolCode)}

--- a/src/js/components/LayerPanel/DensityDisplay.js
+++ b/src/js/components/LayerPanel/DensityDisplay.js
@@ -41,21 +41,18 @@ export default class DensityDisplay extends Component {
     const {buttonHover} = this.state;
     const hideDefaultLabel = label === '';
     let customColorTheme;
-    let defaultColorTheme;
     if (this.context.settings) {
       customColorTheme = this.context.settings.customColorTheme;
-      defaultColorTheme = this.context.settings.defaultColorTheme;
     } else {
       customColorTheme = resources.customColorTheme;
-      defaultColorTheme = resources.defaultColorTheme;
     }
 
     return (
       <div className='tree-cover-canopy-display'>
         <span className='canopy-label'>{label || hideDefaultLabel ? label : text[language].DENSITY_FIRST}</span>
         <div
-          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
           className='canopy-button pointer'
           onClick={showModal}
           onMouseEnter={this.toggleHover}

--- a/src/js/components/LayerPanel/DensityDisplay.js
+++ b/src/js/components/LayerPanel/DensityDisplay.js
@@ -5,6 +5,7 @@ import React, {
   Component,
   PropTypes
 } from 'react';
+import {defaultColorTheme} from '../../config';
 
 const showModal = function showModal () {
   mapActions.toggleCanopyModal({ visible: true });
@@ -51,8 +52,8 @@ export default class DensityDisplay extends Component {
       <div className='tree-cover-canopy-display'>
         <span className='canopy-label'>{label || hideDefaultLabel ? label : text[language].DENSITY_FIRST}</span>
         <div
-          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
           className='canopy-button pointer'
           onClick={showModal}
           onMouseEnter={this.toggleHover}

--- a/src/js/components/LayerPanel/FiresControls.js
+++ b/src/js/components/LayerPanel/FiresControls.js
@@ -4,6 +4,7 @@ import text from 'js/languages';
 import DatePicker from 'react-datepicker';
 import moment from 'moment';
 import 'react-datepicker/dist/react-datepicker.css';
+import {defaultColorTheme} from '../../config';
 
 export default class FiresControls extends React.Component {
 
@@ -92,13 +93,13 @@ export default class FiresControls extends React.Component {
               {this.renderActiveFireOptions(this.fireOptions)}
               </select>
               <div
-                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
                 className='fa-button sml white pointer'>{activeFireOptionLabel}
               </div>
             </div>
           </div>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className="fa-button sml white pointer"
             onClick={() => this.setState({
               customRange: !customRange,
@@ -152,7 +153,7 @@ export default class FiresControls extends React.Component {
 const StartButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >
@@ -164,7 +165,7 @@ const StartButton = ({ onClick, value, customColorTheme }) => {
 const EndButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >

--- a/src/js/components/LayerPanel/FiresControls.js
+++ b/src/js/components/LayerPanel/FiresControls.js
@@ -78,7 +78,7 @@ export default class FiresControls extends React.Component {
     const { startDate, endDate } = this.props;
     const {language} = this.context;
     const {customRange, activeFireOption, activeFireOptionLabel} = this.state;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     return (
       <div>
         <div className="active-fires-controls-container">
@@ -92,13 +92,13 @@ export default class FiresControls extends React.Component {
               {this.renderActiveFireOptions(this.fireOptions)}
               </select>
               <div
-                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
                 className='fa-button sml white pointer'>{activeFireOptionLabel}
               </div>
             </div>
           </div>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className="fa-button sml white pointer"
             onClick={() => this.setState({
               customRange: !customRange,
@@ -115,7 +115,7 @@ export default class FiresControls extends React.Component {
                 <div className='glad-controls__calendars--row'>
                   <label>{text[language].TIMELINE_START}</label>
                   <DatePicker
-                    customInput={<StartButton customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+                    customInput={<StartButton customColorTheme={customColorTheme} />}
                     showMonthDropdown
                     showYearDropdown
                     dropdownMode="select"
@@ -129,7 +129,7 @@ export default class FiresControls extends React.Component {
                 <div className='glad-controls__calendars--row'>
                   <label>{text[language].TIMELINE_END}</label>
                   <DatePicker
-                    customInput={<EndButton customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+                    customInput={<EndButton customColorTheme={customColorTheme} />}
                     showMonthDropdown
                     showYearDropdown
                     dropdownMode="select"
@@ -149,10 +149,10 @@ export default class FiresControls extends React.Component {
   }
 }
 
-const StartButton = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const StartButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >
@@ -161,10 +161,10 @@ const StartButton = ({ onClick, value, customColorTheme, defaultColorTheme }) =>
   );
 };
 
-const EndButton = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const EndButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >

--- a/src/js/components/LayerPanel/FormaControls.js
+++ b/src/js/components/LayerPanel/FormaControls.js
@@ -5,6 +5,7 @@ import text from 'js/languages';
 import DatePicker from 'react-datepicker';
 import moment from 'moment';
 import 'react-datepicker/dist/react-datepicker.css';
+import {defaultColorTheme} from '../../config';
 
 export default class FormaControls extends Component {
 
@@ -93,7 +94,7 @@ export default class FormaControls extends Component {
 const StartButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >
@@ -105,7 +106,7 @@ const StartButton = ({ onClick, value, customColorTheme }) => {
 const EndButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >

--- a/src/js/components/LayerPanel/FormaControls.js
+++ b/src/js/components/LayerPanel/FormaControls.js
@@ -51,7 +51,7 @@ export default class FormaControls extends Component {
   render () {
     const {startDate, endDate} = this.props;
     const {language} = this.context;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     
     return (
       <div className='glad-controls forma-controls'>
@@ -59,7 +59,7 @@ export default class FormaControls extends Component {
           <div className='glad-controls__calendars--row'>
             <label>{text[language].TIMELINE_START}</label>
             {startDate && <DatePicker
-              customInput={<StartButton customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+              customInput={<StartButton customColorTheme={customColorTheme} />}
               showMonthDropdown
               showYearDropdown
               dropdownMode="select"
@@ -73,7 +73,7 @@ export default class FormaControls extends Component {
           <div className='glad-controls__calendars--row'>
             <label>{text[language].TIMELINE_END}</label>
             {endDate && <DatePicker
-              customInput={<EndButton customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+              customInput={<EndButton customColorTheme={customColorTheme} />}
               showMonthDropdown
               showYearDropdown
               dropdownMode="select"
@@ -90,10 +90,10 @@ export default class FormaControls extends Component {
   }
 }
 
-const StartButton = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const StartButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >
@@ -102,10 +102,10 @@ const StartButton = ({ onClick, value, customColorTheme, defaultColorTheme }) =>
   );
 };
 
-const EndButton = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const EndButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >

--- a/src/js/components/LayerPanel/GladControls.js
+++ b/src/js/components/LayerPanel/GladControls.js
@@ -6,6 +6,7 @@ import text from 'js/languages';
 import DatePicker from 'react-datepicker';
 import moment from 'moment';
 import 'react-datepicker/dist/react-datepicker.css';
+import {defaultColorTheme} from '../../config';
 
 export default class GladControls extends Component {
 
@@ -107,7 +108,7 @@ export default class GladControls extends Component {
 const StartButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >
@@ -119,7 +120,7 @@ const StartButton = ({ onClick, value, customColorTheme }) => {
 const EndButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >

--- a/src/js/components/LayerPanel/GladControls.js
+++ b/src/js/components/LayerPanel/GladControls.js
@@ -64,7 +64,7 @@ export default class GladControls extends Component {
     const {startDate, endDate} = this.props;
     const {unconfirmed} = this.state;
     const {language} = this.context;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     
     return (
       <div className='glad-controls'>
@@ -73,7 +73,7 @@ export default class GladControls extends Component {
           <div className='glad-controls__calendars--row'>
             <label>{text[language].TIMELINE_START}</label>
             {startDate && <DatePicker
-              customInput={<StartButton customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+              customInput={<StartButton customColorTheme={customColorTheme} />}
               showMonthDropdown
               showYearDropdown
               dropdownMode="select"
@@ -87,7 +87,7 @@ export default class GladControls extends Component {
           <div className='glad-controls__calendars--row'>
             <label>{text[language].TIMELINE_END}</label>
             {endDate && <DatePicker
-              customInput={<EndButton customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+              customInput={<EndButton customColorTheme={customColorTheme} />}
               showMonthDropdown
               showYearDropdown
               dropdownMode="select"
@@ -104,10 +104,10 @@ export default class GladControls extends Component {
   }
 }
 
-const StartButton = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const StartButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >
@@ -116,10 +116,10 @@ const StartButton = ({ onClick, value, customColorTheme, defaultColorTheme }) =>
   );
 };
 
-const EndButton = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const EndButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >

--- a/src/js/components/LayerPanel/LandsatLayer.js
+++ b/src/js/components/LayerPanel/LandsatLayer.js
@@ -2,11 +2,12 @@ import LayerKeys from 'constants/LayerConstants';
 import basemapUtils from 'utils/basemapUtils';
 import mapActions from 'actions/MapActions';
 import utils from 'utils/AppUtils';
-
+import {defaultColorTheme} from '../../config';
 import React, {
   Component,
   PropTypes
 } from 'react';
+
 
 export default class LandsatLayer extends Component {
 
@@ -39,7 +40,7 @@ export default class LandsatLayer extends Component {
             {this.props.years.map(this.yearOption.bind(this))}
           </select>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='fa-button sml white'
           >
             {this.state.yearSelected}

--- a/src/js/components/LayerPanel/LandsatLayer.js
+++ b/src/js/components/LayerPanel/LandsatLayer.js
@@ -29,7 +29,7 @@ export default class LandsatLayer extends Component {
       backgroundImage: `url('${this.props.icon}')`,
       backgroundRepeat: 'no-repeat'
     };
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     return (
       <div className={classes}>
         <span style={imgStyles} className='layer-basemap-icon landsat' onClick={this.toggle}></span>
@@ -39,7 +39,7 @@ export default class LandsatLayer extends Component {
             {this.props.years.map(this.yearOption.bind(this))}
           </select>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='fa-button sml white'
           >
             {this.state.yearSelected}

--- a/src/js/components/LayerPanel/LayerCheckbox.js
+++ b/src/js/components/LayerPanel/LayerCheckbox.js
@@ -4,7 +4,7 @@ import layerKeys from 'constants/LayerConstants';
 import LayersHelper from 'helpers/LayersHelper';
 import LayerTransparency from './LayerTransparency';
 import SVGIcon from 'utils/svgIcon';
-
+import {defaultColorTheme} from '../../config';
 import React, {
   Component,
   PropTypes
@@ -136,7 +136,7 @@ export default class LayerCheckbox extends Component {
     if (checked === 'active' && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (checked === 'active' && (!customColorTheme || customColorTheme === '')) {
-        colorTheme = '#F0AB00';
+        colorTheme = defaultColorTheme;
     } else {
         colorTheme = '#929292';
     }
@@ -149,14 +149,14 @@ export default class LayerCheckbox extends Component {
         </span>
         {onEdit && this.props.checked &&
         <div
-          style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+          style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
           className='fa-button sml white layer-edit'
           onClick={onEdit}
         >
           <span className='layer-edit-text'>Edit</span>
         </div>}
 
-        <span style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className={`info-icon pointer ${this.props.iconLoading === this.props.layer.id ? 'iconLoading' : ''}`} onClick={this.showInfo.bind(this)}>
+        <span style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className={`info-icon pointer ${this.props.iconLoading === this.props.layer.id ? 'iconLoading' : ''}`} onClick={this.showInfo.bind(this)}>
           <SVGIcon id={'shape-info'} />
         </span>
         {!sublabel ? null : <div className='layer-checkbox-sublabel'>{sublabel[language]}</div>}

--- a/src/js/components/LayerPanel/LayerCheckbox.js
+++ b/src/js/components/LayerPanel/LayerCheckbox.js
@@ -132,11 +132,11 @@ export default class LayerCheckbox extends Component {
     const {sublabel} = layer;
     
     let colorTheme = '';
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     if (checked === 'active' && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (checked === 'active' && (!customColorTheme || customColorTheme === '')) {
-        colorTheme = defaultColorTheme;
+        colorTheme = '#F0AB00';
     } else {
         colorTheme = '#929292';
     }
@@ -149,14 +149,14 @@ export default class LayerCheckbox extends Component {
         </span>
         {onEdit && this.props.checked &&
         <div
-          style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+          style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
           className='fa-button sml white layer-edit'
           onClick={onEdit}
         >
           <span className='layer-edit-text'>Edit</span>
         </div>}
 
-        <span style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className={`info-icon pointer ${this.props.iconLoading === this.props.layer.id ? 'iconLoading' : ''}`} onClick={this.showInfo.bind(this)}>
+        <span style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className={`info-icon pointer ${this.props.iconLoading === this.props.layer.id ? 'iconLoading' : ''}`} onClick={this.showInfo.bind(this)}>
           <SVGIcon id={'shape-info'} />
         </span>
         {!sublabel ? null : <div className='layer-checkbox-sublabel'>{sublabel[language]}</div>}

--- a/src/js/components/LayerPanel/LayerFieldFilter.js
+++ b/src/js/components/LayerPanel/LayerFieldFilter.js
@@ -4,8 +4,9 @@ import Query from 'esri/tasks/query';
 import Select from 'react-select';
 import mapActions from 'actions/MapActions';
 import resources from '../../../resources';
+import {defaultColorTheme} from '../../config';
 
-const colorTheme = resources.customColorTheme ? resources.customColorTheme : '#F0AB00';
+const colorTheme = resources.customColorTheme ? resources.customColorTheme : defaultColorTheme;
 
 const customStyles = {
   option: (provided, state) => ({

--- a/src/js/components/LayerPanel/LayerFieldFilter.js
+++ b/src/js/components/LayerPanel/LayerFieldFilter.js
@@ -5,7 +5,7 @@ import Select from 'react-select';
 import mapActions from 'actions/MapActions';
 import resources from '../../../resources';
 
-const colorTheme = resources.customColorTheme ? resources.customColorTheme : resources.defaultColorTheme;
+const colorTheme = resources.customColorTheme ? resources.customColorTheme : '#F0AB00';
 
 const customStyles = {
   option: (provided, state) => ({

--- a/src/js/components/LayerPanel/LayerVersions.js
+++ b/src/js/components/LayerPanel/LayerVersions.js
@@ -65,7 +65,7 @@ export default class LayerVersions extends Component {
     const { versions, selected } = this.state;
     const { layer } = this.props;
     const { language } = this.context;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
 
     return (
       <div className='relative layer-versions'>
@@ -74,7 +74,7 @@ export default class LayerVersions extends Component {
           {versions.map(this.renderVersionOptions)}
         </select>
         <div
-          style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+          style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
           className='fa-button sml white'
         >
           {selected}

--- a/src/js/components/LayerPanel/LayerVersions.js
+++ b/src/js/components/LayerPanel/LayerVersions.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import layerFactory from 'utils/layerFactory';
 import mapActions from 'actions/MapActions';
 import on from 'dojo/on';
+import {defaultColorTheme} from '../../config';
 
 export default class LayerVersions extends Component {
 
@@ -74,7 +75,7 @@ export default class LayerVersions extends Component {
           {versions.map(this.renderVersionOptions)}
         </select>
         <div
-          style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+          style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
           className='fa-button sml white'
         >
           {selected}

--- a/src/js/components/LayerPanel/LossControls.js
+++ b/src/js/components/LayerPanel/LossControls.js
@@ -5,6 +5,7 @@ import 'rc-slider/assets/index.css';
 import 'rc-tooltip/assets/bootstrap.css';
 import React, { Component, PropTypes } from 'react';
 import Slider from 'rc-slider';
+import {defaultColorTheme} from '../../config';
 
 const createSliderWithTooltip = Slider.createSliderWithTooltip;
 const Range = createSliderWithTooltip(Slider.Range);
@@ -160,7 +161,7 @@ export default class LossControls extends Component {
           }} : {}),
           [currentValue]: {
             style: {
-              color: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'
+              color: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme
             },
             label: <small>{lossOptions[currentValue - 1].label}</small>
           },
@@ -237,15 +238,15 @@ export default class LossControls extends Component {
           tipFormatter={value => 2000 + value}
           dots={true}
           marks={sliderMarks}
-          trackStyle={[{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}]}
-          handleStyle={[{borderColor: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}]}
+          trackStyle={[{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}]}
+          handleStyle={[{borderColor: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}]}
           dotStyle={{border: '1px solid #e9e9e9'}}
-          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
         />
         <div
           id="lossPlayButton"
           className={`${playing ? ' hidden' : ''}`}
-          style={disabled ? disabledStyles : {color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+          style={disabled ? disabledStyles : {color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
           onClick={disabled ? null : this.startVisualization}
           title={disabled ? 'Please select a range to view animation' : ''}
         >

--- a/src/js/components/LayerPanel/LossControls.js
+++ b/src/js/components/LayerPanel/LossControls.js
@@ -132,7 +132,7 @@ export default class LossControls extends Component {
     const start = sliderValue[0];
     let currentValue = start;
     const stop = sliderValue[1];
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
 
     const visualizeLoss = () => {
       if (currentValue === stop + 1) {
@@ -160,7 +160,7 @@ export default class LossControls extends Component {
           }} : {}),
           [currentValue]: {
             style: {
-              color: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme
+              color: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'
             },
             label: <small>{lossOptions[currentValue - 1].label}</small>
           },
@@ -223,7 +223,7 @@ export default class LossControls extends Component {
     if (lossOptions.length === 0) {
       return <div className='timeline-container loss flex'>loading...</div>;
     }
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
 
     return (
       <div className='timeline-container loss'>
@@ -237,15 +237,15 @@ export default class LossControls extends Component {
           tipFormatter={value => 2000 + value}
           dots={true}
           marks={sliderMarks}
-          trackStyle={[{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}]}
-          handleStyle={[{borderColor: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}]}
+          trackStyle={[{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}]}
+          handleStyle={[{borderColor: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}]}
           dotStyle={{border: '1px solid #e9e9e9'}}
-          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
         />
         <div
           id="lossPlayButton"
           className={`${playing ? ' hidden' : ''}`}
-          style={disabled ? disabledStyles : {color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+          style={disabled ? disabledStyles : {color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
           onClick={disabled ? null : this.startVisualization}
           title={disabled ? 'Please select a range to view animation' : ''}
         >

--- a/src/js/components/LayerPanel/NestedCheckbox.js
+++ b/src/js/components/LayerPanel/NestedCheckbox.js
@@ -69,11 +69,11 @@ export default class NestedCheckbox extends Component {
     const { groupLabel, layers } = this.props;
     const checked = this.props.checked ? 'active' : '';
     let colorTheme = '';
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     if (checked === 'active' && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (checked === 'active' && (!customColorTheme || customColorTheme === '')) {
-        colorTheme = defaultColorTheme;
+        colorTheme = '#F0AB00';
     } else {
         colorTheme = '#929292';
     }

--- a/src/js/components/LayerPanel/NestedCheckbox.js
+++ b/src/js/components/LayerPanel/NestedCheckbox.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import LayerCheckbox from './LayerCheckbox';
 import LayerActions from 'actions/LayerActions';
+import {defaultColorTheme} from '../../config';
 
 export default class NestedCheckbox extends Component {
   static contextTypes = {
@@ -73,7 +74,7 @@ export default class NestedCheckbox extends Component {
     if (checked === 'active' && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (checked === 'active' && (!customColorTheme || customColorTheme === '')) {
-        colorTheme = '#F0AB00';
+        colorTheme = defaultColorTheme;
     } else {
         colorTheme = '#929292';
     }

--- a/src/js/components/LayerPanel/RadioButton.js
+++ b/src/js/components/LayerPanel/RadioButton.js
@@ -1,6 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import LayerTransparency from './LayerTransparency';
 import SVGIcon from 'utils/svgIcon';
+import {defaultColorTheme} from '../../config';
 
 export default class RadioButton extends Component {
   static contextTypes = {
@@ -34,7 +35,7 @@ export default class RadioButton extends Component {
     if (selected === 'active' && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (selected === 'active' && customColorTheme && customColorTheme === '') {
-        colorTheme = '#F0AB00';
+        colorTheme = defaultColorTheme;
     } else {
         colorTheme = '#ffffff';
     }
@@ -46,7 +47,7 @@ export default class RadioButton extends Component {
           {label}
         </span>
         <span
-          style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+          style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
           className={`info-icon pointer ${iconLoading === id ? 'iconLoading' : ''}`}
           onClick={this.handleShowInfo}
         >

--- a/src/js/components/LayerPanel/RadioButton.js
+++ b/src/js/components/LayerPanel/RadioButton.js
@@ -30,11 +30,11 @@ export default class RadioButton extends Component {
       initialLayerOpacities
     } = this.props;
     let colorTheme = '';
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     if (selected === 'active' && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (selected === 'active' && customColorTheme && customColorTheme === '') {
-        colorTheme = defaultColorTheme;
+        colorTheme = '#F0AB00';
     } else {
         colorTheme = '#ffffff';
     }
@@ -46,7 +46,7 @@ export default class RadioButton extends Component {
           {label}
         </span>
         <span
-          style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+          style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
           className={`info-icon pointer ${iconLoading === id ? 'iconLoading' : ''}`}
           onClick={this.handleShowInfo}
         >

--- a/src/js/components/LayerPanel/SadControls.js
+++ b/src/js/components/LayerPanel/SadControls.js
@@ -146,7 +146,7 @@ export default class SadControls extends Component {
     const {startMonth, startYear, endMonth, endYear} = this.props;
     const {language} = this.context;
     const {min_year} = this.state;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     //- If min_year, or any year value for that matter, is still 0, don't render the UI
     if (!min_year) { return <div />; }
 
@@ -159,7 +159,7 @@ export default class SadControls extends Component {
             {this.renderMonthOptions('start')}
           </select>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='fa-button sml white'
           >
             {text[language].MONTHS_LIST[startMonth].abbr}
@@ -172,7 +172,7 @@ export default class SadControls extends Component {
             {this.renderYearOptions('start')}
           </select>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='fa-button sml white'
           >
             {startYear}
@@ -186,7 +186,7 @@ export default class SadControls extends Component {
             {this.renderMonthOptions('end')}
           </select>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='fa-button sml white'
           >
             {text[language].MONTHS_LIST[endMonth].abbr}
@@ -199,7 +199,7 @@ export default class SadControls extends Component {
             {this.renderYearOptions('end')}
           </select>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='fa-button sml white'
           >
             {endYear}

--- a/src/js/components/LayerPanel/SadControls.js
+++ b/src/js/components/LayerPanel/SadControls.js
@@ -5,6 +5,7 @@ import request from 'utils/request';
 import utils from 'utils/AppUtils';
 import all from 'dojo/promise/all';
 import text from 'js/languages';
+import {defaultColorTheme} from '../../config';
 
 const STATS = {
   url: 'https://gis-gfw.wri.org/arcgis/rest/services/forest_change/MapServer/2',
@@ -159,7 +160,7 @@ export default class SadControls extends Component {
             {this.renderMonthOptions('start')}
           </select>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='fa-button sml white'
           >
             {text[language].MONTHS_LIST[startMonth].abbr}
@@ -172,7 +173,7 @@ export default class SadControls extends Component {
             {this.renderYearOptions('start')}
           </select>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='fa-button sml white'
           >
             {startYear}
@@ -186,7 +187,7 @@ export default class SadControls extends Component {
             {this.renderMonthOptions('end')}
           </select>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='fa-button sml white'
           >
             {text[language].MONTHS_LIST[endMonth].abbr}
@@ -199,7 +200,7 @@ export default class SadControls extends Component {
             {this.renderYearOptions('end')}
           </select>
           <div
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='fa-button sml white'
           >
             {endYear}

--- a/src/js/components/LayerPanel/TerraIControls.js
+++ b/src/js/components/LayerPanel/TerraIControls.js
@@ -61,7 +61,7 @@ export default class TerraIControls extends Component {
     const { startDate, endDate } = this.props;
     const { min, max } = this.state;
     const {language} = this.context;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     
     return (
       <div className='terra-i-controls'>
@@ -69,7 +69,7 @@ export default class TerraIControls extends Component {
           <div className='terra-i-controls__calendars--row'>
             <label>{text[language].TIMELINE_START}</label>
             {startDate && <DatePicker
-              customInput={<StartButton customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+              customInput={<StartButton customColorTheme={customColorTheme} />}
               showMonthDropdown
               showYearDropdown
               dropdownMode="select"
@@ -83,7 +83,7 @@ export default class TerraIControls extends Component {
           <div className='terra-i-controls__calendars--row'>
             <label>{text[language].TIMELINE_END}</label>
             {endDate && <DatePicker
-              customInput={<EndButton customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+              customInput={<EndButton customColorTheme={customColorTheme} />}
               showMonthDropdown
               showYearDropdown
               dropdownMode="select"
@@ -100,10 +100,10 @@ export default class TerraIControls extends Component {
   }
 }
 
-const StartButton = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const StartButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >
@@ -112,10 +112,10 @@ const StartButton = ({ onClick, value, customColorTheme, defaultColorTheme }) =>
   );
 };
 
-const EndButton = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const EndButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >

--- a/src/js/components/LayerPanel/TerraIControls.js
+++ b/src/js/components/LayerPanel/TerraIControls.js
@@ -5,6 +5,7 @@ import layerActions from 'actions/LayerActions';
 import DatePicker from 'react-datepicker';
 import moment from 'moment';
 import 'react-datepicker/dist/react-datepicker.css';
+import {defaultColorTheme} from '../../config';
 
 export default class TerraIControls extends Component {
 
@@ -103,7 +104,7 @@ export default class TerraIControls extends Component {
 const StartButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >
@@ -115,7 +116,7 @@ const StartButton = ({ onClick, value, customColorTheme }) => {
 const EndButton = ({ onClick, value, customColorTheme }) => {
   return (
     <button
-      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+      style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
       className='fa-button sml white pointer'
       onClick={onClick}
     >

--- a/src/js/components/MapControls/MobileTimeWidget.js
+++ b/src/js/components/MapControls/MobileTimeWidget.js
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from 'react';
 import mapActions from 'actions/MapActions';
 import text from 'js/languages';
 import SVGIcon from 'utils/svgIcon';
+import {defaultColorTheme} from '../../config';
 
 const START = 'START',
       END = 'END';
@@ -73,7 +74,7 @@ export default class MobileTimeWidget extends Component {
               {values.map(this.optionMapper({ type: START, ...currentTimeExtent}))}
             </select>
             <div
-              style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+              style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
               className='fa-button sml white'
             >
               {currentTimeExtent.start}
@@ -85,7 +86,7 @@ export default class MobileTimeWidget extends Component {
               {values.map(this.optionMapper({ type: END, ...currentTimeExtent}))}
             </select>
             <div
-              style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+              style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
               className='fa-button sml white'
             >
               {currentTimeExtent.end}

--- a/src/js/components/MapControls/MobileTimeWidget.js
+++ b/src/js/components/MapControls/MobileTimeWidget.js
@@ -57,7 +57,7 @@ export default class MobileTimeWidget extends Component {
       visible,
       currentTimeExtent
     } = this.props;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
 
     return (
       <div className={`mobile-time-widget map-component mobile-show ${visible ? '' : 'hidden'}`}>
@@ -73,7 +73,7 @@ export default class MobileTimeWidget extends Component {
               {values.map(this.optionMapper({ type: START, ...currentTimeExtent}))}
             </select>
             <div
-              style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+              style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
               className='fa-button sml white'
             >
               {currentTimeExtent.start}
@@ -85,7 +85,7 @@ export default class MobileTimeWidget extends Component {
               {values.map(this.optionMapper({ type: END, ...currentTimeExtent}))}
             </select>
             <div
-              style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+              style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
               className='fa-button sml white'
             >
               {currentTimeExtent.end}

--- a/src/js/components/MapControls/TimeWidget.js
+++ b/src/js/components/MapControls/TimeWidget.js
@@ -110,9 +110,9 @@ export default class TimeWidget extends Component {
   }
 
   render () {
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     return (
-      <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='time-widget map-component shadow mobile-hide'>
+      <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='time-widget map-component shadow mobile-hide'>
         <div ref='timeSlider'></div>
       </div>
     );

--- a/src/js/components/MapControls/TimeWidget.js
+++ b/src/js/components/MapControls/TimeWidget.js
@@ -2,6 +2,7 @@ import TimeSlider from 'esri/dijit/TimeSlider';
 import mapActions from 'actions/MapActions';
 import TimeExtent from 'esri/TimeExtent';
 import React, {Component, PropTypes} from 'react';
+import {defaultColorTheme} from '../../config';
 
 /**
 * Make a date object for time extent using a year, date should be Dec 31 for the given year
@@ -112,7 +113,7 @@ export default class TimeWidget extends Component {
   render () {
     const { customColorTheme } = this.context.settings;
     return (
-      <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='time-widget map-component shadow mobile-hide'>
+      <div style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='time-widget map-component shadow mobile-hide'>
         <div ref='timeSlider'></div>
       </div>
     );

--- a/src/js/components/Modals/CanopyModal.js
+++ b/src/js/components/Modals/CanopyModal.js
@@ -8,6 +8,8 @@ import React, {
 } from 'react';
 import Slider, { createSliderWithTooltip } from 'rc-slider';
 import resources from '../../../resources';
+import {defaultColorTheme} from '../../config';
+
 const SliderWithTooltip = createSliderWithTooltip(Slider);
 
 export default class CanopyModal extends Component {
@@ -149,11 +151,11 @@ export default class CanopyModal extends Component {
           step={null}
           onChange={this.handleSliderChange}
           tipFormatter={value => sliderMarks[value].label}
-          railStyle={{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00', height: 10}}
+          railStyle={{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme, height: 10}}
           trackStyle={{backgroundColor: '#e9e9e9', height: 10}}
-          dotStyle={{border: `2px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, height: 10, width: 10, bottom: -6, marginLeft: -7}}
+          dotStyle={{border: `2px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, height: 10, width: 10, bottom: -6, marginLeft: -7}}
           activeDotStyle={{border: '2px solid #e9e9e9'}}
-          handleStyle={[{border: `2px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, height: 20, width: 20, marginLeft: -13}]}
+          handleStyle={[{border: `2px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, height: 20, width: 20, marginLeft: -13}]}
         />
         </div>
       </ControlledModalWrapper>

--- a/src/js/components/Modals/CanopyModal.js
+++ b/src/js/components/Modals/CanopyModal.js
@@ -120,13 +120,10 @@ export default class CanopyModal extends Component {
     const { sliderMarks } = this.state;
     const { canopyDensity } = this.props;
     let customColorTheme;
-    let defaultColorTheme;
     if (this.context.settings) {
       customColorTheme = this.context.settings.customColorTheme;
-      defaultColorTheme = this.context.settings.defaultColorTheme;
     } else {
       customColorTheme = resources.customColorTheme;
-      defaultColorTheme = resources.defaultColorTheme;
     }
     let language;
     if (this.context.language) {
@@ -152,11 +149,11 @@ export default class CanopyModal extends Component {
           step={null}
           onChange={this.handleSliderChange}
           tipFormatter={value => sliderMarks[value].label}
-          railStyle={{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme, height: 10}}
+          railStyle={{backgroundColor: customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00', height: 10}}
           trackStyle={{backgroundColor: '#e9e9e9', height: 10}}
-          dotStyle={{border: `2px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, height: 10, width: 10, bottom: -6, marginLeft: -7}}
+          dotStyle={{border: `2px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, height: 10, width: 10, bottom: -6, marginLeft: -7}}
           activeDotStyle={{border: '2px solid #e9e9e9'}}
-          handleStyle={[{border: `2px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, height: 20, width: 20, marginLeft: -13}]}
+          handleStyle={[{border: `2px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, height: 20, width: 20, marginLeft: -13}]}
         />
         </div>
       </ControlledModalWrapper>

--- a/src/js/components/Modals/ConfirmModal.js
+++ b/src/js/components/Modals/ConfirmModal.js
@@ -52,7 +52,7 @@ export default class ConfirmModal extends Component {
   render () {
     const {language} = this.context;
     const {subscriptionToDelete} = this.props;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     
     return (
       <ControlledModalWrapper onClose={this.close}>
@@ -62,8 +62,8 @@ export default class ConfirmModal extends Component {
         <p>{text[language].SUBSCRIBE_DELETE_DESC}</p>
 
         <div className='subscription-sub-buttons'>
-          <button style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='fa-button color' onClick={this.delete}>{text[language].SUBSCRIBE_DELETE_CONFIRM}</button>
-          <button style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='fa-button color' onClick={this.cancelDeletion}>{text[language].SUBSCRIBE_DELETE_CANCEL}</button>
+          <button style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='fa-button color' onClick={this.delete}>{text[language].SUBSCRIBE_DELETE_CONFIRM}</button>
+          <button style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='fa-button color' onClick={this.cancelDeletion}>{text[language].SUBSCRIBE_DELETE_CANCEL}</button>
         </div>
 
       </ControlledModalWrapper>

--- a/src/js/components/Modals/ConfirmModal.js
+++ b/src/js/components/Modals/ConfirmModal.js
@@ -1,9 +1,8 @@
 import ControlledModalWrapper from 'components/Modals/ControlledModalWrapper';
 import mapActions from 'actions/MapActions';
 import text from 'js/languages';
-
+import {defaultColorTheme} from '../../config';
 import React, {Component, PropTypes} from 'react';
-
 
 export default class ConfirmModal extends Component {
 
@@ -62,8 +61,8 @@ export default class ConfirmModal extends Component {
         <p>{text[language].SUBSCRIBE_DELETE_DESC}</p>
 
         <div className='subscription-sub-buttons'>
-          <button style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='fa-button color' onClick={this.delete}>{text[language].SUBSCRIBE_DELETE_CONFIRM}</button>
-          <button style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='fa-button color' onClick={this.cancelDeletion}>{text[language].SUBSCRIBE_DELETE_CANCEL}</button>
+          <button style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='fa-button color' onClick={this.delete}>{text[language].SUBSCRIBE_DELETE_CONFIRM}</button>
+          <button style={{backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='fa-button color' onClick={this.cancelDeletion}>{text[language].SUBSCRIBE_DELETE_CANCEL}</button>
         </div>
 
       </ControlledModalWrapper>

--- a/src/js/components/Modals/CoordinatesModal.js
+++ b/src/js/components/Modals/CoordinatesModal.js
@@ -356,7 +356,7 @@ export default class CoordinatesModal extends Component {
     const {language} = this.context;
     const latitudeDirectionOptions = text[language].ANALYSIS_COORDINATES_LATITUDE_DIRECTIONS;
     const longitudeDirectionOptions = text[language].ANALYSIS_COORDINATES_LONGITUDE_DIRECTIONS;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     
     return (
       <div key={`DMS-${index}`}>
@@ -408,7 +408,7 @@ export default class CoordinatesModal extends Component {
               {latitudeDirectionOptions && latitudeDirectionOptions.map(this.createOptions)}
             </select>
             <div
-              style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+              style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
               className='analysis-coordinates-directions__select-arrow'
             ></div>
           </div>
@@ -453,7 +453,7 @@ export default class CoordinatesModal extends Component {
               {longitudeDirectionOptions && longitudeDirectionOptions.map(this.createOptions)}
             </select>
             <div
-              style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+              style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
               className='analysis-coordinates-directions__select-arrow'
             ></div>
           </div>
@@ -530,7 +530,7 @@ export default class CoordinatesModal extends Component {
     const {language} = this.context;
     const {coordinatesFormat, dmsCoordinates, ddCoordinates, errors, buttonHover} = this.state;
     const coordinateFormatOptions = text[language].ANALYSIS_COORDINATES_FORMATS;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     
     return (
       <ControlledModalWrapper onClose={this.close}>
@@ -546,7 +546,7 @@ export default class CoordinatesModal extends Component {
             {coordinateFormatOptions && coordinateFormatOptions.map(this.createOptions)}
           </select>
           <div
-            style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='analysis-coordinates__select-arrow'
           >
           </div>
@@ -564,8 +564,8 @@ export default class CoordinatesModal extends Component {
           <span className="analysis-instructions__add-more">{text[language].ANALYSIS_COORDINATES_BUTTONS[1]}</span>
         </div>
         <div
-          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
           className="fa-button color analysis-instructions__make-shape-button"
           onClick={this.validateShape}
           onMouseEnter={this.toggleHover}

--- a/src/js/components/Modals/CoordinatesModal.js
+++ b/src/js/components/Modals/CoordinatesModal.js
@@ -7,6 +7,7 @@ import geometryUtils from '../../utils/geometryUtils';
 import Polygon from 'esri/geometry/Polygon';
 import Point from 'esri/geometry/Point';
 import layerKeys from '../../constants/LayerConstants';
+import {defaultColorTheme} from '../../config';
 
 const defaultDMS = {
   lat: {
@@ -408,7 +409,7 @@ export default class CoordinatesModal extends Component {
               {latitudeDirectionOptions && latitudeDirectionOptions.map(this.createOptions)}
             </select>
             <div
-              style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+              style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
               className='analysis-coordinates-directions__select-arrow'
             ></div>
           </div>
@@ -453,7 +454,7 @@ export default class CoordinatesModal extends Component {
               {longitudeDirectionOptions && longitudeDirectionOptions.map(this.createOptions)}
             </select>
             <div
-              style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+              style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
               className='analysis-coordinates-directions__select-arrow'
             ></div>
           </div>
@@ -546,7 +547,7 @@ export default class CoordinatesModal extends Component {
             {coordinateFormatOptions && coordinateFormatOptions.map(this.createOptions)}
           </select>
           <div
-            style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={{color: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='analysis-coordinates__select-arrow'
           >
           </div>
@@ -564,8 +565,8 @@ export default class CoordinatesModal extends Component {
           <span className="analysis-instructions__add-more">{text[language].ANALYSIS_COORDINATES_BUTTONS[1]}</span>
         </div>
         <div
-          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
           className="fa-button color analysis-instructions__make-shape-button"
           onClick={this.validateShape}
           onMouseEnter={this.toggleHover}

--- a/src/js/components/Modals/ImageryModal.js
+++ b/src/js/components/Modals/ImageryModal.js
@@ -153,7 +153,7 @@ export default class ImageryModal extends Component {
   renderThumbnails = (tileObj, i) => {
 
       let reloadCount = 0;
-      const { customColorTheme, defaultColorTheme } = this.context.settings;
+      const { customColorTheme } = this.context.settings;
       const handleError = (event) => {
         if (reloadCount < 20) {
           event.persist();
@@ -184,7 +184,7 @@ export default class ImageryModal extends Component {
             onMouseLeave={() => this.hoverThumbnail(null)}
             className='thumbnail'
             style={this.state.selectedThumb && this.state.selectedThumb.index === i ?
-            {border: `4px solid ${customColorTheme && customColorTheme ? customColorTheme : defaultColorTheme}`} : {}}
+            {border: `4px solid ${customColorTheme && customColorTheme ? customColorTheme : '#F0AB00'}`} : {}}
             key={`thumb-${i}`}>
               <img src={tileObj.thumbUrl} onError={handleError} />
           </div>
@@ -281,7 +281,7 @@ export default class ImageryModal extends Component {
     const filteredImageryData = imageryData.filter((data) => {
       return data.attributes.cloud_score >= cloudScore[0] && data.attributes.cloud_score <= cloudScore[1];
     });
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     
     return (
       <DraggableModalWrapper onClose={this.close} onDragEnd={this.onDragEnd}>
@@ -301,7 +301,7 @@ export default class ImageryModal extends Component {
                     {modalText.imagery.monthsOptions.map(this.renderDropdownOptions)}
                   </select>
                   <div
-                    style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+                    style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
                     className='fa-button sml white'
                   >
                     {monthsVal}
@@ -342,7 +342,7 @@ export default class ImageryModal extends Component {
                 {modalText.imagery.imageStyleOptions.map(this.renderDropdownOptions)}
               </select>
               <div
-                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
                 className='fa-button sml white'
               >
                 {imageStyleVal}

--- a/src/js/components/Modals/ImageryModal.js
+++ b/src/js/components/Modals/ImageryModal.js
@@ -13,11 +13,11 @@ import GraphicsLayer from 'esri/layers/GraphicsLayer';
 import Polygon from 'esri/geometry/Polygon';
 import symbols from 'utils/symbols';
 import layerKeys from 'constants/LayerConstants';
-
 import ProjectParameters from 'esri/tasks/ProjectParameters';
 import GeometryService from 'esri/tasks/GeometryService';
 import SpatialReference from 'esri/SpatialReference';
 import { modalText } from 'js/config';
+import {defaultColorTheme} from '../../config';
 
 export default class ImageryModal extends Component {
 
@@ -184,7 +184,7 @@ export default class ImageryModal extends Component {
             onMouseLeave={() => this.hoverThumbnail(null)}
             className='thumbnail'
             style={this.state.selectedThumb && this.state.selectedThumb.index === i ?
-            {border: `4px solid ${customColorTheme && customColorTheme ? customColorTheme : '#F0AB00'}`} : {}}
+            {border: `4px solid ${customColorTheme && customColorTheme ? customColorTheme : defaultColorTheme}`} : {}}
             key={`thumb-${i}`}>
               <img src={tileObj.thumbUrl} onError={handleError} />
           </div>
@@ -301,7 +301,7 @@ export default class ImageryModal extends Component {
                     {modalText.imagery.monthsOptions.map(this.renderDropdownOptions)}
                   </select>
                   <div
-                    style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+                    style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
                     className='fa-button sml white'
                   >
                     {monthsVal}
@@ -342,7 +342,7 @@ export default class ImageryModal extends Component {
                 {modalText.imagery.imageStyleOptions.map(this.renderDropdownOptions)}
               </select>
               <div
-                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
                 className='fa-button sml white'
               >
                 {imageStyleVal}

--- a/src/js/components/Modals/LayerModal.js
+++ b/src/js/components/Modals/LayerModal.js
@@ -30,7 +30,7 @@ export default class Modal extends Component {
     } else if(info.licenseInfo && !info.license) {
       info.license = info.licenseInfo;
     }
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     const {buttonHover} = this.state;
     
     return (
@@ -68,7 +68,7 @@ export default class Modal extends Component {
             <div className='source-learn-more flex'>
               <a
                 href={info.learn_more}
-                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
                 className='source-learn-more-link fa-button white'
                 target='_blank'
               >
@@ -81,8 +81,8 @@ export default class Modal extends Component {
           <div className='source-footer'>
             <a href={info.download_data}
             target='_blank'
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className="source-download fa-button color"
             onMouseEnter={this.toggleHover}
             onMouseLeave={this.toggleHover}

--- a/src/js/components/Modals/LayerModal.js
+++ b/src/js/components/Modals/LayerModal.js
@@ -2,6 +2,7 @@ import ControlledModalWrapper from 'components/Modals/ControlledModalWrapper';
 import mapActions from 'actions/MapActions';
 import text from 'js/languages';
 import React, {Component, PropTypes} from 'react';
+import {defaultColorTheme} from '../../config';
 
 export default class Modal extends Component {
 
@@ -68,7 +69,7 @@ export default class Modal extends Component {
             <div className='source-learn-more flex'>
               <a
                 href={info.learn_more}
-                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+                style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
                 className='source-learn-more-link fa-button white'
                 target='_blank'
               >
@@ -81,8 +82,8 @@ export default class Modal extends Component {
           <div className='source-footer'>
             <a href={info.download_data}
             target='_blank'
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className="source-download fa-button color"
             onMouseEnter={this.toggleHover}
             onMouseLeave={this.toggleHover}

--- a/src/js/components/Modals/SearchModal.js
+++ b/src/js/components/Modals/SearchModal.js
@@ -5,6 +5,7 @@ import text from 'js/languages';
 import Search from 'esri/dijit/Search';
 import FeatureLayer from 'esri/layers/FeatureLayer';
 import InfoTemplate from 'esri/InfoTemplate';
+import {defaultColorTheme} from '../../config';
 import React, {
   Component,
   PropTypes
@@ -125,8 +126,8 @@ export default class SearchModal extends Component {
           <span>Lon:</span><input ref='decimalDegreeLng' type='number' className='deg-input' id='deg-lng' name='deg-lng' />
         </div>
         <button
-          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
           className='search-submit-button fa-button color'
           onClick={this.decimalDegreeSearch}
           onMouseEnter={this.toggleHover}

--- a/src/js/components/Modals/SearchModal.js
+++ b/src/js/components/Modals/SearchModal.js
@@ -113,7 +113,7 @@ export default class SearchModal extends Component {
 
   render () {
     const {language} = this.context;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     const {buttonHover} = this.state;
     
     return (
@@ -125,8 +125,8 @@ export default class SearchModal extends Component {
           <span>Lon:</span><input ref='decimalDegreeLng' type='number' className='deg-input' id='deg-lng' name='deg-lng' />
         </div>
         <button
-          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+          style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+          {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
           className='search-submit-button fa-button color'
           onClick={this.decimalDegreeSearch}
           onMouseEnter={this.toggleHover}

--- a/src/js/components/Modals/ShareModal.js
+++ b/src/js/components/Modals/ShareModal.js
@@ -5,6 +5,7 @@ import utils from 'utils/AppUtils';
 import React, {Component, PropTypes} from 'react';
 import SVGIcon from 'utils/svgIcon';
 import resources from '../../../resources';
+import {defaultColorTheme} from '../../config';
 
 const windowOptions = 'toolbar=0,status=0,height=650,width=450';
 
@@ -74,7 +75,7 @@ export default class ShareModal extends Component {
         <div className='share-input'>
           <input ref='shareInput' type='text' readOnly value={url ? url : this.state.bitlyUrl} onClick={this.handleFocus} />
           <button
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='gfw-btn white pointer'
             onClick={() => this.copyShare()}
           >

--- a/src/js/components/Modals/ShareModal.js
+++ b/src/js/components/Modals/ShareModal.js
@@ -62,13 +62,10 @@ export default class ShareModal extends Component {
   render () {
     const {url} = this.props;
     let customColorTheme;
-    let defaultColorTheme;
     if (this.context.settings) {
       customColorTheme = this.context.settings.customColorTheme;
-      defaultColorTheme = this.context.settings.defaultColorTheme;
     } else {
       customColorTheme = resources.customColorTheme;
-      defaultColorTheme = resources.defaultColorTheme;
     }
     return (
       <ModalWrapper>
@@ -77,7 +74,7 @@ export default class ShareModal extends Component {
         <div className='share-input'>
           <input ref='shareInput' type='text' readOnly value={url ? url : this.state.bitlyUrl} onClick={this.handleFocus} />
           <button
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='gfw-btn white pointer'
             onClick={() => this.copyShare()}
           >

--- a/src/js/components/Modals/SubscribeModal.js
+++ b/src/js/components/Modals/SubscribeModal.js
@@ -2,6 +2,7 @@ import ControlledModalWrapper from 'components/Modals/ControlledModalWrapper';
 import mapActions from 'actions/MapActions';
 import text from 'js/languages';
 import React, {Component, PropTypes} from 'react';
+import {defaultColorTheme} from '../../config';
 
 const initialState = {
   currentStep: 1,
@@ -321,8 +322,8 @@ export default class SubscribeModal extends Component {
         <div className='subscription-sub-buttons'>
           {this.state.currentStep === 0 ?
           <button
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='fa-button color'
             onClick={this.refreshSubscriptions}
             onMouseEnter={this.toggleHover}
@@ -332,8 +333,8 @@ export default class SubscribeModal extends Component {
           </button> : null }
           {this.state.currentStep > 1 ?
           <button
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='fa-button color'
             onClick={this.back}
             onMouseEnter={this.toggleHover}
@@ -343,8 +344,8 @@ export default class SubscribeModal extends Component {
           </button> : null }
           {this.state.currentStep === 1 || this.state.currentStep === 2 ?
           <button
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='fa-button color'
             onClick={this.next}
             onMouseEnter={this.toggleHover}
@@ -354,8 +355,8 @@ export default class SubscribeModal extends Component {
           </button> : null }
           {this.state.currentStep === 3 ?
           <button
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='fa-button color'
             onClick={this.save}
             onMouseEnter={this.toggleHover}

--- a/src/js/components/Modals/SubscribeModal.js
+++ b/src/js/components/Modals/SubscribeModal.js
@@ -260,7 +260,7 @@ export default class SubscribeModal extends Component {
   render () {
     const {language} = this.context;
     const langs = ['English', '中文', 'Français', 'Bahasa Indonesia', 'Português (Brasil)', 'Español (Mexico)']; //TODO: Get from resources or config!
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     const {buttonHover} = this.state;
     
     return (
@@ -321,8 +321,8 @@ export default class SubscribeModal extends Component {
         <div className='subscription-sub-buttons'>
           {this.state.currentStep === 0 ?
           <button
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='fa-button color'
             onClick={this.refreshSubscriptions}
             onMouseEnter={this.toggleHover}
@@ -332,8 +332,8 @@ export default class SubscribeModal extends Component {
           </button> : null }
           {this.state.currentStep > 1 ?
           <button
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='fa-button color'
             onClick={this.back}
             onMouseEnter={this.toggleHover}
@@ -343,8 +343,8 @@ export default class SubscribeModal extends Component {
           </button> : null }
           {this.state.currentStep === 1 || this.state.currentStep === 2 ?
           <button
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='fa-button color'
             onClick={this.next}
             onMouseEnter={this.toggleHover}
@@ -354,8 +354,8 @@ export default class SubscribeModal extends Component {
           </button> : null }
           {this.state.currentStep === 3 ?
           <button
-            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+            {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='fa-button color'
             onClick={this.save}
             onMouseEnter={this.toggleHover}

--- a/src/js/components/Modals/SubscriptionsModal.js
+++ b/src/js/components/Modals/SubscriptionsModal.js
@@ -10,6 +10,7 @@ import Polygon from 'esri/geometry/Polygon';
 import Graphic from 'esri/graphic';
 import React, {Component, PropTypes} from 'react';
 import SVGIcon from 'utils/svgIcon';
+import {defaultColorTheme} from '../../config';
 
 const datasets = ['viirs-active-fires', 'umd-loss-gain', 'glad-alerts', 'imazon-alerts', 'forma-alerts', 'terrai-alerts', 'prodes-loss'];
 
@@ -103,7 +104,7 @@ export default class SubscriptionsModal extends Component {
     if (subscription.attributes.datasets.indexOf(dataset) !== -1 && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (subscription.attributes.datasets.indexOf(dataset) !== -1 && (!customColorTheme || customColorTheme === '')) {
-        colorTheme = '#F0AB00';
+        colorTheme = defaultColorTheme;
     } else {
         colorTheme = '#929292';
     }

--- a/src/js/components/Modals/SubscriptionsModal.js
+++ b/src/js/components/Modals/SubscriptionsModal.js
@@ -99,11 +99,11 @@ export default class SubscriptionsModal extends Component {
     }
     
     let colorTheme = '';
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     if (subscription.attributes.datasets.indexOf(dataset) !== -1 && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (subscription.attributes.datasets.indexOf(dataset) !== -1 && (!customColorTheme || customColorTheme === '')) {
-        colorTheme = defaultColorTheme;
+        colorTheme = '#F0AB00';
     } else {
         colorTheme = '#929292';
     }

--- a/src/js/components/Navigation/LanguageToggle.js
+++ b/src/js/components/Navigation/LanguageToggle.js
@@ -45,7 +45,7 @@ export default class LanguageToggle extends Component {
     for (const lang in settings.labels) {
       languageButtons.push(this.createListButton(language, lang));
     }
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
 
     return (
       <li className='app-header__nav-link app-header__nav-link--language pointer'>
@@ -53,7 +53,7 @@ export default class LanguageToggle extends Component {
           <SVGIcon id={'icon-h-language'} />
         </svg>
         {text[language].NAV_LANGUAGE}
-        <ul style={{borderTop: `3px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='app-header__language-list shadow pointer'>
+        <ul style={{borderTop: `3px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='app-header__language-list shadow pointer'>
           {languageButtons}
         </ul>
       </li>

--- a/src/js/components/Navigation/LanguageToggle.js
+++ b/src/js/components/Navigation/LanguageToggle.js
@@ -1,7 +1,7 @@
 import appActions from 'actions/AppActions';
 import text from 'js/languages';
 import SVGIcon from 'utils/svgIcon';
-
+import {defaultColorTheme} from '../../config';
 import React, {
   Component,
   PropTypes
@@ -53,7 +53,7 @@ export default class LanguageToggle extends Component {
           <SVGIcon id={'icon-h-language'} />
         </svg>
         {text[language].NAV_LANGUAGE}
-        <ul style={{borderTop: `3px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='app-header__language-list shadow pointer'>
+        <ul style={{borderTop: `3px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='app-header__language-list shadow pointer'>
           {languageButtons}
         </ul>
       </li>

--- a/src/js/components/Navigation/MapThemes.js
+++ b/src/js/components/Navigation/MapThemes.js
@@ -1,5 +1,6 @@
 import text from 'js/languages';
 import SVGIcon from 'utils/svgIcon';
+import {defaultColorTheme} from '../../config';
 import React, {
   Component,
   PropTypes
@@ -33,7 +34,7 @@ export default class MapThemes extends Component {
           <SVGIcon id={'icon-h-themes'} />
         </svg>
         {text[language].NAV_MAP_THEMES}
-        <ul style={{borderTop: `3px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='app-header__theme-list shadow'>
+        <ul style={{borderTop: `3px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='app-header__theme-list shadow'>
           {themes.map(this.renderThemeList(language))}
         </ul>
       </li>

--- a/src/js/components/Navigation/MapThemes.js
+++ b/src/js/components/Navigation/MapThemes.js
@@ -26,14 +26,14 @@ export default class MapThemes extends Component {
   render () {
     const {language} = this.context;
     const {themes} = this.props;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     return (
       <li className='app-header__nav-link app-header__nav-link--map-themes pointer'>
         <svg className='svg-icon__nav'>
           <SVGIcon id={'icon-h-themes'} />
         </svg>
         {text[language].NAV_MAP_THEMES}
-        <ul style={{borderTop: `3px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='app-header__theme-list shadow'>
+        <ul style={{borderTop: `3px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='app-header__theme-list shadow'>
           {themes.map(this.renderThemeList(language))}
         </ul>
       </li>

--- a/src/js/components/Navigation/MobileNavigation.js
+++ b/src/js/components/Navigation/MobileNavigation.js
@@ -1,5 +1,6 @@
 import appActions from 'actions/AppActions';
 import text from 'js/languages';
+import {defaultColorTheme} from '../../config';
 import React, {
   Component,
   PropTypes
@@ -40,7 +41,7 @@ export default class Navigation extends Component {
         if (currentLanguage === language && customColorTheme && customColorTheme !== '') {
           colorTheme = customColorTheme;
         } else if (currentLanguage === language && customColorTheme && customColorTheme === '') {
-            colorTheme = '#F0AB00';
+            colorTheme = defaultColorTheme;
         } else {
             colorTheme = 'inherit';
         }

--- a/src/js/components/Navigation/MobileNavigation.js
+++ b/src/js/components/Navigation/MobileNavigation.js
@@ -33,14 +33,14 @@ export default class Navigation extends Component {
   renderLanguageButtons = (currentLanguage, settings) => {
     // Not sure how to test this out in the mobile navigation!
     let colorTheme = '';
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
 
     if (settings.useAlternativeLanguage) {
       return Object.keys(settings.labels).map((language) => {
         if (currentLanguage === language && customColorTheme && customColorTheme !== '') {
           colorTheme = customColorTheme;
         } else if (currentLanguage === language && customColorTheme && customColorTheme === '') {
-            colorTheme = defaultColorTheme;
+            colorTheme = '#F0AB00';
         } else {
             colorTheme = 'inherit';
         }

--- a/src/js/components/SatelliteImagery/ImageryDatePicker.js
+++ b/src/js/components/SatelliteImagery/ImageryDatePicker.js
@@ -68,12 +68,12 @@ export default class AnalysisDatePicker extends Component {
   render() {
     const { minDate, maxDate } = this.props;
     const { dateSelected } = this.state;
-    const {customColorTheme, defaultColorTheme} = this.context.settings;
+    const { customColorTheme } = this.context.settings;
 
     return (
       <div className='analysis-results__select-form-item-container'>
         <DatePicker
-          customInput={<Button customColorTheme={customColorTheme} defaultColorTheme={defaultColorTheme} />}
+          customInput={<Button customColorTheme={customColorTheme} />}
           showMonthDropdown
           showYearDropdown
           dropdownMode="select"
@@ -98,11 +98,11 @@ export default class AnalysisDatePicker extends Component {
   }
 }
 
-const Button = ({ onClick, value, customColorTheme, defaultColorTheme }) => {
+const Button = ({ onClick, value, customColorTheme }) => {
   return (
     <div>
       <button
-        style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+        style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
         className='fa-button sml white pointer'
         onClick={onClick}
       >

--- a/src/js/components/SatelliteImagery/ImageryDatePicker.js
+++ b/src/js/components/SatelliteImagery/ImageryDatePicker.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import moment from 'moment';
 import DatePicker from 'react-datepicker';
+import {defaultColorTheme} from '../../config';
 
 export default class AnalysisDatePicker extends Component {
   static contextTypes = {
@@ -102,7 +103,7 @@ const Button = ({ onClick, value, customColorTheme }) => {
   return (
     <div>
       <button
-        style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+        style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
         className='fa-button sml white pointer'
         onClick={onClick}
       >

--- a/src/js/components/SatelliteImagery/ImageryModalSlider.js
+++ b/src/js/components/SatelliteImagery/ImageryModalSlider.js
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 import Slider from 'rc-slider';
 import MapActions from 'actions/MapActions';
+import {defaultColorTheme} from '../../config';
+
 const createSliderWithTooltip = Slider.createSliderWithTooltip;
 const Range = createSliderWithTooltip(Slider.Range);
 
@@ -87,10 +89,10 @@ export default class AnalysisRangeSlider extends Component {
           step={step}
           marks={sliderMarks}
           dots={bounds[1] - bounds[0] <= 20}
-          trackStyle={[{backgroundColor: `${customColorTheme && customColorTheme ? customColorTheme : '#F0AB00'}`}]}
-          handleStyle={[{borderColor: `${customColorTheme && customColorTheme ? customColorTheme : '#F0AB00'}`}]}
-          dotStyle={{border: `1px solid ${customColorTheme && customColorTheme ? customColorTheme : '#F0AB00'}`}}
-          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme ? customColorTheme : '#F0AB00'}`}}
+          trackStyle={[{backgroundColor: `${customColorTheme && customColorTheme ? customColorTheme : defaultColorTheme}`}]}
+          handleStyle={[{borderColor: `${customColorTheme && customColorTheme ? customColorTheme : defaultColorTheme}`}]}
+          dotStyle={{border: `1px solid ${customColorTheme && customColorTheme ? customColorTheme : defaultColorTheme}`}}
+          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme ? customColorTheme : defaultColorTheme}`}}
         />
       </div>
     );

--- a/src/js/components/SatelliteImagery/ImageryModalSlider.js
+++ b/src/js/components/SatelliteImagery/ImageryModalSlider.js
@@ -73,7 +73,7 @@ export default class AnalysisRangeSlider extends Component {
   render() {
     const { bounds, step, rangeSliderCallback } = this.props;
     const { rangeSliderValue, sliderMarks } = this.state;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     return (
       <div className='analysis-results__select-form-item-container'>
         <Range
@@ -87,10 +87,10 @@ export default class AnalysisRangeSlider extends Component {
           step={step}
           marks={sliderMarks}
           dots={bounds[1] - bounds[0] <= 20}
-          trackStyle={[{backgroundColor: `${customColorTheme && customColorTheme ? customColorTheme : defaultColorTheme}`}]}
-          handleStyle={[{borderColor: `${customColorTheme && customColorTheme ? customColorTheme : defaultColorTheme}`}]}
-          dotStyle={{border: `1px solid ${customColorTheme && customColorTheme ? customColorTheme : defaultColorTheme}`}}
-          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme ? customColorTheme : defaultColorTheme}`}}
+          trackStyle={[{backgroundColor: `${customColorTheme && customColorTheme ? customColorTheme : '#F0AB00'}`}]}
+          handleStyle={[{borderColor: `${customColorTheme && customColorTheme ? customColorTheme : '#F0AB00'}`}]}
+          dotStyle={{border: `1px solid ${customColorTheme && customColorTheme ? customColorTheme : '#F0AB00'}`}}
+          activeDotStyle={{border: `1px solid ${customColorTheme && customColorTheme ? customColorTheme : '#F0AB00'}`}}
         />
       </div>
     );

--- a/src/js/components/Shared/ReportSubscribe.js
+++ b/src/js/components/Shared/ReportSubscribe.js
@@ -6,6 +6,7 @@ import mapActions from 'actions/MapActions';
 import appUtils from 'utils/AppUtils';
 import text from 'js/languages';
 import moment from 'moment';
+import {defaultColorTheme} from '../../config';
 
 export default class ReportSubscribeButtons extends Component {
   constructor(props) {
@@ -140,7 +141,7 @@ export default class ReportSubscribeButtons extends Component {
           className='report-sub-buttons'
         >
           <button
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
             className='report-sub-button pointer'
             id='print'
             onClick={this.printReport}

--- a/src/js/components/Shared/ReportSubscribe.js
+++ b/src/js/components/Shared/ReportSubscribe.js
@@ -132,7 +132,7 @@ export default class ReportSubscribeButtons extends Component {
     const {
       isLoggedIn
     } = mapStore.getState();
-    const {customColorTheme, defaultColorTheme} = this.context.settings;
+    const { customColorTheme } = this.context.settings;
 
     return (
       <div className='report-sub-button-container'>
@@ -140,7 +140,7 @@ export default class ReportSubscribeButtons extends Component {
           className='report-sub-buttons'
         >
           <button
-            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+            style={{border: `1px solid ${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
             className='report-sub-button pointer'
             id='print'
             onClick={this.printReport}

--- a/src/js/components/Shared/ToggleSwitch.js
+++ b/src/js/components/Shared/ToggleSwitch.js
@@ -1,3 +1,4 @@
+import {defaultColorTheme} from '../../config';
 import React, {Component, PropTypes} from 'react';
 
 export default class ToggleSwitch extends Component {
@@ -14,7 +15,7 @@ export default class ToggleSwitch extends Component {
     if (checkedClass === 'active' && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (checkedClass === 'active' && (!customColorTheme || customColorTheme === '')) {
-        colorTheme = '#F0AB00';
+        colorTheme = defaultColorTheme;
     } else {
         colorTheme = '#929292';
     }

--- a/src/js/components/Shared/ToggleSwitch.js
+++ b/src/js/components/Shared/ToggleSwitch.js
@@ -10,11 +10,11 @@ export default class ToggleSwitch extends Component {
     const checkedClass = checked ? 'active' : '';
     const disabledClass = disabled ? 'disabled' : '';
     let colorTheme;
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     if (checkedClass === 'active' && customColorTheme && customColorTheme !== '') {
         colorTheme = customColorTheme;
     } else if (checkedClass === 'active' && (!customColorTheme || customColorTheme === '')) {
-        colorTheme = defaultColorTheme;
+        colorTheme = '#F0AB00';
     } else {
         colorTheme = '#929292';
     }

--- a/src/js/components/TabPanel/Documents.js
+++ b/src/js/components/TabPanel/Documents.js
@@ -103,7 +103,7 @@ class DocumentResults extends Component {
   }
 
   renderDocuments (documents, language) {
-    const { customColorTheme, defaultColorTheme } = this.context.settings;
+    const { customColorTheme } = this.context.settings;
     return (
       <table className='documents-table'>
         <thead>
@@ -119,7 +119,7 @@ class DocumentResults extends Component {
                 <td>{doc.size}</td>
                 <td className='documents-table__link'>
                   <a href={doc.url} target='_blank'>
-                    <svg style={{fill: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='svg-icon'>
+                    <svg style={{fill: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='svg-icon'>
                       <SVGIcon id={'icon-documents'} />
                     </svg>
                   </a>

--- a/src/js/components/TabPanel/Documents.js
+++ b/src/js/components/TabPanel/Documents.js
@@ -2,6 +2,7 @@ import Loader from 'components/Loader';
 // import request from 'utils/request';
 import SVGIcon from 'utils/svgIcon';
 import text from 'js/languages';
+import {defaultColorTheme} from '../../config';
 import React, {
   Component,
   PropTypes
@@ -119,7 +120,7 @@ class DocumentResults extends Component {
                 <td>{doc.size}</td>
                 <td className='documents-table__link'>
                   <a href={doc.url} target='_blank'>
-                    <svg style={{fill: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}} className='svg-icon'>
+                    <svg style={{fill: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}} className='svg-icon'>
                       <SVGIcon id={'icon-documents'} />
                     </svg>
                   </a>

--- a/src/js/components/TabPanel/TabButtons.js
+++ b/src/js/components/TabPanel/TabButtons.js
@@ -115,7 +115,7 @@ export default class TabButtons extends Component {
     const {settings, language} = this.context;
     const {tableOfContentsVisible} = this.props;
     const narrative = settings.labels && settings.labels[language] && settings.labels[language].narrative || '';
-    const {customColorTheme, defaultColorTheme} = resources;
+    const { customColorTheme } = resources;
     return (
       <nav className={`tab-buttons map-component ${tableOfContentsVisible ? '' : 'hidden'}`}>
         <ul className='tab-buttons__header'>
@@ -187,7 +187,7 @@ export default class TabButtons extends Component {
           }
           {!this.props.analysisDisabled && this.props.activeTab !== ANALYSIS && this.state.notifiers.indexOf(ANALYSIS) > -1 ?
             <span
-              style={{backgroundColor: `${customColorTheme ? customColorTheme : defaultColorTheme}`}}
+              style={{backgroundColor: `${customColorTheme ? customColorTheme : '#F0AB00'}`}}
               className="tab-dot"
             >
             </span>
@@ -210,7 +210,7 @@ export default class TabButtons extends Component {
           }
           {this.props.activeTab !== DOCUMENTS && this.state.notifiers.indexOf(DOCUMENTS) > -1 ?
             <span
-              style={{backgroundColor: `${customColorTheme ? customColorTheme : defaultColorTheme}`}}
+              style={{backgroundColor: `${customColorTheme ? customColorTheme : '#F0AB00'}`}}
               className="tab-dot"
             >
             </span>

--- a/src/js/components/TabPanel/TabButtons.js
+++ b/src/js/components/TabPanel/TabButtons.js
@@ -6,6 +6,7 @@ import {getUrlParams} from 'utils/params';
 import React, {Component, PropTypes} from 'react';
 import SVGIcon from 'utils/svgIcon';
 import resources from '../../../resources';
+import {defaultColorTheme} from '../../config';
 
 //- Parse Keys for easier access
 const {
@@ -187,7 +188,7 @@ export default class TabButtons extends Component {
           }
           {!this.props.analysisDisabled && this.props.activeTab !== ANALYSIS && this.state.notifiers.indexOf(ANALYSIS) > -1 ?
             <span
-              style={{backgroundColor: `${customColorTheme ? customColorTheme : '#F0AB00'}`}}
+              style={{backgroundColor: `${customColorTheme ? customColorTheme : defaultColorTheme}`}}
               className="tab-dot"
             >
             </span>
@@ -210,7 +211,7 @@ export default class TabButtons extends Component {
           }
           {this.props.activeTab !== DOCUMENTS && this.state.notifiers.indexOf(DOCUMENTS) > -1 ?
             <span
-              style={{backgroundColor: `${customColorTheme ? customColorTheme : '#F0AB00'}`}}
+              style={{backgroundColor: `${customColorTheme ? customColorTheme : defaultColorTheme}`}}
               className="tab-dot"
             >
             </span>

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -304,6 +304,8 @@ config.analysis[analysisKeys.IFL] = {
   analysisUrl: 'https://production-api.globalforestwatch.org/widget/d0d22aeb-9642-4c4d-a310-f7fb95a48c21',
 };
 
+config.defaultColorTheme = '#F0AB00'; // default gold color theme
+
 export const mapConfig = config.map;
 export const uploadConfig = config.upload;
 export const analysisConfig = config.analysis;
@@ -314,3 +316,4 @@ export const modalText = config.modals;
 export const errors = config.errors;
 export const urls = config.urls;
 export const shortTermServices = config.shortTermServices;
+export const defaultColorTheme = config.defaultColorTheme;

--- a/src/js/report/ReportSettings.js
+++ b/src/js/report/ReportSettings.js
@@ -10,6 +10,7 @@ import mapActions from '../actions/MapActions';
 import layerActions from '../actions/LayerActions';
 import analysisUtils from './../utils/analysisUtils';
 import resources from '../../resources';
+import {defaultColorTheme} from '../config';
 
 
 const AnalysisItemWrapper = ({ title, itemNumber, children }) => (
@@ -356,8 +357,8 @@ export default class ReportSettings extends Component {
             </div>
             <div className='run-report-analysis-button-container print-hide'>
               <button
-                style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
-                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
+                style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
+                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
                 className='run-report-analysis-button fa-button color pointer'
                 onClick={this.runAnalysis}
                 onMouseEnter={this.toggleHover}

--- a/src/js/report/ReportSettings.js
+++ b/src/js/report/ReportSettings.js
@@ -344,13 +344,10 @@ export default class ReportSettings extends Component {
     const {language} = this.props;
     const {buttonHover} = this.state;
     let customColorTheme;
-    let defaultColorTheme;
     if (this.context.settings) {
       customColorTheme = this.context.settings.customColorTheme;
-      defaultColorTheme = this.context.settings.defaultColorTheme;
     } else {
       customColorTheme = resources.customColorTheme;
-      defaultColorTheme = resources.defaultColorTheme;
     }
       return (
           <div className="analysis-results__select-form-container">
@@ -359,8 +356,8 @@ export default class ReportSettings extends Component {
             </div>
             <div className='run-report-analysis-button-container print-hide'>
               <button
-                style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`, opacity: '0.8'} :
-                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}`}}
+                style={buttonHover ? {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`, opacity: '0.8'} :
+                {backgroundColor: `${customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}`}}
                 className='run-report-analysis-button fa-button color pointer'
                 onClick={this.runAnalysis}
                 onMouseEnter={this.toggleHover}

--- a/src/js/utils/svgIcon.js
+++ b/src/js/utils/svgIcon.js
@@ -3,7 +3,7 @@ import resources from '../../resources';
 
 export default (props) => {
   let icon = null;
-  const { customColorTheme, defaultColorTheme } = resources;
+  const { customColorTheme } = resources;
   switch (props.id) {
 
     case 'shape-close':
@@ -16,7 +16,7 @@ export default (props) => {
     case 'shape-warning':
       icon = <svg className='svg-icon'><svg id="shape-warning" viewBox="0 0 483.537 483.537" width="100%" height="100%">
       <title>Analysis Warning</title>
-      <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme} d="M479.963,425.047L269.051,29.854c-5.259-9.88-15.565-16.081-26.782-16.081h-0.03 c-11.217,0-21.492,6.171-26.782,16.051L3.603,425.016c-5.046,9.485-4.773,20.854,0.699,29.974 c5.502,9.15,15.413,14.774,26.083,14.774H453.12c10.701,0,20.58-5.594,26.083-14.774 C484.705,445.84,484.979,434.471,479.963,425.047z M242.239,408.965c-16.781,0-30.399-13.619-30.399-30.399  c0-16.78,13.619-30.399,30.399-30.399c16.75,0,30.399,13.619,30.399,30.399C272.638,395.346,259.02,408.965,242.239,408.965z M272.669,287.854c0,16.811-13.649,30.399-30.399,30.399c-16.781,0-30.399-13.589-30.399-30.399V166.256 c0-16.781,13.619-30.399,30.399-30.399c16.75,0,30.399,13.619,30.399,30.399V287.854z"></path>
+      <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'} d="M479.963,425.047L269.051,29.854c-5.259-9.88-15.565-16.081-26.782-16.081h-0.03 c-11.217,0-21.492,6.171-26.782,16.051L3.603,425.016c-5.046,9.485-4.773,20.854,0.699,29.974 c5.502,9.15,15.413,14.774,26.083,14.774H453.12c10.701,0,20.58-5.594,26.083-14.774 C484.705,445.84,484.979,434.471,479.963,425.047z M242.239,408.965c-16.781,0-30.399-13.619-30.399-30.399  c0-16.78,13.619-30.399,30.399-30.399c16.75,0,30.399,13.619,30.399,30.399C272.638,395.346,259.02,408.965,242.239,408.965z M272.669,287.854c0,16.811-13.649,30.399-30.399,30.399c-16.781,0-30.399-13.589-30.399-30.399V166.256 c0-16.781,13.619-30.399,30.399-30.399c16.75,0,30.399,13.619,30.399,30.399V287.854z"></path>
       </svg></svg>;
       break;
 
@@ -198,19 +198,19 @@ export default (props) => {
       icon = <svg className='svg-icon'><svg id="icon-analysis-draw" viewBox="0 0 145 101">
       <title>Analysis Draw</title>
       <g>
-        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme} d="M135.726,62.687 C135.726,62.687 134.274,65.313 134.274,65.313 C134.274,65.313 52.274,12.313 52.274,12.313 C52.274,12.313 53.726,9.687 53.726,9.687 C53.726,9.687 135.726,62.687 135.726,62.687 Z" fillRule="evenodd"></path>
-        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M105.726,90.687 C105.726,90.687 104.274,93.313 104.274,93.313 C104.274,93.313 42.274,83.313 42.274,83.313 C42.274,83.313 43.726,80.687 43.726,80.687 C43.726,80.687 105.726,90.687 105.726,90.687 Z" fillRule="evenodd"></path>
-        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M105.153,92.235 C105.153,92.235 102.760,90.425 102.760,90.425 C102.760,90.425 134.847,60.765 134.847,60.765 C134.847,60.765 137.240,62.575 137.240,62.575 C137.240,62.575 105.153,92.235 105.153,92.235 Z" fillRule="evenodd"></path>
-        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M43.793,81.207 C43.793,81.207 44.153,82.235 44.153,82.235 C44.153,82.235 41.760,80.425 41.760,80.425 C41.760,80.425 26.847,37.765 26.847,37.765 C26.847,37.765 28.207,38.793 28.207,38.793 C28.207,38.793 27.847,37.765 27.847,37.765 C27.847,37.765 30.240,39.575 30.240,39.575 C30.240,39.575 45.153,82.235 45.153,82.235 C45.153,82.235 43.793,81.207 43.793,81.207 Z" fillRule="evenodd"></path>
-        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="49" cy="9" r="9"></circle>
+        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'} d="M135.726,62.687 C135.726,62.687 134.274,65.313 134.274,65.313 C134.274,65.313 52.274,12.313 52.274,12.313 C52.274,12.313 53.726,9.687 53.726,9.687 C53.726,9.687 135.726,62.687 135.726,62.687 Z" fillRule="evenodd"></path>
+        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M105.726,90.687 C105.726,90.687 104.274,93.313 104.274,93.313 C104.274,93.313 42.274,83.313 42.274,83.313 C42.274,83.313 43.726,80.687 43.726,80.687 C43.726,80.687 105.726,90.687 105.726,90.687 Z" fillRule="evenodd"></path>
+        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M105.153,92.235 C105.153,92.235 102.760,90.425 102.760,90.425 C102.760,90.425 134.847,60.765 134.847,60.765 C134.847,60.765 137.240,62.575 137.240,62.575 C137.240,62.575 105.153,92.235 105.153,92.235 Z" fillRule="evenodd"></path>
+        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M43.793,81.207 C43.793,81.207 44.153,82.235 44.153,82.235 C44.153,82.235 41.760,80.425 41.760,80.425 C41.760,80.425 26.847,37.765 26.847,37.765 C26.847,37.765 28.207,38.793 28.207,38.793 C28.207,38.793 27.847,37.765 27.847,37.765 C27.847,37.765 30.240,39.575 30.240,39.575 C30.240,39.575 45.153,82.235 45.153,82.235 C45.153,82.235 43.793,81.207 43.793,81.207 Z" fillRule="evenodd"></path>
+        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="49" cy="9" r="9"></circle>
         <circle fill="#FFFFFF" cx="49" cy="9" r="6"></circle>
-        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="136" cy="65" r="9"></circle>
+        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="136" cy="65" r="9"></circle>
         <circle fill="#FFFFFF" cx="136" cy="65" r="6"></circle>
-        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="106" cy="92" r="9"></circle>
+        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="106" cy="92" r="9"></circle>
         <circle fill="#FFFFFF" cx="106" cy="92" r="6"></circle>
-        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="43" cy="82" r="9"></circle>
+        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="43" cy="82" r="9"></circle>
         <circle fill="#FFFFFF" cx="43" cy="82" r="6"></circle>
-        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="29" cy="39" r="9"></circle>
+        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="29" cy="39" r="9"></circle>
         <circle fill="#FFFFFF" cx="29" cy="39" r="6"></circle>
         <path fill="#555555" d="M13.896,14.212 C13.896,14.212 15.096,13.010 15.096,13.010 C15.096,13.010 23.668,21.597 23.668,21.597 C23.668,21.597 22.468,22.799 22.468,22.799 C22.468,22.799 13.896,14.212 13.896,14.212 ZM5.324,19.879 C5.324,19.879 13.896,11.293 13.896,11.293 C13.896,11.293 15.096,12.495 15.096,12.495 C15.096,12.495 6.524,21.081 6.524,21.081 C6.524,21.081 5.324,19.879 5.324,19.879 ZM5.838,16.617 C4.467,17.990 4.809,17.819 3.438,19.192 C3.438,19.192 1.038,16.617 1.038,16.617 C-0.334,15.414 -0.334,13.182 1.038,11.808 C1.038,11.808 5.838,7.000 5.838,7.000 C7.210,5.626 9.267,5.626 10.638,7.000 C10.638,7.000 13.210,9.404 13.210,9.404 C11.839,10.606 12.010,10.434 10.638,11.808 C10.638,11.808 5.838,16.617 5.838,16.617 ZM16.811,28.466 C16.811,28.466 15.610,29.668 15.610,29.668 C15.610,29.668 7.038,21.081 7.038,21.081 C7.038,21.081 8.238,19.879 8.238,19.879 C8.238,19.879 16.811,28.466 16.811,28.466 ZM11.667,16.445 C11.667,16.445 20.239,25.031 20.239,25.031 C20.239,25.031 19.039,26.233 19.039,26.233 C19.039,26.233 10.467,17.647 10.467,17.647 C10.467,17.647 11.667,16.445 11.667,16.445 ZM24.011,30.011 C24.011,30.011 17.325,29.324 17.325,29.324 C17.325,29.324 23.325,23.314 23.325,23.314 C23.325,23.314 24.011,30.011 24.011,30.011 Z" fillRule="evenodd"></path>
       </g>
@@ -221,21 +221,21 @@ export default (props) => {
       icon = <svg className='svg-icon'><svg id="icon-analysis-poly" viewBox="0 0 109 86">
       <title>Analysis Click Polygon</title>
       <g>
-        <path className="cls-3" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  opacity="0.2" d="M19.000,74.000 C19.000,74.000 8.000,35.000 8.000,35.000 C8.000,35.000 50.000,10.000 50.000,10.000 C50.000,10.000 54.000,9.000 54.000,9.000 C54.000,9.000 99.000,35.000 99.000,35.000 C99.000,35.000 91.000,74.000 91.000,74.000 C91.000,74.000 19.000,74.000 19.000,74.000 Z" fillRule="evenodd"></path>
-        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M9.772,35.286 C9.772,35.286 8.228,32.714 8.228,32.714 C8.228,32.714 53.228,5.714 53.228,5.714 C53.228,5.714 54.772,8.286 54.772,8.286 C54.772,8.286 9.772,35.286 9.772,35.286 Z" fillRule="evenodd"></path>
-        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M19.438,70.573 C19.438,70.573 16.562,71.427 16.562,71.427 C16.562,71.427 5.562,34.427 5.562,34.427 C5.562,34.427 8.438,33.573 8.438,33.573 C8.438,33.573 19.438,70.573 19.438,70.573 Z" fillRule="evenodd"></path>
-        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M17.020,74.500 C17.020,74.500 16.980,71.500 16.980,71.500 C16.980,71.500 91.980,70.500 91.980,70.500 C91.980,70.500 92.020,73.500 92.020,73.500 C92.020,73.500 17.020,74.500 17.020,74.500 Z" fillRule="evenodd"></path>
-        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M92.462,72.337 C92.462,72.337 89.538,71.663 89.538,71.663 C89.538,71.663 98.538,32.663 98.538,32.663 C98.538,32.663 101.462,33.337 101.462,33.337 C101.462,33.337 92.462,72.337 92.462,72.337 Z" fillRule="evenodd"></path>
-        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M99.726,31.687 C99.726,31.687 98.274,34.313 98.274,34.313 C98.274,34.313 51.274,8.313 51.274,8.313 C51.274,8.313 52.726,5.687 52.726,5.687 C52.726,5.687 99.726,31.687 99.726,31.687 Z" fillRule="evenodd"></path>
-        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="54" cy="9" r="9"></circle>
+        <path className="cls-3" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  opacity="0.2" d="M19.000,74.000 C19.000,74.000 8.000,35.000 8.000,35.000 C8.000,35.000 50.000,10.000 50.000,10.000 C50.000,10.000 54.000,9.000 54.000,9.000 C54.000,9.000 99.000,35.000 99.000,35.000 C99.000,35.000 91.000,74.000 91.000,74.000 C91.000,74.000 19.000,74.000 19.000,74.000 Z" fillRule="evenodd"></path>
+        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M9.772,35.286 C9.772,35.286 8.228,32.714 8.228,32.714 C8.228,32.714 53.228,5.714 53.228,5.714 C53.228,5.714 54.772,8.286 54.772,8.286 C54.772,8.286 9.772,35.286 9.772,35.286 Z" fillRule="evenodd"></path>
+        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M19.438,70.573 C19.438,70.573 16.562,71.427 16.562,71.427 C16.562,71.427 5.562,34.427 5.562,34.427 C5.562,34.427 8.438,33.573 8.438,33.573 C8.438,33.573 19.438,70.573 19.438,70.573 Z" fillRule="evenodd"></path>
+        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M17.020,74.500 C17.020,74.500 16.980,71.500 16.980,71.500 C16.980,71.500 91.980,70.500 91.980,70.500 C91.980,70.500 92.020,73.500 92.020,73.500 C92.020,73.500 17.020,74.500 17.020,74.500 Z" fillRule="evenodd"></path>
+        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M92.462,72.337 C92.462,72.337 89.538,71.663 89.538,71.663 C89.538,71.663 98.538,32.663 98.538,32.663 C98.538,32.663 101.462,33.337 101.462,33.337 C101.462,33.337 92.462,72.337 92.462,72.337 Z" fillRule="evenodd"></path>
+        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M99.726,31.687 C99.726,31.687 98.274,34.313 98.274,34.313 C98.274,34.313 51.274,8.313 51.274,8.313 C51.274,8.313 52.726,5.687 52.726,5.687 C52.726,5.687 99.726,31.687 99.726,31.687 Z" fillRule="evenodd"></path>
+        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="54" cy="9" r="9"></circle>
         <circle className="cls-10" fill="#FFFFFF" cx="54" cy="9" r="6"></circle>
-        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="9" cy="35" r="9"></circle>
+        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="9" cy="35" r="9"></circle>
         <circle className="cls-10" fill="#FFFFFF" cx="9" cy="35" r="6"></circle>
-        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="100" cy="35" r="9"></circle>
+        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="100" cy="35" r="9"></circle>
         <circle className="cls-10" fill="#FFFFFF" cx="100" cy="35" r="6"></circle>
-        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="90" cy="72" r="9"></circle>
+        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="90" cy="72" r="9"></circle>
         <circle className="cls-10" fill="#FFFFFF" cx="90" cy="72" r="6"></circle>
-        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="18" cy="72" r="9"></circle>
+        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="18" cy="72" r="9"></circle>
         <circle className="cls-10" fill="#FFFFFF" cx="18" cy="72" r="6"></circle>
         <path className="cls-19" fill="#FFFFFF" stroke="#555555" strokeLinejoin="round" strokeWidth="2px" d="M69.990,83.228 C69.990,83.228 69.937,71.694 69.937,71.694 C69.932,70.823 69.524,70.051 68.894,69.562 C68.447,69.215 67.891,69.011 67.286,69.014 C66.881,69.016 66.498,69.111 66.155,69.280 C66.114,68.459 65.715,67.738 65.115,67.272 C64.668,66.925 64.112,66.721 63.508,66.725 C62.770,66.729 62.105,67.042 61.627,67.541 C61.627,67.541 61.626,67.117 61.626,67.117 C61.622,66.247 61.214,65.475 60.583,64.986 C60.137,64.640 59.581,64.436 58.978,64.439 C58.239,64.443 57.572,64.756 57.099,65.255 C57.099,65.255 57.069,58.680 57.069,58.680 C57.064,57.810 56.656,57.038 56.026,56.548 C55.579,56.202 55.022,55.998 54.418,56.001 C52.962,56.008 51.787,57.220 51.794,58.705 C51.794,58.705 51.869,75.182 51.869,75.182 C51.869,75.182 50.733,73.637 50.733,73.637 C50.583,73.434 50.409,73.256 50.219,73.109 C49.305,72.400 48.008,72.361 47.042,73.102 C45.877,73.994 45.643,75.681 46.517,76.871 C46.517,76.871 52.436,84.919 52.436,84.919 C52.585,85.121 52.759,85.299 52.948,85.445 C53.398,85.794 53.944,85.984 54.507,85.993 C54.507,85.993 67.365,85.930 67.365,85.930 C68.821,85.924 69.997,84.714 69.990,83.228 Z" fillRule="evenodd"></path>
       </g>
@@ -423,7 +423,7 @@ export default (props) => {
         <svg width="20px" height="21px" viewBox="0 0 20 21" version="1.1" xmlns="http://www.w3.org/2000/svg">
           <title>add-circle-outline</title>
           <g id="Coordinates" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-              <g id="coordinates-b" transform="translate(-580.000000, -687.000000)" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}>
+              <g id="coordinates-b" transform="translate(-580.000000, -687.000000)" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}>
                   <g id="Group-12" transform="translate(560.000000, 192.000000)">
                       <g id="Group-9">
                           <g id="Group-8" transform="translate(20.000000, 495.500000)">

--- a/src/js/utils/svgIcon.js
+++ b/src/js/utils/svgIcon.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import resources from '../../resources';
+import {defaultColorTheme} from '../config';
 
 export default (props) => {
   let icon = null;
@@ -16,7 +17,7 @@ export default (props) => {
     case 'shape-warning':
       icon = <svg className='svg-icon'><svg id="shape-warning" viewBox="0 0 483.537 483.537" width="100%" height="100%">
       <title>Analysis Warning</title>
-      <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'} d="M479.963,425.047L269.051,29.854c-5.259-9.88-15.565-16.081-26.782-16.081h-0.03 c-11.217,0-21.492,6.171-26.782,16.051L3.603,425.016c-5.046,9.485-4.773,20.854,0.699,29.974 c5.502,9.15,15.413,14.774,26.083,14.774H453.12c10.701,0,20.58-5.594,26.083-14.774 C484.705,445.84,484.979,434.471,479.963,425.047z M242.239,408.965c-16.781,0-30.399-13.619-30.399-30.399  c0-16.78,13.619-30.399,30.399-30.399c16.75,0,30.399,13.619,30.399,30.399C272.638,395.346,259.02,408.965,242.239,408.965z M272.669,287.854c0,16.811-13.649,30.399-30.399,30.399c-16.781,0-30.399-13.589-30.399-30.399V166.256 c0-16.781,13.619-30.399,30.399-30.399c16.75,0,30.399,13.619,30.399,30.399V287.854z"></path>
+      <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme} d="M479.963,425.047L269.051,29.854c-5.259-9.88-15.565-16.081-26.782-16.081h-0.03 c-11.217,0-21.492,6.171-26.782,16.051L3.603,425.016c-5.046,9.485-4.773,20.854,0.699,29.974 c5.502,9.15,15.413,14.774,26.083,14.774H453.12c10.701,0,20.58-5.594,26.083-14.774 C484.705,445.84,484.979,434.471,479.963,425.047z M242.239,408.965c-16.781,0-30.399-13.619-30.399-30.399  c0-16.78,13.619-30.399,30.399-30.399c16.75,0,30.399,13.619,30.399,30.399C272.638,395.346,259.02,408.965,242.239,408.965z M272.669,287.854c0,16.811-13.649,30.399-30.399,30.399c-16.781,0-30.399-13.589-30.399-30.399V166.256 c0-16.781,13.619-30.399,30.399-30.399c16.75,0,30.399,13.619,30.399,30.399V287.854z"></path>
       </svg></svg>;
       break;
 
@@ -198,19 +199,19 @@ export default (props) => {
       icon = <svg className='svg-icon'><svg id="icon-analysis-draw" viewBox="0 0 145 101">
       <title>Analysis Draw</title>
       <g>
-        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'} d="M135.726,62.687 C135.726,62.687 134.274,65.313 134.274,65.313 C134.274,65.313 52.274,12.313 52.274,12.313 C52.274,12.313 53.726,9.687 53.726,9.687 C53.726,9.687 135.726,62.687 135.726,62.687 Z" fillRule="evenodd"></path>
-        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M105.726,90.687 C105.726,90.687 104.274,93.313 104.274,93.313 C104.274,93.313 42.274,83.313 42.274,83.313 C42.274,83.313 43.726,80.687 43.726,80.687 C43.726,80.687 105.726,90.687 105.726,90.687 Z" fillRule="evenodd"></path>
-        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M105.153,92.235 C105.153,92.235 102.760,90.425 102.760,90.425 C102.760,90.425 134.847,60.765 134.847,60.765 C134.847,60.765 137.240,62.575 137.240,62.575 C137.240,62.575 105.153,92.235 105.153,92.235 Z" fillRule="evenodd"></path>
-        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M43.793,81.207 C43.793,81.207 44.153,82.235 44.153,82.235 C44.153,82.235 41.760,80.425 41.760,80.425 C41.760,80.425 26.847,37.765 26.847,37.765 C26.847,37.765 28.207,38.793 28.207,38.793 C28.207,38.793 27.847,37.765 27.847,37.765 C27.847,37.765 30.240,39.575 30.240,39.575 C30.240,39.575 45.153,82.235 45.153,82.235 C45.153,82.235 43.793,81.207 43.793,81.207 Z" fillRule="evenodd"></path>
-        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="49" cy="9" r="9"></circle>
+        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme} d="M135.726,62.687 C135.726,62.687 134.274,65.313 134.274,65.313 C134.274,65.313 52.274,12.313 52.274,12.313 C52.274,12.313 53.726,9.687 53.726,9.687 C53.726,9.687 135.726,62.687 135.726,62.687 Z" fillRule="evenodd"></path>
+        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M105.726,90.687 C105.726,90.687 104.274,93.313 104.274,93.313 C104.274,93.313 42.274,83.313 42.274,83.313 C42.274,83.313 43.726,80.687 43.726,80.687 C43.726,80.687 105.726,90.687 105.726,90.687 Z" fillRule="evenodd"></path>
+        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M105.153,92.235 C105.153,92.235 102.760,90.425 102.760,90.425 C102.760,90.425 134.847,60.765 134.847,60.765 C134.847,60.765 137.240,62.575 137.240,62.575 C137.240,62.575 105.153,92.235 105.153,92.235 Z" fillRule="evenodd"></path>
+        <path fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M43.793,81.207 C43.793,81.207 44.153,82.235 44.153,82.235 C44.153,82.235 41.760,80.425 41.760,80.425 C41.760,80.425 26.847,37.765 26.847,37.765 C26.847,37.765 28.207,38.793 28.207,38.793 C28.207,38.793 27.847,37.765 27.847,37.765 C27.847,37.765 30.240,39.575 30.240,39.575 C30.240,39.575 45.153,82.235 45.153,82.235 C45.153,82.235 43.793,81.207 43.793,81.207 Z" fillRule="evenodd"></path>
+        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="49" cy="9" r="9"></circle>
         <circle fill="#FFFFFF" cx="49" cy="9" r="6"></circle>
-        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="136" cy="65" r="9"></circle>
+        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="136" cy="65" r="9"></circle>
         <circle fill="#FFFFFF" cx="136" cy="65" r="6"></circle>
-        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="106" cy="92" r="9"></circle>
+        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="106" cy="92" r="9"></circle>
         <circle fill="#FFFFFF" cx="106" cy="92" r="6"></circle>
-        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="43" cy="82" r="9"></circle>
+        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="43" cy="82" r="9"></circle>
         <circle fill="#FFFFFF" cx="43" cy="82" r="6"></circle>
-        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="29" cy="39" r="9"></circle>
+        <circle fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="29" cy="39" r="9"></circle>
         <circle fill="#FFFFFF" cx="29" cy="39" r="6"></circle>
         <path fill="#555555" d="M13.896,14.212 C13.896,14.212 15.096,13.010 15.096,13.010 C15.096,13.010 23.668,21.597 23.668,21.597 C23.668,21.597 22.468,22.799 22.468,22.799 C22.468,22.799 13.896,14.212 13.896,14.212 ZM5.324,19.879 C5.324,19.879 13.896,11.293 13.896,11.293 C13.896,11.293 15.096,12.495 15.096,12.495 C15.096,12.495 6.524,21.081 6.524,21.081 C6.524,21.081 5.324,19.879 5.324,19.879 ZM5.838,16.617 C4.467,17.990 4.809,17.819 3.438,19.192 C3.438,19.192 1.038,16.617 1.038,16.617 C-0.334,15.414 -0.334,13.182 1.038,11.808 C1.038,11.808 5.838,7.000 5.838,7.000 C7.210,5.626 9.267,5.626 10.638,7.000 C10.638,7.000 13.210,9.404 13.210,9.404 C11.839,10.606 12.010,10.434 10.638,11.808 C10.638,11.808 5.838,16.617 5.838,16.617 ZM16.811,28.466 C16.811,28.466 15.610,29.668 15.610,29.668 C15.610,29.668 7.038,21.081 7.038,21.081 C7.038,21.081 8.238,19.879 8.238,19.879 C8.238,19.879 16.811,28.466 16.811,28.466 ZM11.667,16.445 C11.667,16.445 20.239,25.031 20.239,25.031 C20.239,25.031 19.039,26.233 19.039,26.233 C19.039,26.233 10.467,17.647 10.467,17.647 C10.467,17.647 11.667,16.445 11.667,16.445 ZM24.011,30.011 C24.011,30.011 17.325,29.324 17.325,29.324 C17.325,29.324 23.325,23.314 23.325,23.314 C23.325,23.314 24.011,30.011 24.011,30.011 Z" fillRule="evenodd"></path>
       </g>
@@ -221,21 +222,21 @@ export default (props) => {
       icon = <svg className='svg-icon'><svg id="icon-analysis-poly" viewBox="0 0 109 86">
       <title>Analysis Click Polygon</title>
       <g>
-        <path className="cls-3" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  opacity="0.2" d="M19.000,74.000 C19.000,74.000 8.000,35.000 8.000,35.000 C8.000,35.000 50.000,10.000 50.000,10.000 C50.000,10.000 54.000,9.000 54.000,9.000 C54.000,9.000 99.000,35.000 99.000,35.000 C99.000,35.000 91.000,74.000 91.000,74.000 C91.000,74.000 19.000,74.000 19.000,74.000 Z" fillRule="evenodd"></path>
-        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M9.772,35.286 C9.772,35.286 8.228,32.714 8.228,32.714 C8.228,32.714 53.228,5.714 53.228,5.714 C53.228,5.714 54.772,8.286 54.772,8.286 C54.772,8.286 9.772,35.286 9.772,35.286 Z" fillRule="evenodd"></path>
-        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M19.438,70.573 C19.438,70.573 16.562,71.427 16.562,71.427 C16.562,71.427 5.562,34.427 5.562,34.427 C5.562,34.427 8.438,33.573 8.438,33.573 C8.438,33.573 19.438,70.573 19.438,70.573 Z" fillRule="evenodd"></path>
-        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M17.020,74.500 C17.020,74.500 16.980,71.500 16.980,71.500 C16.980,71.500 91.980,70.500 91.980,70.500 C91.980,70.500 92.020,73.500 92.020,73.500 C92.020,73.500 17.020,74.500 17.020,74.500 Z" fillRule="evenodd"></path>
-        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M92.462,72.337 C92.462,72.337 89.538,71.663 89.538,71.663 C89.538,71.663 98.538,32.663 98.538,32.663 C98.538,32.663 101.462,33.337 101.462,33.337 C101.462,33.337 92.462,72.337 92.462,72.337 Z" fillRule="evenodd"></path>
-        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  d="M99.726,31.687 C99.726,31.687 98.274,34.313 98.274,34.313 C98.274,34.313 51.274,8.313 51.274,8.313 C51.274,8.313 52.726,5.687 52.726,5.687 C52.726,5.687 99.726,31.687 99.726,31.687 Z" fillRule="evenodd"></path>
-        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="54" cy="9" r="9"></circle>
+        <path className="cls-3" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  opacity="0.2" d="M19.000,74.000 C19.000,74.000 8.000,35.000 8.000,35.000 C8.000,35.000 50.000,10.000 50.000,10.000 C50.000,10.000 54.000,9.000 54.000,9.000 C54.000,9.000 99.000,35.000 99.000,35.000 C99.000,35.000 91.000,74.000 91.000,74.000 C91.000,74.000 19.000,74.000 19.000,74.000 Z" fillRule="evenodd"></path>
+        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M9.772,35.286 C9.772,35.286 8.228,32.714 8.228,32.714 C8.228,32.714 53.228,5.714 53.228,5.714 C53.228,5.714 54.772,8.286 54.772,8.286 C54.772,8.286 9.772,35.286 9.772,35.286 Z" fillRule="evenodd"></path>
+        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M19.438,70.573 C19.438,70.573 16.562,71.427 16.562,71.427 C16.562,71.427 5.562,34.427 5.562,34.427 C5.562,34.427 8.438,33.573 8.438,33.573 C8.438,33.573 19.438,70.573 19.438,70.573 Z" fillRule="evenodd"></path>
+        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M17.020,74.500 C17.020,74.500 16.980,71.500 16.980,71.500 C16.980,71.500 91.980,70.500 91.980,70.500 C91.980,70.500 92.020,73.500 92.020,73.500 C92.020,73.500 17.020,74.500 17.020,74.500 Z" fillRule="evenodd"></path>
+        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M92.462,72.337 C92.462,72.337 89.538,71.663 89.538,71.663 C89.538,71.663 98.538,32.663 98.538,32.663 C98.538,32.663 101.462,33.337 101.462,33.337 C101.462,33.337 92.462,72.337 92.462,72.337 Z" fillRule="evenodd"></path>
+        <path className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  d="M99.726,31.687 C99.726,31.687 98.274,34.313 98.274,34.313 C98.274,34.313 51.274,8.313 51.274,8.313 C51.274,8.313 52.726,5.687 52.726,5.687 C52.726,5.687 99.726,31.687 99.726,31.687 Z" fillRule="evenodd"></path>
+        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="54" cy="9" r="9"></circle>
         <circle className="cls-10" fill="#FFFFFF" cx="54" cy="9" r="6"></circle>
-        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="9" cy="35" r="9"></circle>
+        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="9" cy="35" r="9"></circle>
         <circle className="cls-10" fill="#FFFFFF" cx="9" cy="35" r="6"></circle>
-        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="100" cy="35" r="9"></circle>
+        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="100" cy="35" r="9"></circle>
         <circle className="cls-10" fill="#FFFFFF" cx="100" cy="35" r="6"></circle>
-        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="90" cy="72" r="9"></circle>
+        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="90" cy="72" r="9"></circle>
         <circle className="cls-10" fill="#FFFFFF" cx="90" cy="72" r="6"></circle>
-        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}  cx="18" cy="72" r="9"></circle>
+        <circle className="cls-4" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}  cx="18" cy="72" r="9"></circle>
         <circle className="cls-10" fill="#FFFFFF" cx="18" cy="72" r="6"></circle>
         <path className="cls-19" fill="#FFFFFF" stroke="#555555" strokeLinejoin="round" strokeWidth="2px" d="M69.990,83.228 C69.990,83.228 69.937,71.694 69.937,71.694 C69.932,70.823 69.524,70.051 68.894,69.562 C68.447,69.215 67.891,69.011 67.286,69.014 C66.881,69.016 66.498,69.111 66.155,69.280 C66.114,68.459 65.715,67.738 65.115,67.272 C64.668,66.925 64.112,66.721 63.508,66.725 C62.770,66.729 62.105,67.042 61.627,67.541 C61.627,67.541 61.626,67.117 61.626,67.117 C61.622,66.247 61.214,65.475 60.583,64.986 C60.137,64.640 59.581,64.436 58.978,64.439 C58.239,64.443 57.572,64.756 57.099,65.255 C57.099,65.255 57.069,58.680 57.069,58.680 C57.064,57.810 56.656,57.038 56.026,56.548 C55.579,56.202 55.022,55.998 54.418,56.001 C52.962,56.008 51.787,57.220 51.794,58.705 C51.794,58.705 51.869,75.182 51.869,75.182 C51.869,75.182 50.733,73.637 50.733,73.637 C50.583,73.434 50.409,73.256 50.219,73.109 C49.305,72.400 48.008,72.361 47.042,73.102 C45.877,73.994 45.643,75.681 46.517,76.871 C46.517,76.871 52.436,84.919 52.436,84.919 C52.585,85.121 52.759,85.299 52.948,85.445 C53.398,85.794 53.944,85.984 54.507,85.993 C54.507,85.993 67.365,85.930 67.365,85.930 C68.821,85.924 69.997,84.714 69.990,83.228 Z" fillRule="evenodd"></path>
       </g>
@@ -423,7 +424,7 @@ export default (props) => {
         <svg width="20px" height="21px" viewBox="0 0 20 21" version="1.1" xmlns="http://www.w3.org/2000/svg">
           <title>add-circle-outline</title>
           <g id="Coordinates" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-              <g id="coordinates-b" transform="translate(-580.000000, -687.000000)" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : '#F0AB00'}>
+              <g id="coordinates-b" transform="translate(-580.000000, -687.000000)" fill={customColorTheme && customColorTheme !== '' ? customColorTheme : defaultColorTheme}>
                   <g id="Group-12" transform="translate(560.000000, 192.000000)">
                       <g id="Group-9">
                           <g id="Group-8" transform="translate(20.000000, 495.500000)">

--- a/src/resources.js
+++ b/src/resources.js
@@ -22,7 +22,6 @@ export default {
 	includeMyGFWLogin: true,
 	navLinksInNewTab: false,
 	customColorTheme: '#17eae7',
-	defaultColorTheme: '#F0AB00', //Default gold theme
 	//- Language Settings
 	language: 'en',
 	useAlternativeLanguage: false,


### PR DESCRIPTION
@SwampGuzzler See Richard's comments: https://github.com/wri/gfw-mapbuilder/issues/460#issuecomment-532884367

Build: http://alpha.blueraster.io/gfw-mapbuilder/custom-color-theme-refactor/

This now uses `defaultColorTheme` from the `config` rather than pulling from our `resources` to prevent the user from having to set this or accidentally forgetting to! Also makes it easy to update the defaultColorTheme to something else in the future.

In addition, this PR fixes `line-height` issue of buttons AND a build error occurring in our `sprint-6-base`. Externals from this branch should be used instead of what we currently have in `sprint-6-base`!!!
