### PR TITLE
Redux architecture, provider & store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,16 @@
         "@types/cldrjs": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
@@ -188,6 +198,18 @@
       "dev": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.5.tgz",
+      "integrity": "sha512-ZoNGQMDxh5ENY7PzU7MVonxDzS1l/EWiy8nUhDqxFqUZn4ovboCyvk4Djf68x6COb7vhGTKjyjxHxtFdAA5sUA==",
+      "dev": true,
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/source-list-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2527,6 +2527,14 @@
       "dev": true,
       "requires": {
         "dojo": "1.14.2"
+      },
+      "dependencies": {
+        "dojo": {
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/dojo/-/dojo-1.14.2.tgz",
+          "integrity": "sha512-TI+Ytgfh/VfmHWERp45Jte6NFMdoJTPsvUP/uzJUvAXET8FP2h442LePWWJ/q/xZ4V0V8OtdJhx8It/GB+Zbxg==",
+          "dev": true
+        }
       }
     },
     "dir-glob": {
@@ -2584,6 +2592,14 @@
       "dev": true,
       "requires": {
         "dojo": "^1.9.0"
+      },
+      "dependencies": {
+        "dojo": {
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/dojo/-/dojo-1.16.0.tgz",
+          "integrity": "sha512-DUiXyoLK6vMF5BPr/qiMLTxDMfiM9qlzN1jxfDsVfuvB/CwhYpNxA/M4mbqKN8PCVGLmccXBJbfmFJPP5+zmzw==",
+          "dev": true
+        }
       }
     },
     "dojo-util": {
@@ -2636,6 +2652,23 @@
       "requires": {
         "dijit": "1.14.2",
         "dojo": "1.14.2"
+      },
+      "dependencies": {
+        "dijit": {
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/dijit/-/dijit-1.14.2.tgz",
+          "integrity": "sha512-T/jEhBVpGdU3ruw5K68S8qn8VCjn1Pv/2fC4g0QJjPD0VgxOV9BvXdjo8Fjpv5AQ69PEUdZijHrSTTcPwIo7bg==",
+          "dev": true,
+          "requires": {
+            "dojo": "1.14.2"
+          }
+        },
+        "dojo": {
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/dojo/-/dojo-1.14.2.tgz",
+          "integrity": "sha512-TI+Ytgfh/VfmHWERp45Jte6NFMdoJTPsvUP/uzJUvAXET8FP2h442LePWWJ/q/xZ4V0V8OtdJhx8It/GB+Zbxg==",
+          "dev": true
+        }
       }
     },
     "dom-converter": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/node": "^13.1.4",
     "@types/react": "^16.9.17",
     "@types/react-dom": "^16.9.4",
+    "@types/react-redux": "^7.1.5",
     "@typescript-eslint/eslint-plugin": "^2.15.0",
     "@typescript-eslint/parser": "^2.15.0",
     "clean-webpack-plugin": "^3.0.0",

--- a/src/js/components/App.tsx
+++ b/src/js/components/App.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
+import { useSelector } from 'react-redux';
+
 import { Mapview } from './mapview/Mapview';
 import { mapController } from '../controllers/mapController';
+import { MapviewStore } from '../store/mapview/types';
 import 'arcgis-js-api/themes/light/main.scss';
 import '../../css/index.scss';
 
@@ -9,10 +12,16 @@ function handleClick() {
 }
 
 export function App() {
+  const isMapReady = useSelector((store: MapviewStore) => store.isMapReady);
+  const loadError = useSelector((store: MapviewStore) => store.loadError);
+
   handleClick();
   return (
     <>
-      <div onClick={handleClick}>Hi</div>
+      <div onClick={handleClick}>
+        {isMapReady ? 'Ready!' : 'Loading'}
+        {loadError ? 'Error!' : 'No error!'}
+      </div>
       <Mapview />
     </>
   );

--- a/src/js/constants/actionTypes.js
+++ b/src/js/constants/actionTypes.js
@@ -1,1 +1,2 @@
 export const MAP_READY = 'MAP_READY';
+export const MAP_ERROR = 'MAP_ERROR';

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -37,7 +37,7 @@ export class MapController {
           store.dispatch({ type: 'MAP_ERROR', loadError: true });
         }
       )
