### PR TITLE
Resource layers to map

### DIFF
--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -8,6 +8,8 @@
   width: 300px;
   background: $white;
   box-shadow: 0px 1px 2px rgba(85, 85, 85, 0.25);
+  height: calc(100% - 250px);
+  overflow-y: auto;
 }
 
 .tab-header-container {

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -10,6 +10,7 @@ import SketchViewModel from 'esri/widgets/Sketch/SketchViewModel';
 import { RefObject } from 'react';
 import store from '../store/index';
 import { TreeCoverLossLayer } from 'js/layers/TreeCoverLossLayer';
+import { TreeCoverGainLayer } from 'js/layers/TreeCoverGainLayer';
 
 import {
   allAvailableLayers,
@@ -19,7 +20,7 @@ import {
 import { selectActiveTab, toggleTabviewPanel } from 'js/store/appState/actions';
 import { LayerProps } from 'js/store/mapview/types';
 
-const allowedLayers = ['feature', 'dynamic', 'loss']; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
+const allowedLayers = ['feature', 'dynamic', 'loss', 'gain']; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
 
 interface ZoomParams {
   zoomIn: boolean;
@@ -314,7 +315,15 @@ export class MapController {
           urlTemplate: layerConfig.url,
           view: this._mapview
         });
-
+        break;
+      case 'gain':
+        esriLayer = new TreeCoverGainLayer({
+          id: layerConfig.id,
+          title: layerConfig.title,
+          visible: layerConfig.visible,
+          urlTemplate: layerConfig.url,
+          view: this._mapview
+        });
         break;
       default:
         // throw new Error('No matching layer type!')

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -9,6 +9,8 @@ import MapImageLayer from 'esri/layers/MapImageLayer';
 import SketchViewModel from 'esri/widgets/Sketch/SketchViewModel';
 import { RefObject } from 'react';
 import store from '../store/index';
+import { TreeCoverLossLayer } from 'js/layers/TreeCoverLossLayer';
+
 import {
   allAvailableLayers,
   mapError,
@@ -17,7 +19,7 @@ import {
 import { selectActiveTab, toggleTabviewPanel } from 'js/store/appState/actions';
 import { LayerProps } from 'js/store/mapview/types';
 
-const allowedLayers = ['feature', 'dynamic']; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
+const allowedLayers = ['feature', 'dynamic', 'loss']; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
 
 interface ZoomParams {
   zoomIn: boolean;
@@ -303,6 +305,16 @@ export class MapController {
           visible: layerConfig.visible,
           url: layerConfig.url
         });
+        break;
+      case 'loss':
+        esriLayer = new TreeCoverLossLayer({
+          id: layerConfig.id,
+          title: layerConfig.title,
+          visible: layerConfig.visible,
+          urlTemplate: layerConfig.url,
+          view: this._mapview
+        });
+
         break;
       default:
         // throw new Error('No matching layer type!')

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -17,7 +17,7 @@ import {
 import { selectActiveTab, toggleTabviewPanel } from 'js/store/appState/actions';
 import { LayerProps } from 'js/store/mapview/types';
 
-const allowedLayers = ['feature', 'dynamic'];
+const allowedLayers = ['feature', 'dynamic']; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
 
 interface ZoomParams {
   zoomIn: boolean;

--- a/src/js/helpers/LayerFactory.ts
+++ b/src/js/helpers/LayerFactory.ts
@@ -1,6 +1,66 @@
+// import MapView from 'esri/views/MapView';
 import Layer from 'esri/layers/Layer';
+import ImageryLayer from 'esri/layers/ImageryLayer';
+import FeatureLayer from 'esri/layers/FeatureLayer';
+import MapImageLayer from 'esri/layers/MapImageLayer';
+import { TreeCoverLossLayer } from 'js/layers/TreeCoverLossLayer';
+import { TreeCoverGainLayer } from 'js/layers/TreeCoverGainLayer';
 
-export function LayerFactory(): Layer | Error {
-  // return 'hey';
-  return new Layer();
+import { LayerFactoryObject } from 'js/interfaces/mapping';
+
+export function LayerFactory(
+  mapView: any,
+  layerConfig: LayerFactoryObject
+): Layer {
+  let esriLayer;
+  switch (layerConfig.type) {
+    case 'dynamic':
+      esriLayer = new MapImageLayer({
+        id: layerConfig.id,
+        title: layerConfig.title,
+        visible: layerConfig.visible,
+        url: layerConfig.url
+      });
+      break;
+    case 'image':
+      esriLayer = new ImageryLayer({
+        id: layerConfig.id,
+        title: layerConfig.title,
+        visible: layerConfig.visible,
+        url: layerConfig.url
+      });
+      break;
+    case 'feature':
+      esriLayer = new FeatureLayer({
+        id: layerConfig.id,
+        title: layerConfig.title,
+        visible: layerConfig.visible,
+        url: layerConfig.url
+      });
+      break;
+    case 'loss':
+      esriLayer = new TreeCoverLossLayer({
+        id: layerConfig.id,
+        title: layerConfig.title,
+        visible: layerConfig.visible,
+        urlTemplate: layerConfig.url,
+        view: mapView
+      });
+      break;
+    case 'gain':
+      esriLayer = new TreeCoverGainLayer({
+        id: layerConfig.id,
+        title: layerConfig.title,
+        visible: layerConfig.visible,
+        urlTemplate: layerConfig.url,
+        view: mapView
+      });
+      break;
+    default:
+      // throw new Error('No matching layer type!')
+      console.error('No error type!');
+      break;
+  }
+
+  return esriLayer;
 }

--- a/src/js/helpers/LayerFactory.ts
+++ b/src/js/helpers/LayerFactory.ts
@@ -1,0 +1,6 @@
+import Layer from 'esri/layers/Layer';
+
+export function LayerFactory(): Layer | Error {
+  // return 'hey';
+  return new Layer();
+}

--- a/src/js/interfaces/mapping.ts
+++ b/src/js/interfaces/mapping.ts
@@ -1,0 +1,9 @@
+export interface LayerFactoryObject {
+    id: string;
+    title: string;
+    opacity: number;
+    visible: boolean;
+    definitionExpression: string | undefined;
+    url: string;
+    type: string;
+}

--- a/src/js/interfaces/mapping.ts
+++ b/src/js/interfaces/mapping.ts
@@ -1,9 +1,9 @@
 export interface LayerFactoryObject {
-    id: string;
-    title: string;
-    opacity: number;
-    visible: boolean;
-    definitionExpression: string | undefined;
-    url: string;
-    type: string;
+  id: string;
+  title: string;
+  opacity: number;
+  visible: boolean;
+  definitionExpression: string | undefined;
+  url: string;
+  type: string;
 }

--- a/src/js/layers/TreeCoverGainLayer.ts
+++ b/src/js/layers/TreeCoverGainLayer.ts
@@ -1,0 +1,53 @@
+// @ts-nocheck
+
+import BaseTileLayer from 'esri/layers/BaseTileLayer';
+import esriRequest from 'esri/request';
+import Color from 'esri/Color';
+
+export const TreeCoverGainLayer: any = BaseTileLayer.createSubclass({
+  properties: {
+    urlTemplate: null
+  },
+
+  getTileUrl: function(level: number, row: number, column: number) {
+    return this.urlTemplate
+      .replace('{z}', level)
+      .replace('{x}', column)
+      .replace('{y}', row);
+  },
+
+  fetchTile: function(level: number, row: number, column: number) {
+    // call getTileUrl() method to construct the URL to tiles
+    // for a given level, row and col provided by the LayerView
+    const url = this.getTileUrl(level, row, column);
+    // request for tiles based on the generated url
+    // set allowImageDataAccess to true to allow
+    // cross-domain access to create WebGL textures for 3D.
+
+    // request for tiles based on the generated url
+    // the signal option ensures that obsolete requests are aborted
+    return esriRequest(url, {
+      responseType: 'image',
+      allowImageDataAccess: true
+    }).then(
+      function(response) {
+        // when esri request resolves successfully
+        // get the image from the response
+        const image = response.data;
+        const width = this.tileInfo.size[0];
+        const height = this.tileInfo.size[0];
+
+        // create a canvas with 2D rendering context
+        const canvas = document.createElement('canvas');
+        const context = canvas.getContext('2d');
+        canvas.width = width;
+        canvas.height = height;
+
+        // Draw the blended image onto the canvas.
+        context.drawImage(image, 0, 0, width, height);
+
+        return canvas;
+      }.bind(this)
+    );
+  }
+});

--- a/src/js/layers/TreeCoverLossLayer.ts
+++ b/src/js/layers/TreeCoverLossLayer.ts
@@ -1,0 +1,143 @@
+// @ts-nocheck
+
+import BaseTileLayer from 'esri/layers/BaseTileLayer';
+import esriRequest from 'esri/request';
+
+// Power function to determine intensity
+const getScalePowFunc = (exp: number) => {
+  // y = m * x ^ k + b
+  const domain = [0, 256];
+  const range = [0, 256];
+  const b = range[0] - domain[0];
+  const m = (range[1] - b) / Math.pow(domain[1], exp);
+
+  return (x: number): number => {
+    return Math.pow(x, exp) * m + b;
+  };
+};
+
+const intensityBank = {};
+// Populate the intensity bank
+for (let z = 1; z < 21; z++) {
+  //each zoom level on the map
+  intensityBank[z] = [];
+  const exp = z < 11 ? 0.3 + (z - 3) / 20 : 1;
+  const lMoney = getScalePowFunc(exp);
+  for (let f = 0; f < 256; f++) {
+    //each potential intensity value
+    intensityBank[z][f] = [];
+    intensityBank[z][f].push(33 - z + 153 - lMoney(f) / z);
+    intensityBank[z][f].push(z < 13 ? lMoney(f) : f);
+    intensityBank[z][f].push(220);
+    intensityBank[z][f].push(72 - z + 102 - (3 * lMoney(f)) / z);
+  }
+}
+
+export const TreeCoverLossLayer: any = BaseTileLayer.createSubclass({
+  properties: {
+    threshold: 30,
+    minYear: 2001,
+    maxYear: 2018 //config.latestTreeCoverLossYearFC
+  },
+
+  getTileUrl: function(level: number, row: number, column: number) {
+    return this.urlTemplate
+      .replace('{z}', level)
+      .replace('{x}', column)
+      .replace('{y}', row)
+      .replace('{thresh}', this.threshold);
+  },
+
+  fetchTile: function(level: number, row: number, column: number) {
+    // call getTileUrl() method to construct the URL to tiles
+    // for a given level, row and col provided by the LayerView
+    const url = this.getTileUrl(level, row, column);
+    // request for tiles based on the generated url
+    // set allowImageDataAccess to true to allow
+    // cross-domain access to create WebGL textures for 3D.
+    return esriRequest(url, {
+      responseType: 'image',
+      allowImageDataAccess: true
+    }).then((response: any) => {
+      const image = response.data;
+      const width = this.tileInfo.size[0];
+      const height = this.tileInfo.size[0];
+
+      const canvas = document.createElement('canvas');
+      const context = canvas.getContext('2d');
+      canvas.width = width;
+      canvas.height = height;
+
+      const imageObject = new Image();
+      imageObject.crossOrigin = 'Anonymous';
+
+      imageObject.onload = () => {
+        context?.drawImage(imageObject, 0, 0, width, height);
+        const imageData = context?.getImageData(0, 0, width, height);
+        imageData?.data.set(this.filter(imageData.data));
+        context?.putImageData(imageData, 0, 0);
+      };
+      imageObject.src = image.src;
+      return canvas;
+    });
+  },
+
+  // Filter Data Method
+  filter: function(data: []) {
+    const z = this.view.zoom;
+
+    for (let i = 0; i < data.length; i += 4) {
+      // Decode the rgba/pixel so I can filter on date ranges
+      const slice = [data[i], data[i + 1], data[i + 2]];
+      const values = this.decodeDate(slice);
+
+      if (!values.intensity) {
+        values.intensity = 0;
+      }
+      if (
+        values.year >= this.minYear - 2000 &&
+        values.year <= this.maxYear - 2000
+      ) {
+        if (intensityBank[z] && intensityBank[z][values.intensity]) {
+          data[i] =
+            intensityBank[z] &&
+            intensityBank[z][values.intensity] &&
+            intensityBank[z][values.intensity][2]
+              ? intensityBank[z][values.intensity][2]
+              : 0;
+          data[i + 1] =
+            intensityBank[z] &&
+            intensityBank[z][values.intensity] &&
+            intensityBank[z][values.intensity][3]
+              ? intensityBank[z][values.intensity][3]
+              : 0;
+          data[i + 2] =
+            intensityBank[z] &&
+            intensityBank[z][values.intensity] &&
+            intensityBank[z][values.intensity][0]
+              ? intensityBank[z][values.intensity][0]
+              : 0;
+          data[i + 3] =
+            intensityBank[z] &&
+            intensityBank[z][values.intensity] &&
+            intensityBank[z][values.intensity][1]
+              ? intensityBank[z][values.intensity][1]
+              : 0;
+        }
+      } else {
+        // Hide the pixel
+        data[i + 3] = 0;
+        data[i + 2] = 0;
+        data[i + 1] = 0;
+        data[i] = 0;
+      }
+    }
+    return data;
+  },
+
+  decodeDate: function(pixel: []) {
+    const year = pixel[2];
+    const intensity = pixel[0];
+    return { intensity, year };
+  }
+});


### PR DESCRIPTION
- Sync's up our mapLayers with the layer checkboxes
- Removes layerPanel overflow
- Removes layers and their checkboxes for layers of most types (for now)

**Update!**
- Allows for custom layer types
- Creates examples of two:
1. A layer that does not require any outside UI for filtering
2. A filterable layer that re-renders based on internal property changes which will fire based off of map interactions

-- Also we hoisted all of this action to a `layerFactory` helper!