### PR TITLE
Ticket 713 - Modal sizing

### DIFF
--- a/src/css/header.scss
+++ b/src/css/header.scss
@@ -1,20 +1,19 @@
-$header-height: 50px; // 5rem;
+@import 'variables.scss';
 
 .header-container {
   display: flex;
   position: absolute;
-  flex-direction: row;
   justify-content: space-between;
   width: 100%;
   top: 0;
   height: $header-height;
-  background-color: rgba(255, 255, 255, 0.5);
+  background-color: $header-color;
   z-index: 2;
+  font-family: $fira-sans;
+  color: $dark-grey;
 
   .title-container {
     display: flex;
-    max-height: 5rem;
-    height: 100%;
 
     .gfw-logo {
       max-height: $header-height;
@@ -35,12 +34,10 @@ $header-height: 50px; // 5rem;
 
       h1 {
         font-size: 1.5rem;
-        // margin-bottom: 0;
       }
 
       h2 {
         font-size: 1rem;
-        // margin-top: 0;
       }
     }
   }
@@ -52,7 +49,7 @@ $header-height: 50px; // 5rem;
   }
 }
 
-@media screen and (max-width: 475px) {
+@media screen and (max-width: $mobile-device) {
   .header-container {
     justify-content: flex-end;
 

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -1,13 +1,7 @@
 @import 'variables.scss';
 
 html,
-body {
-  padding: 0;
-  margin: 0;
-  width: 100%;
-  height: 100%;
-}
-
+body,
 .mapview-container,
 .mapview,
 #main {

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -1,11 +1,4 @@
-$blue: #0079c1;
-$gray: #efefef;
-$white: #fff;
-$header-height: 50px;
-
-//? when I try to incorporate $header-height in
-// .mapview-container height attribute, the map isn't able to render
-// even though this same approach works in other SASS files
+@import 'variables.scss';
 
 html,
 body {
@@ -13,11 +6,6 @@ body {
   margin: 0;
   width: 100%;
   height: 100%;
-  // display: flex;
-  // flex-direction: column;
-  // letter-spacing: 0em;
-  // font-family: "Arial", sans-serif;
-  // line-height: 1.55rem;
 }
 
 .mapview-container,

--- a/src/css/mapWidgets.scss
+++ b/src/css/mapWidgets.scss
@@ -29,14 +29,6 @@
         margin-top: auto;
         margin-bottom: auto;
         border: none;
-
-        .svg-icon {
-          fill: $dark-grey;
-          display: block;
-          margin: auto;
-          height: $map-widget-svg;
-          width: $map-widget-svg;
-        }
       }
     }
   }

--- a/src/css/mapWidgets.scss
+++ b/src/css/mapWidgets.scss
@@ -1,10 +1,4 @@
-@font-face {
-  font-family: 'Fira Sans';
-  src: url('../fonts/firasans-regular-webfont.ttf') format('Truetype');
-}
-
-$font: 'Fira Sans', sans-serif;
-$font-color: #555;
+@import 'variables.scss';
 
 .widget-wrapper {
   display: flex;
@@ -16,31 +10,32 @@ $font-color: #555;
   position: absolute;
   z-index: 1;
 
-  .widget-column {
+  .widget-row {
     display: flex;
     flex-direction: row;
 
     .widget-container {
       display: flex;
-      border: 1px solid #aaa;
-      background-color: white;
-      width: 38px;
-      height: 38px;
+      border: 1px solid $medium-dark-grey;
+      background-color: $white;
+      width: $map-widget-square;
+      height: $map-widget-square;
 
       .image-wrapper {
         display: flex;
         height: auto;
-        width: 38px;
+        width: $map-widget-square;
+        background-color: $white;
         margin-top: auto;
         margin-bottom: auto;
         border: none;
 
         .svg-icon {
-          fill: #555;
+          fill: $dark-grey;
           display: block;
           margin: auto;
-          height: 21px;
-          width: 21px;
+          height: $map-widget-svg;
+          width: $map-widget-svg;
         }
       }
     }
@@ -51,13 +46,13 @@ $font-color: #555;
   .widget-wrapper {
     right: 0px;
 
-    .widget-column {
+    .widget-row {
       flex-direction: column;
 
       .widget-container {
         .image-wrapper,
         .exit-button {
-          background: white;
+          background: $white;
         }
       }
     }

--- a/src/css/modalCard.scss
+++ b/src/css/modalCard.scss
@@ -1,4 +1,4 @@
-$header-height: 50px;
+@import 'variables.scss';
 
 .modal-card-container {
   display: flex;
@@ -7,13 +7,24 @@ $header-height: 50px;
   position: absolute;
   z-index: 4;
   padding: 1rem;
-  background: white;
+  background: $white;
+  font-family: $fira-sans;
+  color: $dark-grey;
+
+  overflow-y: scroll;
+  left: 50%;
+  top: 50%;
+  margin-left: -10rem; // * NOTE: -10rem = negative half the width of .modal-card-container
+  margin-top: -7.5rem; // * NOTE: -7.5rem = negative half the height of .modal-card-container
+  width: 20rem;
+  height: 15rem;
 
   .exit-button {
     position: absolute;
     border: none;
     right: 0;
     top: 0;
+    background-color: $white;
 
     svg {
       height: 2rem;
@@ -27,35 +38,14 @@ $header-height: 50px;
   z-index: 3;
   opacity: 0.5;
   width: 100%;
-  background-color: black;
+  background-color: $black;
   top: 0;
   height: 100%;
 }
 
-.print-modal {
-  height: 115px;
-  width: 225px;
-  top: 35%;
-  left: 40%;
-}
-
-.share-modal {
-  width: 300px;
-  height: 225px;
-  top: 35%;
-  left: 40%;
-}
-
-.pen-modal {
-  height: 500px;
-  width: 320px;
-  top: 20%;
-  left: 40%;
-}
-
-.search-modal {
-  width: 390px;
-  height: 160px;
-  top: 35%;
-  left: 35%;
+@media screen and (max-width: $mobile-device) {
+  .modal-card-container {
+    width: 15rem;
+    margin-left: -8.5rem; // * NOTE: -8.5rem is an estimate
+  }
 }

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -1,0 +1,30 @@
+/* COLORS
+============================================= */
+
+$white: #fff;
+$medium-dark-grey: #aaa;
+$dark-grey: #555; // * NOTE: NEW
+$black: black; // * NOTE: NEW
+$header-color: rgba(255, 255, 255, 0.5);
+
+/* FEATURE DIMENSIONS
+============================================= */
+
+$header-height: 50px;
+$map-widget-square: 38px;
+$map-widget-svg: 21px;
+
+/* FONTS
+============================================= */
+
+@font-face {
+  font-family: 'Fira Sans';
+  src: url('../fonts/firasans-regular-webfont.ttf') format('Truetype');
+}
+
+$fira-sans: 'Fira Sans', sans-serif;
+
+/* MEDIA QUERY, DEVICE WIDTH
+============================================= */
+
+$mobile-device: 475px;

--- a/src/js/components/mapWidgets/mapWidgets.tsx
+++ b/src/js/components/mapWidgets/mapWidgets.tsx
@@ -14,18 +14,18 @@ const MapWidgets: FunctionComponent = () => {
   return (
     <>
       <div className="widget-wrapper">
-        <div className="widget-column">
+        <div className="widget-row">
           <ZoomWidget />
         </div>
-        <div className="widget-column">
+        <div className="widget-row">
           <ShareWidget />
           <PrintWidget />
         </div>
-        <div className="widget-column">
+        <div className="widget-row">
           <PenWidget />
           <SearchWidget />
         </div>
-        <div className="widget-column">
+        <div className="widget-row">
           <HideWidget />
           <RefreshWidget />
         </div>

--- a/src/js/components/modal/modalCard.tsx
+++ b/src/js/components/modal/modalCard.tsx
@@ -14,21 +14,6 @@ const ModalCard: FunctionComponent<{}> = () => {
   const modalType = useSelector((state: any) => state.appState.renderModal);
   const dispatch = useDispatch();
 
-  const setModalClassName = () => {
-    switch (modalType) {
-      case 'PrintWidget':
-        return 'print-modal';
-      case 'ShareWidget':
-        return 'share-modal';
-      case 'PenWidget':
-        return 'pen-modal';
-      case 'SearchWidget':
-        return 'search-modal';
-      default:
-        break;
-    }
-  };
-
   const handleEscapeKey = (e: React.KeyboardEvent) => {
     if (e.keyCode === 27) {
       // * NOTE ESC button has a keyCode of 27
@@ -57,7 +42,7 @@ const ModalCard: FunctionComponent<{}> = () => {
         className="dim-container"
         onClick={() => dispatch(renderModal({ renderModal: '' }))}
       ></div>
-      <div className={`modal-card-container ${setModalClassName()}`}>
+      <div className="modal-card-container">
         <button
           className="exit-button"
           onClick={() => dispatch(renderModal({ renderModal: '' }))}


### PR DESCRIPTION
**Styling the modal card**
- `.modal-card-container` in `modalCard.scss` is centers on mobile/desktop consistently to account for changes to width/height. Media query was added to support centering/sizing on mobile devices
- deleted `.print-modal`, `.share-modal`, `.pen-modal` and `.search-modal` since they were no longer needed
- removed `setModalClassName()` from `modalCard.tsx` since the modal card will have a fixed width/height


**SASS variables file**
- `variables.scss` stores all SASS variables, organized into types (color, dimensions, etc)
- `header.scss`, `mapWidgets.scss`, `index.scss` and `modalCard.scss` use SASS variables via importing `variables.scss`
- removed unused SASS variables from `index.scss` since I was given the green light to centralize variables in `variables.scss`. Also removed dead code for code cleanliness
- used font-family SASS variable `$fira-sans` as needed
- removed a few lines of SASS because those attributes didn't contribute anything to the application
- renamed from `widget-column` to `widget-row` in `mapWidgets.scss` and `mapWidgets.tsx`

Fixes https://github.com/wri/gfw-mapbuilder/issues/713