### PR TITLE
Ticket 730 - Pen tool - coordinates scaffolding & logic for DMS

### DIFF
--- a/configs/modal.config.ts
+++ b/configs/modal.config.ts
@@ -231,3 +231,76 @@ export const searchContent = {
     buttonTitle: '搜寻'
   }
 };
+
+export const coordinatesContent = {
+  degree: '°',
+  apostrophe: "'",
+  quotes: `"`,
+  en: {
+    title: 'Enter your own coordinates',
+    dropdownTitle: 'Select Format',
+    decimalOptions: ['Degrees Decimal Seconds (DMS)', 'Decimal Degrees (DD)'],
+    latitude: 'Latitude',
+    longitude: 'Longitude'
+  },
+  ka: {
+    title: 'KA: Enter your own coordinates',
+    dropdownTitle: 'KA: Select Format',
+    decimalOptions: [
+      'KA: Degrees Decimal Seconds (DMS)',
+      'KA: Decimal Degrees (DD)'
+    ],
+    latitude: 'KA: Latitude',
+    longitude: 'KA: Longitude'
+  },
+  fr: {
+    title: 'FR: Enter your own coordinates',
+    dropdownTitle: 'FR: Select Format',
+    decimalOptions: [
+      'FR: Degrees Decimal Seconds (DMS)',
+      'FR: Decimal Degrees (DD)'
+    ],
+    latitude: 'FR: Latitude',
+    longitude: 'FR: Longitude'
+  },
+  es: {
+    title: 'ES: Enter your own coordinates',
+    dropdownTitle: 'ES: Select Format',
+    decimalOptions: [
+      'ES: Degrees Decimal Seconds (DMS)',
+      'ES: Decimal Degrees (DD)'
+    ],
+    latitude: 'ES: Latitude',
+    longitude: 'ES: Longitude'
+  },
+  pt: {
+    title: 'PT: Enter your own coordinates',
+    dropdownTitle: 'PT: Select Format',
+    decimalOptions: [
+      'PT: Degrees Decimal Seconds (DMS)',
+      'PT: Decimal Degrees (DD)'
+    ],
+    latitude: 'PT: Latitude',
+    longitude: 'PT: Longitude'
+  },
+  id: {
+    title: 'ID: Enter your own coordinates',
+    dropdownTitle: 'ID: Select Format',
+    decimalOptions: [
+      'ID: Degrees Decimal Seconds (DMS)',
+      'ID: Decimal Degrees (DD)'
+    ],
+    latitude: 'ID: Latitude',
+    longitude: 'ID: Longitude'
+  },
+  zh: {
+    title: 'ZH: Enter your own coordinates',
+    dropdownTitle: 'ZH: Select Format',
+    decimalOptions: [
+      'ZH: Degrees Decimal Seconds (DMS)',
+      'ZH: Decimal Degrees (DD)'
+    ],
+    latitude: 'ZH: Latitude',
+    longitude: 'ZH: Longitude'
+  }
+};

