### PR TITLE
Implementation of path aliases

### DIFF
--- a/src/js/components/App.tsx
+++ b/src/js/components/App.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Mapview from './mapview/Mapview';
 import Header from './header/Header';
-import { RootState } from './../store/index';
+import { RootState } from 'js/store/index';
 import { useSelector } from 'react-redux';
 
 import 'arcgis-js-api/themes/light/main.scss';
-import '../../css/index.scss';
+import 'css/index.scss';
 
 const Loader = (): React.ReactElement => <h4>Map Loading...</h4>;
 

--- a/src/js/components/mapview/Mapview.tsx
+++ b/src/js/components/mapview/Mapview.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useRef, useEffect } from 'react';
-import { mapController } from '../../controllers/mapController';
+import { mapController } from 'js/controllers/mapController';
 import { useDispatch } from 'react-redux';
-import { overwriteSettings } from '../../store/appState/actions';
+import { overwriteSettings } from 'js/store/appState/actions';
 
 const Mapview: React.FunctionComponent = () => {
   const mapElementRef = useRef(null);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "compilerOptions": {
     "module": "amd",
+    "baseUrl": ".",
+    "paths": {
+      "js/*": ["src/js/*"],
+      "css/*": ["src/css/*"]
+    },
     "lib": ["dom", "es2015.promise", "es5", "es6"],
     "target": "es5",
     "allowJs": true,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -22,8 +22,7 @@ module.exports = {
       {
         test: /\.tsx?$/,
         loader: 'ts-loader',
-        options: {
-        }
+        options: {}
       },
       {
         test: /\.html$/,
@@ -76,6 +75,10 @@ module.exports = {
     })
   ],
   resolve: {
+    alias: {
+      js: path.join(__dirname, 'src/js'),
+      css: path.join(__dirname, 'src/css')
+    },
     modules: [
       path.resolve(__dirname, '/src'),
       path.resolve(__dirname, 'node_modules/')


### PR DESCRIPTION
Webpack/Typescript out of the box does not recognize relative paths, we end up importing components like this : `../../../components/Modal`.

Adding aliases to `webpack` and `tsconfig` allows us more straightforward approach to importing like this:
`js/components/Modal`