### PR TITLE
Flexibly attaching measurement on language-change

### DIFF
--- a/src/js/components/AnalysisPanel/MeasurementTool.js
+++ b/src/js/components/AnalysisPanel/MeasurementTool.js
@@ -7,6 +7,9 @@ import React, {
   PropTypes
 } from 'react';
 
+let measurementDiv;
+let lastMapId;
+
 export default class MeasurementTool extends Component {
   static contextTypes = {
     map: PropTypes.object.isRequired
@@ -14,7 +17,8 @@ export default class MeasurementTool extends Component {
 
   initialized = false
 
-  componentWillUpdate(prevProps) {
+  componentWillUpdate(prevProps, prevState, prevContext) {
+    
     if (
       this.context.map.loaded
       // the Measurement tool depends on navigationManager so we
@@ -24,13 +28,30 @@ export default class MeasurementTool extends Component {
       && this.measurementContainer
     ) {
       this.initialized = true;
-      const measurementDiv = document.createElement('DIV');
-      this.measurementContainer.appendChild(measurementDiv);
-      this.measurement = new Measurement({
-        map: this.context.map
-      }, measurementDiv);
-      this.measurement.startup();
-      
+
+      if (measurementDiv) {
+        measurementDiv = document.createElement('DIV');
+        measurementDiv.setAttribute('id', this.context.map.id + '-measure-div');
+        this.measurementContainer.appendChild(measurementDiv);
+        this.measurement = new Measurement({
+          map: this.context.map
+        }, measurementDiv);
+        this.measurement.startup();
+
+        const oldMeasure = document.getElementById(lastMapId + '-measure-div');
+        oldMeasure.classList.add('hidden');
+      } else {
+        measurementDiv = document.createElement('DIV');
+        measurementDiv.setAttribute('id', this.context.map.id + '-measure-div');
+        this.measurementContainer.appendChild(measurementDiv);
+        this.measurement = new Measurement({
+          map: this.context.map
+        }, measurementDiv);
+        this.measurement.startup();
+        lastMapId = this.context.map.id;
+      }
+
+
       //- Show the selected feature highlight again if not using the measurement tool
       this.measurement.on('tool-change', evt => {
         if (!evt.toolName) {
@@ -44,7 +65,7 @@ export default class MeasurementTool extends Component {
       brApp.map.measurement = this.measurement;
     }
 
-    if (prevProps.activeWebmap !== undefined && prevProps.activeWebmap !== this.props.activeWebmap) {
+    if (prevContext.map !== undefined && prevContext.map.id !== this.context.map.id) {
       if (this.context.map.destroy && this.initialized) {
         this.measurement.clearResult();
         this.initialized = false;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

Test-able here [http://blueraster.teaches-yoga.com/CMR?l=en](http://blueraster.teaches-yoga.com/CMR?l=en)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Right now we are not registering **geometries** to the `geostore` on initial click. This is because we are not entering any of the `if` statements in the `infoWindowUpdated` function because we don't have a `brApp.map.measurement`. This fix is to get that `measurement` registered on `language-change`!!

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- On `language-change`, we create a new **measurement** tool, and add it to the **brApp.map**
- We hide the domNode of the **old** tool

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