-      .catch(error => {
+      .catch((error: Error) => {
         console.log('error in initializeMap()', error);
         store.dispatch({ type: 'MAP_ERROR', loadError: true });
       });

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -27,10 +27,16 @@ export class MapController {
     });
 
     this._mapview
-      .when(() => {
-        console.log('mapview is loaded');
-        store.dispatch({ type: 'MAP_READY', isMapReady: true });
-      })
+      .when(
+        () => {
+          console.log('mapview is loaded');
+          store.dispatch({ type: 'MAP_READY', isMapReady: true });
+        },
+        (error: Error) => {
+          console.log('error in initializeMap()', error);
+          store.dispatch({ type: 'MAP_ERROR', loadError: true });
+        }
+      )
       .catch(error => {
         console.log('error in initializeMap()', error);
         store.dispatch({ type: 'MAP_ERROR', loadError: true });

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -20,20 +20,21 @@ export class MapController {
         id: 'e691172598f04ea8881cd2a4adaa45ba'
       }
     });
+
     this._mapview = new MapView({
       map: this._map,
       container: domRef.current
     });
 
-    this._mapview.when(
-      () => {
+    this._mapview
+      .when(() => {
         console.log('mapview is loaded');
-        store.dispatch({ type: 'MAP_READY', mapReady: true });
-      },
-      (error: Error) => {
-        console.log(error);
-      }
-    );
+        store.dispatch({ type: 'MAP_READY', isMapReady: true });
+      })
+      .catch(error => {
+        console.log('error in initializeMap()', error);
+        store.dispatch({ type: 'MAP_ERROR', loadError: true });
+      });
   }
 
   log(): void {

--- a/src/js/index.tsx
+++ b/src/js/index.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import store from './store/store';
 
 import { App } from './components/App';
 import '../../configs/dojoConfig';
-ReactDOM.render(<App />, document.getElementById('main'));
+
+ReactDOM.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  document.getElementById('main')
+);

--- a/src/js/reducers/app.js
+++ b/src/js/reducers/app.js
@@ -1,7 +1,9 @@
 import { combineReducers } from 'redux';
 
-import mapview from './mapview/mapview';
+import isMapReady from './mapview/mapview';
+import loadError from './mapview/loadError';
 
 export default combineReducers({
-  mapview
+  isMapReady,
+  loadError
 });

--- a/src/js/reducers/mapview/actions.js
+++ b/src/js/reducers/mapview/actions.js
@@ -1,8 +1,15 @@
 import * as types from 'constants/actionTypes';
 
-export function isMapReady(mapReady) {
+export function isMapReady(isMapReady) {
   return {
     type: types.MAP_READY,
-    mapReady
+    isMapReady
+  };
+}
+
+export function mapError(loadError) {
+  return {
+    type: types.MAP_ERROR,
+    loadError
   };
 }

--- a/src/js/reducers/mapview/index.js
+++ b/src/js/reducers/mapview/index.js
@@ -1,0 +1,7 @@
+import { combineReducers } from 'redux';
+
+// import mapview from './mapview/mapview';
+
+// export default combineReducers({
+//   mapview
+// });

--- a/src/js/reducers/mapview/loadError.js
+++ b/src/js/reducers/mapview/loadError.js
@@ -1,11 +1,11 @@
-import { MAP_READY } from '../../constants/actionTypes';
+import { MAP_ERROR } from '../../constants/actionTypes';
 
 const initialState = false;
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case MAP_READY:
-      return action.isMapReady || initialState;
+    case MAP_ERROR:
+      return action.loadError || initialState;
     default:
       return state;
   }

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -1,0 +1,4 @@
+export interface MapviewStore {
+  isMapReady: boolean;
+  loadError: boolean;
+}


### PR DESCRIPTION

- Installed `@types/react-redux` to integrate TSlinting with Redux
- Established a `MapviewStore` TS interface documenting all properties of Redux store
- `index.tsx` updated to leverage `Provider` and make Redux store available, app-wide
- `App.tsx` leverages Redux hooks to hook into state and conditionally manage content. Largely exists to confirm store is updating
- Created a new actionType, `MAP_ERROR` in `actionTypes.js`
- `initializeMap()` in `mapController.ts` was updated to include error-handling logic
- Refactored `mapReady` property of `mapview.js` reducer to be `isMapReady` reducer
- Created `loadError` reducer to architect structure of Redux store
- `app.js` reducer combines all reducers into a store, which is then imported into `store.js`
- Refactored actionCreator `isMapReady()` of `actions.js` to have a parameter of `isMapReady`
- `mapError()` actionCreator of `actions.js` updates store when there is a mapview error
- _Please note:_ `index.js` is an empty file for now, but will store all reducers related to mapview. Will implement this change when feature-building begins