### PR TITLE
Consistent casing rule addition

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     "noUnusedLocals": false,
     "importHelpers": true,
     "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
     "types": ["arcgis-js-api", "moment", "node"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
- Adding `forceConsistentCasingInFileNames ` which does : "Disallow inconsistently-cased references to the same file." [https://www.typescriptlang.org/docs/handbook/compiler-options.html](Docs)
- This will partially solve issues when we import files/components with incorrect casing. Eg: `import Comp from './comp.tsx` and our file name is `Comp.tsx`. Problem is that it compiles okay locally but GH action fails. Eslint is not picking it up, this option should cover some if not most cases.

Error example:
![image](https://user-images.githubusercontent.com/12076555/73848209-b1934600-47f5-11ea-8162-cde803ee8c93.png)