--- a/configs/modal.config.ts
+++ b/configs/modal.config.ts
@@ -234,8 +234,8 @@ export const searchContent = {
 
 export const coordinatesContent = {
   degree: '°',
-  apostrophe: "'",
-  quotes: `"`,
+  minutes: "'",
+  seconds: `"`,
   en: {
     title: 'Enter your own coordinates',
     dropdownTitle: 'Select Format',

--- a/src/css/coordinatesForm.scss
+++ b/src/css/coordinatesForm.scss
@@ -1,0 +1,85 @@
+@import 'variables.scss';
+
+.coordinates-form-container {
+  display: flex;
+  justify-content: center;
+  width: inherit;
+
+  hr {
+    margin: 1.5rem 0 1.5rem 0;
+  }
+
+  .directions {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
+
+    .title {
+      font-weight: 400;
+      margin-bottom: 0px;
+    }
+
+    ol {
+      font-size: 13px;
+    }
+
+    .dms-wrapper {
+      display: flex;
+      flex-wrap: nowrap;
+      flex-direction: column;
+      margin-top: 1rem;
+
+      span {
+        font-size: 0.75rem;
+      }
+
+      .input-wrapper {
+        display: flex;
+
+        input {
+          @extend %input-fields;
+        }
+
+        select {
+          width: 2.75rem;
+          height: 1.75rem;
+        }
+
+        .degree {
+          margin-right: 1rem;
+        }
+      }
+    }
+
+    .dds-wrapper {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: flex-end;
+      height: 3rem;
+      font-size: 0.75rem;
+
+      .degree-input {
+        display: flex;
+
+        input {
+          width: 5rem;
+          height: 1.5rem;
+        }
+      }
+
+      p {
+        margin-bottom: 0rem;
+      }
+    }
+
+    .buttons-wrapper {
+      // * NOTE: DMS wrapper
+      display: flex;
+      flex-wrap: nowrap;
+      flex-direction: column;
+      align-items: center;
+      font-family: $fira-sans;
+    }
+  }
+}

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -15,6 +15,11 @@ $header-height: 50px;
 $map-widget-square: 38px;
 $map-widget-svg: 21px;
 
+%input-fields {
+  width: 2.75rem;
+  height: 1.5rem;
+}
+
 /* FONTS
 ============================================= */
 

--- a/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import '../../../../css/CoordinatesForm';
+import 'css/CoordinatesForm';
 
 interface DMSSectionProps {
   dmsSection: {

--- a/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
@@ -30,14 +30,13 @@ export default function DMSSection(props: DMSSectionProps) {
     setDMSCardinalType,
     degreeSymbol,
     minuteSymbol,
-    secondsSymbol,
-    key
+    secondsSymbol
   } = props;
   const { rowNum, latitude, longitude } = dmsSection;
 
   return (
     <>
-      <div className="dms-wrapper" key={key}>
+      <div className="dms-wrapper">
         <span>Latitude</span>
         <div className="input-wrapper">
           <input

--- a/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
@@ -2,27 +2,25 @@ import React from 'react';
 
 import 'css/CoordinatesForm';
 
+interface coordinateProps {
+  degree: number;
+  minutes: number;
+  seconds: number;
+  cardinalPoint: string;
+}
+
 interface DMSSectionProps {
   dmsSection: {
     rowNum: number;
-    latitude: {
-      degree: number;
-      minutes: number;
-      seconds: number;
-      cardinalPoint: string;
-    };
-    longitude: {
-      degree: number;
-      minutes: number;
-      seconds: number;
-      cardinalPoint: string;
-    };
+    latitude: coordinateProps;
+    longitude: coordinateProps;
   };
   setDMSFormValues: (formValues: any) => void;
   setDMSCardinalType: (cardinalValue: any) => void;
   degreeSymbol: string;
   minuteSymbol: string;
   secondsSymbol: string;
+  key: number;
 }
 
 export default function DMSSection(props: DMSSectionProps) {
@@ -32,13 +30,14 @@ export default function DMSSection(props: DMSSectionProps) {
     setDMSCardinalType,
     degreeSymbol,
     minuteSymbol,
-    secondsSymbol
+    secondsSymbol,
+    key
   } = props;
   const { rowNum, latitude, longitude } = dmsSection;
 
   return (
     <>
-      <div className="dms-wrapper">
+      <div className="dms-wrapper" key={key}>
         <span>Latitude</span>
         <div className="input-wrapper">
           <input
@@ -47,7 +46,7 @@ export default function DMSSection(props: DMSSectionProps) {
             value={latitude.degree}
             onChange={e =>
               setDMSFormValues({
-                coordinateValue: e.target.value,
+                coordinateValue: Number(e.target.value),
                 rowNum,
                 coordinateType: 'latitude',
                 degreeType: 'degree'
@@ -61,7 +60,7 @@ export default function DMSSection(props: DMSSectionProps) {
             value={latitude.minutes}
             onChange={e =>
               setDMSFormValues({
-                coordinateValue: e.target.value,
+                coordinateValue: Number(e.target.value),
                 rowNum,
                 coordinateType: 'latitude',
                 degreeType: 'minutes'
@@ -75,7 +74,7 @@ export default function DMSSection(props: DMSSectionProps) {
             value={latitude.seconds}
             onChange={e =>
               setDMSFormValues({
-                coordinateValue: e.target.value,
+                coordinateValue: Number(e.target.value),
                 rowNum,
                 coordinateType: 'latitude',
                 degreeType: 'seconds'
@@ -107,7 +106,7 @@ export default function DMSSection(props: DMSSectionProps) {
             value={longitude.degree}
             onChange={e =>
               setDMSFormValues({
-                coordinateValue: e.target.value,
+                coordinateValue: Number(e.target.value),
                 rowNum,
                 coordinateType: 'longitude',
                 degreeType: 'degree'
@@ -121,7 +120,7 @@ export default function DMSSection(props: DMSSectionProps) {
             value={longitude.minutes}
             onChange={e =>
               setDMSFormValues({
-                coordinateValue: e.target.value,
+                coordinateValue: Number(e.target.value),
                 rowNum,
                 coordinateType: 'longitude',
                 degreeType: 'minutes'
@@ -135,7 +134,7 @@ export default function DMSSection(props: DMSSectionProps) {
             value={longitude.seconds}
             onChange={e =>
               setDMSFormValues({
-                coordinateValue: e.target.value,
+                coordinateValue: Number(e.target.value),
                 rowNum,
                 coordinateType: 'longitude',
                 degreeType: 'seconds'

--- a/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+
+import '../../../../css/CoordinatesForm';
+
+interface DMSSectionProps {
+  dmsSection: {
+    rowNum: number;
+    latitude: {
+      degree: number;
+      minutes: number;
+      seconds: number;
+      cardinalPoint: string;
+    };
+    longitude: {
+      degree: number;
+      minutes: number;
+      seconds: number;
+      cardinalPoint: string;
+    };
+  };
+  setDMSFormValues: (formValues: any) => void;
+  setDMSCardinalType: (cardinalValue: any) => void;
+  degreeSymbol: string;
+  minuteSymbol: string;
+  secondsSymbol: string;
+}
+
+export default function DMSSection(props: DMSSectionProps) {
+  const {
+    dmsSection,
+    setDMSFormValues,
+    setDMSCardinalType,
+    degreeSymbol,
+    minuteSymbol,
+    secondsSymbol
+  } = props;
+  const { rowNum, latitude, longitude } = dmsSection;
+
+  return (
+    <>
+      <div className="dms-wrapper">
+        <span>Latitude</span>
+        <div className="input-wrapper">
+          <input
+            type="number"
+            name="latitude coordinates"
+            value={latitude.degree}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'latitude',
+                degreeType: 'degree'
+              })
+            }
+          />
+          <span className="degree">{degreeSymbol}</span>
+          <input
+            type="number"
+            name="latitude coordinates"
+            value={latitude.minutes}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'latitude',
+                degreeType: 'minutes'
+              })
+            }
+          />
+          <span className="degree">{minuteSymbol}</span>
+          <input
+            type="number"
+            name="latitude coordinates"
+            value={latitude.seconds}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'latitude',
+                degreeType: 'seconds'
+              })
+            }
+          />
+          <span className="degree">{secondsSymbol}</span>
+          <select
+            value={latitude.cardinalPoint}
+            onChange={e =>
+              setDMSCardinalType({
+                specificPoint: e.target.value,
+                rowNum,
+                coordinateType: 'latitude'
+              })
+            }
+          >
+            <option value="N">N</option>
+            <option value="S">S</option>
+          </select>
+        </div>
+      </div>
+      <div className="dms-wrapper">
+        <span>Longitude</span>
+        <div className="input-wrapper">
+          <input
+            type="number"
+            name="longitude coordinates"
+            value={longitude.degree}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'longitude',
+                degreeType: 'degree'
+              })
+            }
+          />
+          <span className="degree">{degreeSymbol}</span>
+          <input
+            type="number"
+            name="longitude coordinates"
+            value={longitude.minutes}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'longitude',
+                degreeType: 'minutes'
+              })
+            }
+          />
+          <span className="degree">{minuteSymbol}</span>
+          <input
+            type="number"
+            name="longitude coordinates"
+            value={longitude.seconds}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'longitude',
+                degreeType: 'seconds'
+              })
+            }
+          />
+          <span className="degree">{secondsSymbol}</span>
+          <select
+            value={longitude.cardinalPoint}
+            onChange={e =>
+              setDMSCardinalType({
+                specificPoint: e.target.value,
+                rowNum,
+                coordinateType: 'longitude'
+              })
+            }
+          >
+            <option value="E">E</option>
+            <option value="W">W</option>
+          </select>
+        </div>
+      </div>
+      <hr />
+    </>
+  );
+}

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -21,13 +21,21 @@ const CoordinatesForm: FunctionComponent = () => {
     longitude
   } = coordinatesContent[selectedLanguage];
 
-  const setFormValues = (
-    coordinateValue: string,
-    rowNum: Number,
-    coordinateType: string,
-    degreeType: string,
-    cardinalPoint: string
-  ) => {
+  interface DMSFormValues {
+    coordinateValue: string;
+    rowNum: number;
+    coordinateType: string;
+    degreeType: string;
+    cardinalPoint: string;
+  }
+
+  const setDMSFormValues = ({
+    coordinateValue,
+    rowNum,
+    coordinateType,
+    degreeType,
+    cardinalPoint
+  }: DMSFormValues) => {
     if (_dmsFormValues[`row${rowNum}`]) {
       _dmsFormValues[`row${rowNum}`][coordinateType][
         degreeType
@@ -41,14 +49,20 @@ const CoordinatesForm: FunctionComponent = () => {
       };
     }
 
-    console.log('setFormValues()', _dmsFormValues);
+    console.log('setDMSFormValues()', _dmsFormValues);
   };
 
-  const setCardinalType = (
-    specificPoint: string,
-    rowNum: number,
-    coordinateType: string
-  ) => {
+  interface DMSCardinalPoint {
+    specificPoint: string;
+    rowNum: number;
+    coordinateType: string;
+  }
+
+  const setDMSCardinalType = ({
+    specificPoint,
+    rowNum,
+    coordinateType
+  }: DMSCardinalPoint) => {
     if (_dmsFormValues[`row${rowNum}`]) {
       _dmsFormValues[`row${rowNum}`][coordinateType][
         'cardinalPoint'
@@ -61,7 +75,7 @@ const CoordinatesForm: FunctionComponent = () => {
       };
     }
 
-    console.log('setCardinalType()', _dmsFormValues);
+    console.log('setDMSCardinalType()', _dmsFormValues);
   };
 
   const dmsRows = (): any => {
@@ -78,13 +92,13 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setFormValues(
-                        e.target.value,
+                      setDMSFormValues({
+                        coordinateValue: e.target.value,
                         rowNum,
-                        'latitude',
-                        'degree',
-                        'north'
-                      )
+                        coordinateType: 'latitude',
+                        degreeType: 'degree',
+                        cardinalPoint: 'north'
+                      })
                     }
                   />
                   <span className="degree">{degree}</span>
@@ -92,13 +106,13 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setFormValues(
-                        e.target.value,
+                      setDMSFormValues({
+                        coordinateValue: e.target.value,
                         rowNum,
-                        'latitude',
-                        'minutes',
-                        'north'
-                      )
+                        coordinateType: 'latitude',
+                        degreeType: 'minutes',
+                        cardinalPoint: 'north'
+                      })
                     }
                   />
                   <span className="degree">{minutes}</span>
@@ -106,19 +120,23 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setFormValues(
-                        e.target.value,
+                      setDMSFormValues({
+                        coordinateValue: e.target.value,
                         rowNum,
-                        'latitude',
-                        'seconds',
-                        'north'
-                      )
+                        coordinateType: 'latitude',
+                        degreeType: 'seconds',
+                        cardinalPoint: 'north'
+                      })
                     }
                   />
                   <span className="degree">{seconds}</span>
                   <select
                     onChange={e =>
-                      setCardinalType(e.target.value, rowNum, 'latitude')
+                      setDMSCardinalType({
+                        specificPoint: e.target.value,
+                        rowNum,
+                        coordinateType: 'latitude'
+                      })
                     }
                   >
                     <option value="N">N</option>
@@ -138,13 +156,13 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setFormValues(
-                        e.target.value,
+                      setDMSFormValues({
+                        coordinateValue: e.target.value,
                         rowNum,
-                        'longitude',
-                        'degree',
-                        'east'
-                      )
+                        coordinateType: 'longitude',
+                        degreeType: 'degree',
+                        cardinalPoint: 'east'
+                      })
                     }
                   />
                   <span className="degree">{degree}</span>
@@ -152,13 +170,13 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setFormValues(
-                        e.target.value,
+                      setDMSFormValues({
+                        coordinateValue: e.target.value,
                         rowNum,
-                        'longitude',
-                        'minutes',
-                        'east'
-                      )
+                        coordinateType: 'longitude',
+                        degreeType: 'minutes',
+                        cardinalPoint: 'east'
+                      })
                     }
                   />
                   <span className="degree">{minutes}</span>
@@ -166,19 +184,23 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setFormValues(
-                        e.target.value,
+                      setDMSFormValues({
+                        coordinateValue: e.target.value,
                         rowNum,
-                        'longitude',
-                        'seconds',
-                        'east'
-                      )
+                        coordinateType: 'longitude',
+                        degreeType: 'seconds',
+                        cardinalPoint: 'east'
+                      })
                     }
                   />
                   <span className="degree">{seconds}</span>
                   <select
                     onChange={e =>
-                      setCardinalType(e.target.value, rowNum, 'longitude')
+                      setDMSCardinalType({
+                        specificPoint: e.target.value,
+                        rowNum,
+                        coordinateType: 'longitude'
+                      })
                     }
                   >
                     <option value="E">E</option>
@@ -197,20 +219,6 @@ const CoordinatesForm: FunctionComponent = () => {
   const setShape = () => {
     console.log('setShape()', _dmsFormValues);
     // TODO create polygon from formvalues!
-  };
-
-  const returnSelectedContent = (): ReactElement => {
-    return (
-      <>
-        {dmsRows()}
-        <div className="buttons-wrapper">
-          <button>Add more</button>
-          <button className="orange-button" onClick={() => setShape()}>
-            Make shape
-          </button>
-        </div>
-      </>
-    );
   };
 
   // if (decimalOptions[selectedFormat].includes('DD')) {
@@ -287,7 +295,13 @@ const CoordinatesForm: FunctionComponent = () => {
           ))}
         </select>
         <hr />
-        {returnSelectedContent()}
+        {dmsRows()}
+        <div className="buttons-wrapper">
+          <button>Add more</button>
+          <button className="orange-button" onClick={() => setShape()}>
+            Make shape
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -1,146 +1,39 @@
 import React, { FunctionComponent, useState, ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 
+import DMSSection from './coordinatesDMSSection';
+
 import { coordinatesContent } from '../../../../../configs/modal.config';
 
 import '../../../../css/CoordinatesForm';
 
-function DMSSection(props: any) {
-  const {
-    dmsSection,
-    setDMSFormValues,
-    setDMSCardinalType,
-    degreeSymbol,
-    minuteSymbol,
-    secondsSymbol
-  } = props;
-  const { rowNum, latitude, longitude } = dmsSection;
+interface SpecificDMSSection {
+  rowNum: number;
+  latitude: {
+    degree: number;
+    minutes: number;
+    seconds: number;
+    cardinalPoint: string;
+  };
+  longitude: {
+    degree: number;
+    minutes: number;
+    seconds: number;
+    cardinalPoint: string;
+  };
+}
+interface DMSFormValues {
+  coordinateValue: string;
+  rowNum: number;
+  coordinateType: string;
+  degreeType: string;
+  cardinalPoint: string;
+}
 
-  return (
-    <>
-      <div className="dms-wrapper">
-        <span>Latitude</span>
-        <div className="input-wrapper">
-          <input
-            type="number"
-            name="latitude coordinates"
-            value={latitude.degree}
-            onChange={e =>
-              setDMSFormValues({
-                coordinateValue: e.target.value,
-                rowNum,
-                coordinateType: 'latitude',
-                degreeType: 'degree'
-              })
-            }
-          />
-          <span className="degree">{degreeSymbol}</span>
-          <input
-            type="number"
-            name="latitude coordinates"
-            value={latitude.minutes}
-            onChange={e =>
-              setDMSFormValues({
-                coordinateValue: e.target.value,
-                rowNum,
-                coordinateType: 'latitude',
-                degreeType: 'minutes'
-              })
-            }
-          />
-          <span className="degree">{minuteSymbol}</span>
-          <input
-            type="number"
-            name="latitude coordinates"
-            value={latitude.seconds}
-            onChange={e =>
-              setDMSFormValues({
-                coordinateValue: e.target.value,
-                rowNum,
-                coordinateType: 'latitude',
-                degreeType: 'seconds'
-              })
-            }
-          />
-          <span className="degree">{secondsSymbol}</span>
-          <select
-            value={latitude.cardinalPoint}
-            onChange={e =>
-              setDMSCardinalType({
-                specificPoint: e.target.value,
-                rowNum,
-                coordinateType: 'latitude'
-              })
-            }
-          >
-            <option value="N">N</option>
-            <option value="S">S</option>
-          </select>
-        </div>
-      </div>
-      <div className="dms-wrapper">
-        <span>Longitude</span>
-        <div className="input-wrapper">
-          <input
-            type="number"
-            name="longitude coordinates"
-            value={longitude.degree}
-            onChange={e =>
-              setDMSFormValues({
-                coordinateValue: e.target.value,
-                rowNum,
-                coordinateType: 'longitude',
-                degreeType: 'degree'
-              })
-            }
-          />
-          <span className="degree">{degreeSymbol}</span>
-          <input
-            type="number"
-            name="longitude coordinates"
-            value={longitude.minutes}
-            onChange={e =>
-              setDMSFormValues({
-                coordinateValue: e.target.value,
-                rowNum,
-                coordinateType: 'longitude',
-                degreeType: 'minutes'
-              })
-            }
-          />
-          <span className="degree">{minuteSymbol}</span>
-          <input
-            type="number"
-            name="longitude coordinates"
-            value={longitude.seconds}
-            onChange={e =>
-              setDMSFormValues({
-                coordinateValue: e.target.value,
-                rowNum,
-                coordinateType: 'longitude',
-                degreeType: 'seconds'
-              })
-            }
-          />
-          <span className="degree">{secondsSymbol}</span>
-          <select
-            value={longitude.cardinalPoint}
-            onChange={e =>
-              setDMSCardinalType({
-                specificPoint: e.target.value,
-                rowNum,
-                coordinateType: 'longitude'
-              })
-            }
-          >
-            <option value="E">E</option>
-            <option value="W">W</option>
-          </select>
-        </div>
-      </div>
-      <hr />
-    </>
-  );
+interface DMSCardinalPoint {
+  specificPoint: string;
+  rowNum: number;
+  coordinateType: string;
 }
 
 const CoordinatesForm: FunctionComponent = () => {
@@ -201,14 +94,6 @@ const CoordinatesForm: FunctionComponent = () => {
     selectedLanguage
   ];
 
-  interface DMSFormValues {
-    coordinateValue: string;
-    rowNum: number;
-    coordinateType: string;
-    degreeType: string;
-    cardinalPoint: string;
-  }
-
   const setDMSFormValues = ({
     coordinateValue,
     rowNum,
@@ -223,12 +108,6 @@ const CoordinatesForm: FunctionComponent = () => {
     setDMSForm(sections);
   };
 
-  interface DMSCardinalPoint {
-    specificPoint: string;
-    rowNum: number;
-    coordinateType: string;
-  }
-
   const setDMSCardinalType = ({
     specificPoint,
     rowNum,
@@ -236,6 +115,7 @@ const CoordinatesForm: FunctionComponent = () => {
   }: DMSCardinalPoint) => {
     const sections = [...dmsSections];
     const sectionNum = sections.findIndex(section => section.rowNum === rowNum);
+
     sections[sectionNum][coordinateType].cardinalPoint = specificPoint;
 
     setDMSForm(sections);
@@ -321,7 +201,7 @@ const CoordinatesForm: FunctionComponent = () => {
         </select>
         <hr />
         {decimalOptions[selectedFormat].includes('DMS') &&
-          dmsSections.map((dmsSection: any) => {
+          dmsSections.map((dmsSection: SpecificDMSSection) => {
             return (
               <DMSSection
                 dmsSection={dmsSection}

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -5,21 +5,201 @@ import { coordinatesContent } from '../../../../../configs/modal.config';
 
 import '../../../../css/CoordinatesForm';
 
+function DMSSection(props: any) {
+  const {
+    dmsSection,
+    setDMSFormValues,
+    setDMSCardinalType,
+    degreeSymbol,
+    minuteSymbol,
+    secondsSymbol
+  } = props;
+  const { rowNum, latitude, longitude } = dmsSection;
+
+  return (
+    <>
+      <div className="dms-wrapper">
+        <span>Latitude</span>
+        <div className="input-wrapper">
+          <input
+            type="number"
+            name="latitude coordinates"
+            value={latitude.degree}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'latitude',
+                degreeType: 'degree'
+              })
+            }
+          />
+          <span className="degree">{degreeSymbol}</span>
+          <input
+            type="number"
+            name="latitude coordinates"
+            value={latitude.minutes}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'latitude',
+                degreeType: 'minutes'
+              })
+            }
+          />
+          <span className="degree">{minuteSymbol}</span>
+          <input
+            type="number"
+            name="latitude coordinates"
+            value={latitude.seconds}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'latitude',
+                degreeType: 'seconds'
+              })
+            }
+          />
+          <span className="degree">{secondsSymbol}</span>
+          <select
+            value={latitude.cardinalPoint}
+            onChange={e =>
+              setDMSCardinalType({
+                specificPoint: e.target.value,
+                rowNum,
+                coordinateType: 'latitude'
+              })
+            }
+          >
+            <option value="N">N</option>
+            <option value="S">S</option>
+          </select>
+        </div>
+      </div>
+      <div className="dms-wrapper">
+        <span>Longitude</span>
+        <div className="input-wrapper">
+          <input
+            type="number"
+            name="longitude coordinates"
+            value={longitude.degree}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'longitude',
+                degreeType: 'degree'
+              })
+            }
+          />
+          <span className="degree">{degreeSymbol}</span>
+          <input
+            type="number"
+            name="longitude coordinates"
+            value={longitude.minutes}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'longitude',
+                degreeType: 'minutes'
+              })
+            }
+          />
+          <span className="degree">{minuteSymbol}</span>
+          <input
+            type="number"
+            name="longitude coordinates"
+            value={longitude.seconds}
+            onChange={e =>
+              setDMSFormValues({
+                coordinateValue: e.target.value,
+                rowNum,
+                coordinateType: 'longitude',
+                degreeType: 'seconds'
+              })
+            }
+          />
+          <span className="degree">{secondsSymbol}</span>
+          <select
+            value={longitude.cardinalPoint}
+            onChange={e =>
+              setDMSCardinalType({
+                specificPoint: e.target.value,
+                rowNum,
+                coordinateType: 'longitude'
+              })
+            }
+          >
+            <option value="E">E</option>
+            <option value="W">W</option>
+          </select>
+        </div>
+      </div>
+      <hr />
+    </>
+  );
+}
+
 const CoordinatesForm: FunctionComponent = () => {
-  const _dmsFormValues = {};
   const [selectedFormat, setSelectedFormat] = useState(0);
+  const [dmsSections, setDMSForm] = useState([
+    {
+      rowNum: 0,
+      latitude: {
+        degree: 0,
+        minutes: 0,
+        seconds: 0,
+        cardinalPoint: 'N'
+      },
+      longitude: {
+        degree: 0,
+        minutes: 0,
+        seconds: 0,
+        cardinalPoint: 'E'
+      }
+    },
+    {
+      rowNum: 1,
+      latitude: {
+        degree: 0,
+        minutes: 0,
+        seconds: 0,
+        cardinalPoint: 'N'
+      },
+      longitude: {
+        degree: 0,
+        minutes: 0,
+        seconds: 0,
+        cardinalPoint: 'E'
+      }
+    },
+    {
+      rowNum: 2,
+      latitude: {
+        degree: 0,
+        minutes: 0,
+        seconds: 0,
+        cardinalPoint: 'N'
+      },
+      longitude: {
+        degree: 0,
+        minutes: 0,
+        seconds: 0,
+        cardinalPoint: 'E'
+      }
+    }
+  ]);
   const selectedLanguage = useSelector(
     (state: any) => state.appState.selectedLanguage
   );
 
   const { degree, minutes, seconds } = coordinatesContent;
-  const {
-    title,
-    dropdownTitle,
-    decimalOptions,
-    latitude,
-    longitude
-  } = coordinatesContent[selectedLanguage];
+  const { title, dropdownTitle, decimalOptions } = coordinatesContent[
+    selectedLanguage
+  ];
 
   interface DMSFormValues {
     coordinateValue: string;
@@ -33,23 +213,14 @@ const CoordinatesForm: FunctionComponent = () => {
     coordinateValue,
     rowNum,
     coordinateType,
-    degreeType,
-    cardinalPoint
+    degreeType
   }: DMSFormValues) => {
-    if (_dmsFormValues[`row${rowNum}`]) {
-      _dmsFormValues[`row${rowNum}`][coordinateType][
-        degreeType
-      ] = coordinateValue;
-    } else {
-      _dmsFormValues[`row${rowNum}`] = {
-        [coordinateType]: {
-          [degreeType]: coordinateValue,
-          cardinalPoint: cardinalPoint
-        }
-      };
-    }
+    const sections = [...dmsSections];
+    const sectionNum = sections.findIndex(section => section.rowNum === rowNum);
 
-    console.log('setDMSFormValues()', _dmsFormValues);
+    sections[sectionNum][coordinateType][degreeType] = coordinateValue;
+
+    setDMSForm(sections);
   };
 
   interface DMSCardinalPoint {
@@ -63,161 +234,15 @@ const CoordinatesForm: FunctionComponent = () => {
     rowNum,
     coordinateType
   }: DMSCardinalPoint) => {
-    if (_dmsFormValues[`row${rowNum}`]) {
-      _dmsFormValues[`row${rowNum}`][coordinateType][
-        'cardinalPoint'
-      ] = specificPoint;
-    } else {
-      _dmsFormValues[`row${rowNum}`] = {
-        [coordinateType]: {
-          cardinalPoint: specificPoint
-        }
-      };
-    }
+    const sections = [...dmsSections];
+    const sectionNum = sections.findIndex(section => section.rowNum === rowNum);
+    sections[sectionNum][coordinateType].cardinalPoint = specificPoint;
 
-    console.log('setDMSCardinalType()', _dmsFormValues);
-  };
-
-  const dmsRows = (): any => {
-    const rows = [1, 2, 3, 4, 5, 6];
-    if (decimalOptions[selectedFormat].includes('DMS')) {
-      return rows.map(rowNum => {
-        if (rowNum % 2 === 1) {
-          return (
-            <>
-              <div className="dms-wrapper">
-                <span>{latitude}</span>
-                <div className="input-wrapper">
-                  <input
-                    type="number"
-                    name="latitude coordinates"
-                    onChange={e =>
-                      setDMSFormValues({
-                        coordinateValue: e.target.value,
-                        rowNum,
-                        coordinateType: 'latitude',
-                        degreeType: 'degree',
-                        cardinalPoint: 'north'
-                      })
-                    }
-                  />
-                  <span className="degree">{degree}</span>
-                  <input
-                    type="number"
-                    name="latitude coordinates"
-                    onChange={e =>
-                      setDMSFormValues({
-                        coordinateValue: e.target.value,
-                        rowNum,
-                        coordinateType: 'latitude',
-                        degreeType: 'minutes',
-                        cardinalPoint: 'north'
-                      })
-                    }
-                  />
-                  <span className="degree">{minutes}</span>
-                  <input
-                    type="number"
-                    name="latitude coordinates"
-                    onChange={e =>
-                      setDMSFormValues({
-                        coordinateValue: e.target.value,
-                        rowNum,
-                        coordinateType: 'latitude',
-                        degreeType: 'seconds',
-                        cardinalPoint: 'north'
-                      })
-                    }
-                  />
-                  <span className="degree">{seconds}</span>
-                  <select
-                    onChange={e =>
-                      setDMSCardinalType({
-                        specificPoint: e.target.value,
-                        rowNum,
-                        coordinateType: 'latitude'
-                      })
-                    }
-                  >
-                    <option value="N">N</option>
-                    <option value="S">S</option>
-                  </select>
-                </div>
-              </div>
-            </>
-          );
-        } else {
-          return (
-            <>
-              <div className="dms-wrapper">
-                <span>{longitude}</span>
-                <div className="input-wrapper">
-                  <input
-                    type="number"
-                    name="latitude coordinates"
-                    onChange={e =>
-                      setDMSFormValues({
-                        coordinateValue: e.target.value,
-                        rowNum,
-                        coordinateType: 'longitude',
-                        degreeType: 'degree',
-                        cardinalPoint: 'east'
-                      })
-                    }
-                  />
-                  <span className="degree">{degree}</span>
-                  <input
-                    type="number"
-                    name="latitude coordinates"
-                    onChange={e =>
-                      setDMSFormValues({
-                        coordinateValue: e.target.value,
-                        rowNum,
-                        coordinateType: 'longitude',
-                        degreeType: 'minutes',
-                        cardinalPoint: 'east'
-                      })
-                    }
-                  />
-                  <span className="degree">{minutes}</span>
-                  <input
-                    type="number"
-                    name="latitude coordinates"
-                    onChange={e =>
-                      setDMSFormValues({
-                        coordinateValue: e.target.value,
-                        rowNum,
-                        coordinateType: 'longitude',
-                        degreeType: 'seconds',
-                        cardinalPoint: 'east'
-                      })
-                    }
-                  />
-                  <span className="degree">{seconds}</span>
-                  <select
-                    onChange={e =>
-                      setDMSCardinalType({
-                        specificPoint: e.target.value,
-                        rowNum,
-                        coordinateType: 'longitude'
-                      })
-                    }
-                  >
-                    <option value="E">E</option>
-                    <option value="W">W</option>
-                  </select>
-                </div>
-              </div>
-              <hr />
-            </>
-          );
-        }
-      });
-    }
+    setDMSForm(sections);
   };
 
   const setShape = () => {
-    console.log('setShape()', _dmsFormValues);
+    console.log('setShape()', dmsSections);
     // TODO create polygon from formvalues!
   };
 
@@ -295,7 +320,19 @@ const CoordinatesForm: FunctionComponent = () => {
           ))}
         </select>
         <hr />
-        {dmsRows()}
+        {decimalOptions[selectedFormat].includes('DMS') &&
+          dmsSections.map((dmsSection: any) => {
+            return (
+              <DMSSection
+                dmsSection={dmsSection}
+                setDMSFormValues={setDMSFormValues}
+                setDMSCardinalType={setDMSCardinalType}
+                degreeSymbol={degree}
+                minuteSymbol={minutes}
+                secondsSymbol={seconds}
+              />
+            );
+          })}
         <div className="buttons-wrapper">
           <button>Add more</button>
           <button className="orange-button" onClick={() => setShape()}>

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -6,8 +6,7 @@ import { coordinatesContent } from '../../../../../configs/modal.config';
 import '../../../../css/CoordinatesForm';
 
 const CoordinatesForm: FunctionComponent = () => {
-  const _rows = [1, 2, 3, 4, 5, 6];
-  let _formValues = {};
+  const _formValues = {};
   const [selectedFormat, setSelectedFormat] = useState(0);
   const selectedLanguage = useSelector(
     (state: any) => state.appState.selectedLanguage
@@ -22,11 +21,12 @@ const CoordinatesForm: FunctionComponent = () => {
     longitude
   } = coordinatesContent[selectedLanguage];
 
-  const setValues = (
+  const setFormValues = (
     coordinateValue: string,
     rowNum: Number,
     coordinateType: string,
-    degreeType: string
+    degreeType: string,
+    direction: string
   ) => {
     if (_formValues[`row${rowNum}`]) {
       Object.defineProperty(
@@ -41,14 +41,15 @@ const CoordinatesForm: FunctionComponent = () => {
       Object.defineProperty(_formValues, `row${rowNum}`, {
         value: {
           [coordinateType]: {
-            [degreeType]: coordinateValue
+            [degreeType]: coordinateValue,
+            direction: direction
           }
         },
         writable: true
       });
     }
 
-    console.log('component _formValues', _formValues);
+    console.log('setFormValues()', _formValues);
   };
 
   const setCardinalType = (
@@ -67,9 +68,10 @@ const CoordinatesForm: FunctionComponent = () => {
     console.log('setCardinalType()', _formValues);
   };
 
-  const latitudeLongitudeRow = (): any => {
+  const dmsRows = (): any => {
+    const rows = [1, 2, 3, 4, 5, 6];
     if (decimalOptions[selectedFormat].includes('DMS')) {
-      return _rows.map(rowNum => {
+      return rows.map(rowNum => {
         if (rowNum % 2 === 1) {
           return (
             <>
@@ -80,7 +82,13 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setValues(e.target.value, rowNum, 'latitude', 'degree')
+                      setFormValues(
+                        e.target.value,
+                        rowNum,
+                        'latitude',
+                        'degree',
+                        'north'
+                      )
                     }
                   />
                   <span className="degree">{degree}</span>
@@ -88,7 +96,13 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setValues(e.target.value, rowNum, 'latitude', 'minutes')
+                      setFormValues(
+                        e.target.value,
+                        rowNum,
+                        'latitude',
+                        'minutes',
+                        'north'
+                      )
                     }
                   />
                   <span className="degree">{minutes}</span>
@@ -96,7 +110,13 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setValues(e.target.value, rowNum, 'latitude', 'seconds')
+                      setFormValues(
+                        e.target.value,
+                        rowNum,
+                        'latitude',
+                        'seconds',
+                        'north'
+                      )
                     }
                   />
                   <span className="degree">{seconds}</span>
@@ -126,7 +146,13 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setValues(e.target.value, rowNum, 'longitude', 'degree')
+                      setFormValues(
+                        e.target.value,
+                        rowNum,
+                        'longitude',
+                        'degree',
+                        'east'
+                      )
                     }
                   />
                   <span className="degree">{degree}</span>
@@ -134,7 +160,13 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setValues(e.target.value, rowNum, 'longitude', 'minutes')
+                      setFormValues(
+                        e.target.value,
+                        rowNum,
+                        'longitude',
+                        'minutes',
+                        'east'
+                      )
                     }
                   />
                   <span className="degree">{minutes}</span>
@@ -142,7 +174,13 @@ const CoordinatesForm: FunctionComponent = () => {
                     type="number"
                     name="latitude coordinates"
                     onChange={e =>
-                      setValues(e.target.value, rowNum, 'longitude', 'seconds')
+                      setFormValues(
+                        e.target.value,
+                        rowNum,
+                        'longitude',
+                        'seconds',
+                        'east'
+                      )
                     }
                   />
                   <span className="degree">{seconds}</span>
@@ -168,13 +206,20 @@ const CoordinatesForm: FunctionComponent = () => {
     }
   };
 
+  const setShape = () => {
+    console.log('setShape()', _formValues);
+    // TODO create polygon from formvalues!
+  };
+
   const returnSelectedContent = (): ReactElement => {
     return (
       <>
-        {latitudeLongitudeRow()}
+        {dmsRows()}
         <div className="buttons-wrapper">
           <button>Add more</button>
-          <button className="orange-button">Make shape</button>
+          <button className="orange-button" onClick={() => setShape()}>
+            Make shape
+          </button>
         </div>
       </>
     );

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -6,12 +6,14 @@ import { coordinatesContent } from '../../../../../configs/modal.config';
 import '../../../../css/CoordinatesForm';
 
 const CoordinatesForm: FunctionComponent = () => {
+  const _rows = [1, 2, 3, 4, 5, 6];
+  let _formValues = {};
   const [selectedFormat, setSelectedFormat] = useState(0);
   const selectedLanguage = useSelector(
     (state: any) => state.appState.selectedLanguage
   );
 
-  const { degree, apostrophe, quotes } = coordinatesContent;
+  const { degree, minutes, seconds } = coordinatesContent;
   const {
     title,
     dropdownTitle,
@@ -20,26 +22,95 @@ const CoordinatesForm: FunctionComponent = () => {
     longitude
   } = coordinatesContent[selectedLanguage];
 
+  const setValues = (
+    coordinateValue: string,
+    rowNum: Number,
+    coordinateType: string,
+    degreeType: string
+  ) => {
+    if (_formValues[`row${rowNum}`]) {
+      Object.defineProperty(
+        _formValues[`row${rowNum}`][coordinateType],
+        degreeType,
+        {
+          value: coordinateValue,
+          writable: true
+        }
+      );
+    } else {
+      Object.defineProperty(_formValues, `row${rowNum}`, {
+        value: {
+          [coordinateType]: {
+            [degreeType]: coordinateValue
+          }
+        },
+        writable: true
+      });
+    }
+
+    console.log('component _formValues', _formValues);
+  };
+
+  const setCardinalType = (
+    specificPoint: string,
+    rowNum: number,
+    coordinateType: string
+  ) => {
+    Object.defineProperty(
+      _formValues[`row${rowNum}`][coordinateType],
+      'cardinalPoint',
+      {
+        value: specificPoint,
+        writable: true
+      }
+    );
+    console.log('setCardinalType()', _formValues);
+  };
+
   const latitudeLongitudeRow = (): any => {
     if (decimalOptions[selectedFormat].includes('DMS')) {
-      const rows = [1, 2, 3, 4, 5, 6];
-
-      return rows.map(rowNum => {
+      return _rows.map(rowNum => {
         if (rowNum % 2 === 1) {
           return (
             <>
               <div className="dms-wrapper">
                 <span>{latitude}</span>
                 <div className="input-wrapper">
-                  <input type="number" name="latitude coordinates" />
+                  <input
+                    type="number"
+                    name="latitude coordinates"
+                    onChange={e =>
+                      setValues(e.target.value, rowNum, 'latitude', 'degree')
+                    }
+                  />
                   <span className="degree">{degree}</span>
-                  <input type="number" name="latitude coordinates" />
-                  <span className="degree">{apostrophe}</span>
-                  <input type="number" name="latitude coordinates" />
-                  <span className="degree">{quotes}</span>
-                  <select onChange={e => console.log('hmmm', e.target.value)}>
-                    <option value="N">N</option>
-                    <option value="S">S</option>
+                  <input
+                    type="number"
+                    name="latitude coordinates"
+                    onChange={e =>
+                      setValues(e.target.value, rowNum, 'latitude', 'minutes')
+                    }
+                  />
+                  <span className="degree">{minutes}</span>
+                  <input
+                    type="number"
+                    name="latitude coordinates"
+                    onChange={e =>
+                      setValues(e.target.value, rowNum, 'latitude', 'seconds')
+                    }
+                  />
+                  <span className="degree">{seconds}</span>
+                  <select
+                    onChange={e =>
+                      setCardinalType(e.target.value, rowNum, 'latitude')
+                    }
+                  >
+                    <option value="N" key={`${rowNum}a`}>
+                      N
+                    </option>
+                    <option value="S" key={`${rowNum}b`}>
+                      S
+                    </option>
                   </select>
                 </div>
               </div>
@@ -51,15 +122,41 @@ const CoordinatesForm: FunctionComponent = () => {
               <div className="dms-wrapper">
                 <span>{longitude}</span>
                 <div className="input-wrapper">
-                  <input type="number" name="latitude coordinates" />
+                  <input
+                    type="number"
+                    name="latitude coordinates"
+                    onChange={e =>
+                      setValues(e.target.value, rowNum, 'longitude', 'degree')
+                    }
+                  />
                   <span className="degree">{degree}</span>
-                  <input type="number" name="latitude coordinates" />
-                  <span className="degree">{apostrophe}</span>
-                  <input type="number" name="latitude coordinates" />
-                  <span className="degree">{quotes}</span>
-                  <select onChange={e => console.log('hmmm', e.target.value)}>
-                    <option value="E">E</option>
-                    <option value="W">W</option>
+                  <input
+                    type="number"
+                    name="latitude coordinates"
+                    onChange={e =>
+                      setValues(e.target.value, rowNum, 'longitude', 'minutes')
+                    }
+                  />
+                  <span className="degree">{minutes}</span>
+                  <input
+                    type="number"
+                    name="latitude coordinates"
+                    onChange={e =>
+                      setValues(e.target.value, rowNum, 'longitude', 'seconds')
+                    }
+                  />
+                  <span className="degree">{seconds}</span>
+                  <select
+                    onChange={e =>
+                      setCardinalType(e.target.value, rowNum, 'longitude')
+                    }
+                  >
+                    <option value="E" key={`${rowNum}a`}>
+                      E
+                    </option>
+                    <option value="W" key={`${rowNum}b`}>
+                      W
+                    </option>
                   </select>
                 </div>
               </div>

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -145,7 +145,7 @@ const CoordinatesForm: FunctionComponent = () => {
             </div>
           </div>
           <hr />
-          <div className="dds-wrapper">
+          {/* <div className="dds-wrapper">
             <div className="dds-input">
               <p>{latitude}</p>
               <div className="degree-input">
@@ -177,7 +177,7 @@ const CoordinatesForm: FunctionComponent = () => {
                 <span>{degree}</span>
               </div>
             </div>
-          </div>
+          </div> */}
           <hr />
         </>
       );

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -1,0 +1,208 @@
+import React, { FunctionComponent, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { coordinatesContent } from '../../../../../configs/modal.config';
+
+import '../../../../css/CoordinatesForm';
+
+const CoordinatesForm: FunctionComponent = () => {
+  const [selectedFormat, setSelectedFormat] = useState(0);
+  const selectedLanguage = useSelector(
+    (state: any) => state.appState.selectedLanguage
+  );
+
+  const { degree, apostrophe, quotes } = coordinatesContent;
+  const {
+    title,
+    dropdownTitle,
+    decimalOptions,
+    latitude,
+    longitude
+  } = coordinatesContent[selectedLanguage];
+
+  const returnSelectedContent = () => {
+    if (decimalOptions[selectedFormat].includes('DMS')) {
+      return (
+        <>
+          <div className="dms-wrapper">
+            <span>{latitude}</span>
+            <div className="input-wrapper">
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{degree}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{apostrophe}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{quotes}</span>
+              <select onChange={e => console.log('hmmm', e.target.value)}>
+                <option value="N">N</option>
+                <option value="S">S</option>
+              </select>
+            </div>
+          </div>
+          <div className="dms-wrapper">
+            <span>{longitude}</span>
+            <div className="input-wrapper">
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{degree}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{apostrophe}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{quotes}</span>
+              <select onChange={e => console.log('hmmm', e.target.value)}>
+                <option value="E">E</option>
+                <option value="W">W</option>
+              </select>
+            </div>
+          </div>
+          <hr />
+          <div className="dms-wrapper">
+            <span>{latitude}</span>
+            <div className="input-wrapper">
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{degree}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{apostrophe}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{quotes}</span>
+              <select onChange={e => console.log('hmmm', e.target.value)}>
+                <option value="N">N</option>
+                <option value="S">S</option>
+              </select>
+            </div>
+          </div>
+          <div className="dms-wrapper">
+            <span>{longitude}</span>
+            <div className="input-wrapper">
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{degree}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{apostrophe}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{quotes}</span>
+              <select onChange={e => console.log('hmmm', e.target.value)}>
+                <option value="E">E</option>
+                <option value="W">W</option>
+              </select>
+            </div>
+          </div>
+          <hr />
+          <div className="dms-wrapper">
+            <span>{latitude}</span>
+            <div className="input-wrapper">
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{degree}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{apostrophe}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{quotes}</span>
+              <select onChange={e => console.log('hmmm', e.target.value)}>
+                <option value="N">N</option>
+                <option value="S">S</option>
+              </select>
+            </div>
+          </div>
+          <div className="dms-wrapper">
+            <span>{longitude}</span>
+            <div className="input-wrapper">
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{degree}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{apostrophe}</span>
+              <input type="number" name="latitude coordinates" />
+              <span className="degree">{quotes}</span>
+              <select onChange={e => console.log('hmmm', e.target.value)}>
+                <option value="E">E</option>
+                <option value="W">W</option>
+              </select>
+            </div>
+          </div>
+          <hr />
+          <div className="buttons-wrapper">
+            <button>Add more</button>
+            <button className="orange-button">Make shape</button>
+          </div>
+        </>
+      );
+    }
+
+    if (decimalOptions[selectedFormat].includes('DD')) {
+      return (
+        <>
+          <div className="dds-wrapper">
+            <div className="dds-input">
+              <p>{latitude}</p>
+              <div className="degree-input">
+                <input type="number" name="latitude coordinates" />
+                <span>{degree}</span>
+              </div>
+            </div>
+            <div className="dds-input">
+              <p>{longitude}</p>
+              <div className="degree-input">
+                <input type="number" name="longitude coordinates" />
+                <span>{degree}</span>
+              </div>
+            </div>
+          </div>
+          <hr />
+          <div className="dds-wrapper">
+            <div className="dds-input">
+              <p>{latitude}</p>
+              <div className="degree-input">
+                <input type="number" name="latitude coordinates" />
+                <span>{degree}</span>
+              </div>
+            </div>
+            <div className="dds-input">
+              <p>{longitude}</p>
+              <div className="degree-input">
+                <input type="number" name="longitude coordinates" />
+                <span>{degree}</span>
+              </div>
+            </div>
+          </div>
+          <hr />
+          <div className="dds-wrapper">
+            <div className="dds-input">
+              <p>{latitude}</p>
+              <div className="degree-input">
+                <input type="number" name="latitude coordinates" />
+                <span>{degree}</span>
+              </div>
+            </div>
+            <div className="dds-input">
+              <p>{longitude}</p>
+              <div className="degree-input">
+                <input type="number" name="longitude coordinates" />
+                <span>{degree}</span>
+              </div>
+            </div>
+          </div>
+          <hr />
+        </>
+      );
+    }
+  };
+
+  return (
+    <div className="coordinates-form-container">
+      <div className="directions">
+        <div className="titles">
+          <h4 className="title">{title}</h4>
+          <p>{dropdownTitle}</p>
+        </div>
+        <select onChange={e => setSelectedFormat(Number(e.target.value))}>
+          {decimalOptions.map((option: String, index: number) => (
+            <option value={index} key={index}>
+              {option}
+            </option>
+          ))}
+        </select>
+        <hr />
+        {returnSelectedContent()}
+      </div>
+    </div>
+  );
+};
+
+export default CoordinatesForm;

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useState, ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 
 import { coordinatesContent } from '../../../../../configs/modal.config';
@@ -20,169 +20,127 @@ const CoordinatesForm: FunctionComponent = () => {
     longitude
   } = coordinatesContent[selectedLanguage];
 
-  const returnSelectedContent = () => {
+  const latitudeLongitudeRow = (): any => {
     if (decimalOptions[selectedFormat].includes('DMS')) {
-      return (
-        <>
-          <div className="dms-wrapper">
-            <span>{latitude}</span>
-            <div className="input-wrapper">
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{degree}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{apostrophe}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{quotes}</span>
-              <select onChange={e => console.log('hmmm', e.target.value)}>
-                <option value="N">N</option>
-                <option value="S">S</option>
-              </select>
-            </div>
-          </div>
-          <div className="dms-wrapper">
-            <span>{longitude}</span>
-            <div className="input-wrapper">
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{degree}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{apostrophe}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{quotes}</span>
-              <select onChange={e => console.log('hmmm', e.target.value)}>
-                <option value="E">E</option>
-                <option value="W">W</option>
-              </select>
-            </div>
-          </div>
-          <hr />
-          <div className="dms-wrapper">
-            <span>{latitude}</span>
-            <div className="input-wrapper">
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{degree}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{apostrophe}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{quotes}</span>
-              <select onChange={e => console.log('hmmm', e.target.value)}>
-                <option value="N">N</option>
-                <option value="S">S</option>
-              </select>
-            </div>
-          </div>
-          <div className="dms-wrapper">
-            <span>{longitude}</span>
-            <div className="input-wrapper">
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{degree}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{apostrophe}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{quotes}</span>
-              <select onChange={e => console.log('hmmm', e.target.value)}>
-                <option value="E">E</option>
-                <option value="W">W</option>
-              </select>
-            </div>
-          </div>
-          <hr />
-          <div className="dms-wrapper">
-            <span>{latitude}</span>
-            <div className="input-wrapper">
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{degree}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{apostrophe}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{quotes}</span>
-              <select onChange={e => console.log('hmmm', e.target.value)}>
-                <option value="N">N</option>
-                <option value="S">S</option>
-              </select>
-            </div>
-          </div>
-          <div className="dms-wrapper">
-            <span>{longitude}</span>
-            <div className="input-wrapper">
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{degree}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{apostrophe}</span>
-              <input type="number" name="latitude coordinates" />
-              <span className="degree">{quotes}</span>
-              <select onChange={e => console.log('hmmm', e.target.value)}>
-                <option value="E">E</option>
-                <option value="W">W</option>
-              </select>
-            </div>
-          </div>
-          <hr />
-          <div className="buttons-wrapper">
-            <button>Add more</button>
-            <button className="orange-button">Make shape</button>
-          </div>
-        </>
-      );
-    }
+      const rows = [1, 2, 3, 4, 5, 6];
 
-    if (decimalOptions[selectedFormat].includes('DD')) {
-      return (
-        <>
-          <div className="dds-wrapper">
-            <div className="dds-input">
-              <p>{latitude}</p>
-              <div className="degree-input">
-                <input type="number" name="latitude coordinates" />
-                <span>{degree}</span>
+      return rows.map(rowNum => {
+        if (rowNum % 2 === 1) {
+          return (
+            <>
+              <div className="dms-wrapper">
+                <span>{latitude}</span>
+                <div className="input-wrapper">
+                  <input type="number" name="latitude coordinates" />
+                  <span className="degree">{degree}</span>
+                  <input type="number" name="latitude coordinates" />
+                  <span className="degree">{apostrophe}</span>
+                  <input type="number" name="latitude coordinates" />
+                  <span className="degree">{quotes}</span>
+                  <select onChange={e => console.log('hmmm', e.target.value)}>
+                    <option value="N">N</option>
+                    <option value="S">S</option>
+                  </select>
+                </div>
               </div>
-            </div>
-            <div className="dds-input">
-              <p>{longitude}</p>
-              <div className="degree-input">
-                <input type="number" name="longitude coordinates" />
-                <span>{degree}</span>
+            </>
+          );
+        } else {
+          return (
+            <>
+              <div className="dms-wrapper">
+                <span>{longitude}</span>
+                <div className="input-wrapper">
+                  <input type="number" name="latitude coordinates" />
+                  <span className="degree">{degree}</span>
+                  <input type="number" name="latitude coordinates" />
+                  <span className="degree">{apostrophe}</span>
+                  <input type="number" name="latitude coordinates" />
+                  <span className="degree">{quotes}</span>
+                  <select onChange={e => console.log('hmmm', e.target.value)}>
+                    <option value="E">E</option>
+                    <option value="W">W</option>
+                  </select>
+                </div>
               </div>
-            </div>
-          </div>
-          <hr />
-          {/* <div className="dds-wrapper">
-            <div className="dds-input">
-              <p>{latitude}</p>
-              <div className="degree-input">
-                <input type="number" name="latitude coordinates" />
-                <span>{degree}</span>
-              </div>
-            </div>
-            <div className="dds-input">
-              <p>{longitude}</p>
-              <div className="degree-input">
-                <input type="number" name="longitude coordinates" />
-                <span>{degree}</span>
-              </div>
-            </div>
-          </div>
-          <hr />
-          <div className="dds-wrapper">
-            <div className="dds-input">
-              <p>{latitude}</p>
-              <div className="degree-input">
-                <input type="number" name="latitude coordinates" />
-                <span>{degree}</span>
-              </div>
-            </div>
-            <div className="dds-input">
-              <p>{longitude}</p>
-              <div className="degree-input">
-                <input type="number" name="longitude coordinates" />
-                <span>{degree}</span>
-              </div>
-            </div>
-          </div> */}
-          <hr />
-        </>
-      );
+              <hr />
+            </>
+          );
+        }
+      });
     }
   };
+
+  const returnSelectedContent = (): ReactElement => {
+    return (
+      <>
+        {latitudeLongitudeRow()}
+        <div className="buttons-wrapper">
+          <button>Add more</button>
+          <button className="orange-button">Make shape</button>
+        </div>
+      </>
+    );
+  };
+
+  // if (decimalOptions[selectedFormat].includes('DD')) {
+  //   return (
+  //     <>
+  //       <div className="dds-wrapper">
+  //         <div className="dds-input">
+  //           <p>{latitude}</p>
+  //           <div className="degree-input">
+  //             <input type="number" name="latitude coordinates" />
+  //             <span>{degree}</span>
+  //           </div>
+  //         </div>
+  //         <div className="dds-input">
+  //           <p>{longitude}</p>
+  //           <div className="degree-input">
+  //             <input type="number" name="longitude coordinates" />
+  //             <span>{degree}</span>
+  //           </div>
+  //         </div>
+  //       </div>
+  //       <hr />
+  //       {/* <div className="dds-wrapper">
+  //         <div className="dds-input">
+  //           <p>{latitude}</p>
+  //           <div className="degree-input">
+  //             <input type="number" name="latitude coordinates" />
+  //             <span>{degree}</span>
+  //           </div>
+  //         </div>
+  //         <div className="dds-input">
+  //           <p>{longitude}</p>
+  //           <div className="degree-input">
+  //             <input type="number" name="longitude coordinates" />
+  //             <span>{degree}</span>
+  //           </div>
+  //         </div>
+  //       </div>
+  //       <hr />
+  //       <div className="dds-wrapper">
+  //         <div className="dds-input">
+  //           <p>{latitude}</p>
+  //           <div className="degree-input">
+  //             <input type="number" name="latitude coordinates" />
+  //             <span>{degree}</span>
+  //           </div>
+  //         </div>
+  //         <div className="dds-input">
+  //           <p>{longitude}</p>
+  //           <div className="degree-input">
+  //             <input type="number" name="longitude coordinates" />
+  //             <span>{degree}</span>
+  //           </div>
+  //         </div>
+  //       </div> */}
+  //       <hr />
+  //     </>
+  //   );
+  // }
+  // };
 
   return (
     <div className="coordinates-form-container">

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -6,7 +6,7 @@ import { coordinatesContent } from '../../../../../configs/modal.config';
 import '../../../../css/CoordinatesForm';
 
 const CoordinatesForm: FunctionComponent = () => {
-  const _formValues = {};
+  const _dmsFormValues = {};
   const [selectedFormat, setSelectedFormat] = useState(0);
   const selectedLanguage = useSelector(
     (state: any) => state.appState.selectedLanguage
@@ -26,30 +26,22 @@ const CoordinatesForm: FunctionComponent = () => {
     rowNum: Number,
     coordinateType: string,
     degreeType: string,
-    direction: string
+    cardinalPoint: string
   ) => {
-    if (_formValues[`row${rowNum}`]) {
-      Object.defineProperty(
-        _formValues[`row${rowNum}`][coordinateType],
-        degreeType,
-        {
-          value: coordinateValue,
-          writable: true
-        }
-      );
+    if (_dmsFormValues[`row${rowNum}`]) {
+      _dmsFormValues[`row${rowNum}`][coordinateType][
+        degreeType
+      ] = coordinateValue;
     } else {
-      Object.defineProperty(_formValues, `row${rowNum}`, {
-        value: {
-          [coordinateType]: {
-            [degreeType]: coordinateValue,
-            direction: direction
-          }
-        },
-        writable: true
-      });
+      _dmsFormValues[`row${rowNum}`] = {
+        [coordinateType]: {
+          [degreeType]: coordinateValue,
+          cardinalPoint: cardinalPoint
+        }
+      };
     }
 
-    console.log('setFormValues()', _formValues);
+    console.log('setFormValues()', _dmsFormValues);
   };
 
   const setCardinalType = (
@@ -57,15 +49,19 @@ const CoordinatesForm: FunctionComponent = () => {
     rowNum: number,
     coordinateType: string
   ) => {
-    Object.defineProperty(
-      _formValues[`row${rowNum}`][coordinateType],
-      'cardinalPoint',
-      {
-        value: specificPoint,
-        writable: true
-      }
-    );
-    console.log('setCardinalType()', _formValues);
+    if (_dmsFormValues[`row${rowNum}`]) {
+      _dmsFormValues[`row${rowNum}`][coordinateType][
+        'cardinalPoint'
+      ] = specificPoint;
+    } else {
+      _dmsFormValues[`row${rowNum}`] = {
+        [coordinateType]: {
+          cardinalPoint: specificPoint
+        }
+      };
+    }
+
+    console.log('setCardinalType()', _dmsFormValues);
   };
 
   const dmsRows = (): any => {
@@ -125,12 +121,8 @@ const CoordinatesForm: FunctionComponent = () => {
                       setCardinalType(e.target.value, rowNum, 'latitude')
                     }
                   >
-                    <option value="N" key={`${rowNum}a`}>
-                      N
-                    </option>
-                    <option value="S" key={`${rowNum}b`}>
-                      S
-                    </option>
+                    <option value="N">N</option>
+                    <option value="S">S</option>
                   </select>
                 </div>
               </div>
@@ -189,12 +181,8 @@ const CoordinatesForm: FunctionComponent = () => {
                       setCardinalType(e.target.value, rowNum, 'longitude')
                     }
                   >
-                    <option value="E" key={`${rowNum}a`}>
-                      E
-                    </option>
-                    <option value="W" key={`${rowNum}b`}>
-                      W
-                    </option>
+                    <option value="E">E</option>
+                    <option value="W">W</option>
                   </select>
                 </div>
               </div>
@@ -207,7 +195,7 @@ const CoordinatesForm: FunctionComponent = () => {
   };
 
   const setShape = () => {
-    console.log('setShape()', _formValues);
+    console.log('setShape()', _dmsFormValues);
     // TODO create polygon from formvalues!
   };
 

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -26,7 +26,7 @@ interface DMSFormValues {
   coordinateValue: string;
   rowNum: number;
   coordinateType: string;
-  degreeType: string;
+  degreeType: number;
   cardinalPoint: string;
 }
 
@@ -201,7 +201,7 @@ const CoordinatesForm: FunctionComponent = () => {
         </select>
         <hr />
         {decimalOptions[selectedFormat].includes('DMS') &&
-          dmsSections.map((dmsSection: SpecificDMSSection) => {
+          dmsSections.map((dmsSection: SpecificDMSSection, index: number) => {
             return (
               <DMSSection
                 dmsSection={dmsSection}
@@ -210,6 +210,7 @@ const CoordinatesForm: FunctionComponent = () => {
                 degreeSymbol={degree}
                 minuteSymbol={minutes}
                 secondsSymbol={seconds}
+                key={index}
               />
             );
           })}

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -1,11 +1,11 @@
-import React, { FunctionComponent, useState, ReactElement } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import DMSSection from './coordinatesDMSSection';
+import DMSSection from 'js/components/mapWidgets/widgetContent/coordinatesDMSSection';
 
-import { coordinatesContent } from '../../../../../configs/modal.config';
+import { coordinatesContent } from 'configs/modal.config';
 
-import '../../../../css/CoordinatesForm';
+import 'css/CoordinatesForm';
 
 interface SpecificDMSSection {
   rowNum: number;

--- a/src/js/components/modal/modalCard.tsx
+++ b/src/js/components/modal/modalCard.tsx
@@ -5,6 +5,7 @@ import PrintContent from '../mapWidgets/widgetContent/printContent';
 import ShareContent from '../mapWidgets/widgetContent/shareContent';
 import PenContent from '../mapWidgets/widgetContent/penContent';
 import SearchContent from '../mapWidgets/widgetContent/searchContent';
+import CoordinatesForm from '../mapWidgets/widgetContent/coordinatesForm';
 
 import { renderModal } from '../../store/appState/actions';
 
@@ -29,6 +30,8 @@ const ModalCard: FunctionComponent<{}> = () => {
         return <ShareContent />;
       case 'PenWidget':
         return <PenContent />;
+      case 'PenWidget-CoordinatesForm':
+        return <CoordinatesForm />;
       case 'SearchWidget':
         return <SearchContent />;
       default:

--- a/src/js/components/modal/modalCard.tsx
+++ b/src/js/components/modal/modalCard.tsx
@@ -1,15 +1,15 @@
 import React, { FunctionComponent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import PrintContent from '../mapWidgets/widgetContent/printContent';
-import ShareContent from '../mapWidgets/widgetContent/shareContent';
-import PenContent from '../mapWidgets/widgetContent/penContent';
-import SearchContent from '../mapWidgets/widgetContent/searchContent';
-import CoordinatesForm from '../mapWidgets/widgetContent/coordinatesForm';
+import PrintContent from 'src/js/components/mapWidgets/widgetContent/printContent';
+import ShareContent from 'src/js/components/mapWidgets/widgetContent/shareContent';
+import PenContent from 'src/js/components/mapWidgets/widgetContent/penContent';
+import SearchContent from 'src/js/components/mapWidgets/widgetContent/searchContent';
+import CoordinatesForm from 'src/js/components/mapWidgets/widgetContent/coordinatesForm';
 
-import { renderModal } from '../../store/appState/actions';
+import { renderModal } from 'src/js/store/appState/actions';
 
-import '../../../css/modalCard.scss';
+import 'css/modalCard.scss';
 
 const ModalCard: FunctionComponent<{}> = () => {
   const modalType = useSelector((state: any) => state.appState.renderModal);

--- a/src/js/components/modal/modalCard.tsx
+++ b/src/js/components/modal/modalCard.tsx
@@ -1,13 +1,13 @@
 import React, { FunctionComponent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import PrintContent from 'src/js/components/mapWidgets/widgetContent/printContent';
-import ShareContent from 'src/js/components/mapWidgets/widgetContent/shareContent';
-import PenContent from 'src/js/components/mapWidgets/widgetContent/penContent';
-import SearchContent from 'src/js/components/mapWidgets/widgetContent/searchContent';
-import CoordinatesForm from 'src/js/components/mapWidgets/widgetContent/coordinatesForm';
+import PrintContent from 'js/components/mapWidgets/widgetContent/printContent';
+import ShareContent from 'js/components/mapWidgets/widgetContent/shareContent';
+import PenContent from 'js/components/mapWidgets/widgetContent/penContent';
+import SearchContent from 'js/components/mapWidgets/widgetContent/searchContent';
+import CoordinatesForm from 'js/components/mapWidgets/widgetContent/coordinatesForm';
 
-import { renderModal } from 'src/js/store/appState/actions';
+import { renderModal } from 'js/store/appState/actions';
 
 import 'css/modalCard.scss';
 


### PR DESCRIPTION
- `coordinatesDMSSection.tsx` returns the `DMSSection` component
    - leverages TS's `interface` to specify the shape of props
    - returns 1 section of the DMS form (1 row of latitude, 1 row of longitude)
- `coordinatesForm.tsx`
    - leverages TS's `interface` to specify the shape of props, `dmsSection` of `dmsSections`, parameter of `setDMSFormValues()` and parameter of `setDMSCardinalType()`
    - `useState()` hook has default state `dmsSections` set to an array of objects for DMS sections
    - `selectedLanguage` of Redux store is used to dynamically update content by language
   - `setDMSFormValues()` maintains property of local component state, `dmsSections`
   - `setDMSCardinalType()` maintains nested property, `cardinalPoint`,  of local component state, `dmsSections`
    - conditionally returns `<DMSSection/>` in component's return statement
- `modalCard.tsx` helper function `returnContent()` was updated to dynamically return the CoordinatesForm component
- `coordinatesContent` of `modal.config.js` config's the content of the coordinates component

- `coordinatesForm.scss`  styles the DMS section on desktop. I didn't style the DMS section on mobile since this PR was more logic-intensive. I'll create a styling ticket and complimentary feature branch down the line

- Fixes https://github.com/wri/gfw-mapbuilder/issues/730