### PR TITLE
Ticket 738 - Resolve tslint errors (not warnings)

### DIFF
--- a/src/js/components/header/Header.tsx
+++ b/src/js/components/header/Header.tsx
@@ -12,10 +12,15 @@ const Header: FunctionComponent = () => {
   return (
     <div className="header-container">
       <div className="title-container">
-        <a href={logoLinkUrl} target="_blank" rel="noreferrer" tabIndex={0}>
+        <a
+          href={logoLinkUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          tabIndex={0}
+        >
           <img
             src={logoUrl}
-            alt="image of Global Forest Watch logo"
+            alt="Global Forest Watch logo"
             className="gfw-logo"
           />
         </a>

--- a/src/js/components/header/LanguageDropdown.tsx
+++ b/src/js/components/header/LanguageDropdown.tsx
@@ -8,7 +8,7 @@ const LanguageDropdown: FunctionComponent = () => {
 
   return (
     <div className="language-dropdown-container">
-      <select onChange={e => dispatch(setLanguage(e.target.value))}>
+      <select onBlur={e => dispatch(setLanguage(e.target.value))}>
         <option value="en">English</option>
         <option value="ka">Georgian</option>
         <option value="fr">French</option>

--- a/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import 'css/CoordinatesForm';
 
-interface coordinateProps {
+interface CoordinateProps {
   degree: number;
   minutes: number;
   seconds: number;
@@ -12,8 +12,8 @@ interface coordinateProps {
 interface DMSSectionProps {
   dmsSection: {
     rowNum: number;
-    latitude: coordinateProps;
-    longitude: coordinateProps;
+    latitude: CoordinateProps;
+    longitude: CoordinateProps;
   };
   setDMSFormValues: (formValues: any) => void;
   setDMSCardinalType: (cardinalValue: any) => void;
@@ -83,7 +83,7 @@ export default function DMSSection(props: DMSSectionProps) {
           <span className="degree">{secondsSymbol}</span>
           <select
             value={latitude.cardinalPoint}
-            onChange={e =>
+            onBlur={e =>
               setDMSCardinalType({
                 specificPoint: e.target.value,
                 rowNum,
@@ -143,7 +143,7 @@ export default function DMSSection(props: DMSSectionProps) {
           <span className="degree">{secondsSymbol}</span>
           <select
             value={longitude.cardinalPoint}
-            onChange={e =>
+            onBlur={e =>
               setDMSCardinalType({
                 specificPoint: e.target.value,
                 rowNum,

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -192,8 +192,8 @@ const CoordinatesForm: FunctionComponent = () => {
           <h4 className="title">{title}</h4>
           <p>{dropdownTitle}</p>
         </div>
-        <select onChange={e => setSelectedFormat(Number(e.target.value))}>
-          {decimalOptions.map((option: String, index: number) => (
+        <select onBlur={e => setSelectedFormat(Number(e.target.value))}>
+          {decimalOptions.map((option: string, index: number) => (
             <option value={index} key={index}>
               {option}
             </option>

--- a/src/js/components/mapWidgets/widgetContent/penContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/penContent.tsx
@@ -43,7 +43,7 @@ const PenContent: FunctionComponent = () => {
             <h4>{drawTitle}</h4>
           </figcaption>
           <ol>
-            {drawInstructions.map((direction: String, i: number) => (
+            {drawInstructions.map((direction: string, i: number) => (
               <li key={i}>{direction}</li>
             ))}
           </ol>
@@ -64,7 +64,7 @@ const PenContent: FunctionComponent = () => {
             <h4>{coordinatesTitle}</h4>
           </figcaption>
           <ol>
-            {coordinatesInstructions.map((direction: String, i: number) => (
+            {coordinatesInstructions.map((direction: string, i: number) => (
               <li key={i}>{direction}</li>
             ))}
           </ol>

--- a/src/js/components/modal/modalCard.tsx
+++ b/src/js/components/modal/modalCard.tsx
@@ -50,9 +50,11 @@ const ModalCard: FunctionComponent<{}> = () => {
 
   return (
     <>
-      <div
+      <div // eslint-disable-line
         className="dim-container"
         onClick={() => dispatch(renderModal(''))}
+        onKeyDown={() => dispatch(renderModal(''))}
+        role="dialog"
       ></div>
       <div className={`modal-card-container ${className}`}>
         <button

--- a/src/js/components/modal/modalCard.tsx
+++ b/src/js/components/modal/modalCard.tsx
@@ -47,14 +47,14 @@ const ModalCard: FunctionComponent<{}> = () => {
     default:
       break;
   }
-
   return (
     <>
-      <div // eslint-disable-line
+      <div
         className="dim-container"
         onClick={() => dispatch(renderModal(''))}
         onKeyDown={() => dispatch(renderModal(''))}
-        role="dialog"
+        role="button"
+        tabIndex={0}
       ></div>
       <div className={`modal-card-container ${className}`}>
         <button


### PR DESCRIPTION
* Resolved `tslint`/`a11y` errors related to;
    - using `onBlur` instead of `onChange`
    - using `rel` and `alt` correctly
    - proper casing of interface names
    - setting `role` and using `onKeyDown`

* Fixes https://github.com/wri/gfw-mapbuilder/issues/738