### PR TITLE
Upped JS API to 4.14 in dojoConfig

### DIFF
--- a/configs/dojoConfig.ts
+++ b/configs/dojoConfig.ts
@@ -3,7 +3,7 @@
 
 import esriConfig from 'esri/config';
 
-const DEFAULT_WORKER_URL = 'https://js.arcgis.com/4.13/';
+const DEFAULT_WORKER_URL = 'https://js.arcgis.com/4.14/';
 const DEFAULT_LOADER_URL = `${DEFAULT_WORKER_URL}dojo/dojo-lite.js`;
 
 (esriConfig.workers as any).loaderUrl = DEFAULT_LOADER_URL;


### PR DESCRIPTION
Updated version --> Let's figure out how to tie in the `@arcgis/webpack-plugin` module version with this `dojoConfig.ts` version variable