### PR TITLE
Ticket 751 - Hide widget logic

### DIFF
--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -12,6 +12,10 @@
 
 .tab-header-container {
   display: flex;
+
+  &.tab-header-hidden {
+    display: none;
+  }
 }
 
 .tab-button {

--- a/src/js/components/leftPanel/LeftPanel.tsx
+++ b/src/js/components/leftPanel/LeftPanel.tsx
@@ -80,6 +80,10 @@ const Tabs = (props: TabsProps): React.ReactElement => {
     (store: RootState) => store.appState.leftPanel.activeTab
   );
 
+  const isTabVisible = useSelector(
+    (store: RootState) => store.appState.leftPanel.tabVisible
+  );
+
   const tabsGroupRow = props.tabsToRender.map(tab => (
     <Tab
       key={tab.label}
@@ -89,7 +93,14 @@ const Tabs = (props: TabsProps): React.ReactElement => {
       activeTab={savedActiveTab}
     />
   ));
-  return <div className="tab-header-container">{tabsGroupRow}</div>;
+
+  const test = () => {
+    if (isTabVisible) {
+      return <div className="tab-header-container">{tabsGroupRow}</div>;
+    }
+  };
+
+  return { test };
 };
 
 const LeftPanel = (): React.ReactElement => {

--- a/src/js/components/leftPanel/LeftPanel.tsx
+++ b/src/js/components/leftPanel/LeftPanel.tsx
@@ -80,8 +80,8 @@ const Tabs = (props: TabsProps): React.ReactElement => {
     (store: RootState) => store.appState.leftPanel.activeTab
   );
 
-  const isTabVisible = useSelector(
-    (store: RootState) => store.appState.leftPanel.tabVisible
+  const { tabVisible } = useSelector(
+    (store: RootState) => store.appState.leftPanel
   );
 
   const tabsGroupRow = props.tabsToRender.map(tab => (
@@ -97,7 +97,7 @@ const Tabs = (props: TabsProps): React.ReactElement => {
   return (
     <div
       className={`tab-header-container ${
-        isTabVisible ? '' : 'tab-header-hidden'
+        tabVisible ? '' : 'tab-header-hidden'
       }`}
     >
       {tabsGroupRow}

--- a/src/js/components/leftPanel/LeftPanel.tsx
+++ b/src/js/components/leftPanel/LeftPanel.tsx
@@ -94,13 +94,15 @@ const Tabs = (props: TabsProps): React.ReactElement => {
     />
   ));
 
-  const test = () => {
-    if (isTabVisible) {
-      return <div className="tab-header-container">{tabsGroupRow}</div>;
-    }
-  };
-
-  return { test };
+  return (
+    <div
+      className={`tab-header-container ${
+        isTabVisible ? '' : 'tab-header-hidden'
+      }`}
+    >
+      {tabsGroupRow}
+    </div>
+  );
 };
 
 const LeftPanel = (): React.ReactElement => {

--- a/src/js/components/mapWidgets/hideWidget.tsx
+++ b/src/js/components/mapWidgets/hideWidget.tsx
@@ -16,15 +16,9 @@ const HideWidget: FunctionComponent = () => {
   );
 
   const toggleContent = (): void => {
-    if (tabViewVisible) {
-      dispatch(toggleTabviewPanel(false));
-      dispatch(toggleTab(false));
-      mapController.toggleLegend(false);
-    } else {
-      dispatch(toggleTabviewPanel(true));
-      dispatch(toggleTab(true));
-      mapController.toggleLegend(true);
-    }
+    dispatch(toggleTabviewPanel(!tabViewVisible));
+    dispatch(toggleTab(!tabViewVisible));
+    mapController.toggleLegend(!tabViewVisible);
   };
 
   return (

--- a/src/js/components/mapWidgets/hideWidget.tsx
+++ b/src/js/components/mapWidgets/hideWidget.tsx
@@ -17,14 +17,13 @@ const HideWidget: FunctionComponent = () => {
   const toggleContent = (): void => {
     if (tabViewVisible) {
       // [X] toggle left panel content
-      // [ ] toggle layer panel buttons
+      // [X] toggle layer panel buttons
       // [ ] toggle legend
       dispatch(toggleTabviewPanel(false));
       dispatch(toggleTab(false));
-      // turn off
     } else {
-      // turn on!
       dispatch(toggleTabviewPanel(true));
+      dispatch(toggleTab(true));
     }
   };
 

--- a/src/js/components/mapWidgets/hideWidget.tsx
+++ b/src/js/components/mapWidgets/hideWidget.tsx
@@ -3,12 +3,13 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import { toggleTabviewPanel, toggleTab } from 'js/store/appState/actions';
 
+import { mapController } from 'js/controllers/mapController';
+
 import { RootState } from 'js/store/index';
 
 import { ReactComponent as HideIcon } from '../../../images/hideIcon.svg';
 
 const HideWidget: FunctionComponent = () => {
-  // TODO connect to Redux to toggle leftPanel and Legend
   const dispatch = useDispatch();
   const { tabViewVisible } = useSelector(
     (state: RootState) => state.appState.leftPanel
@@ -16,14 +17,13 @@ const HideWidget: FunctionComponent = () => {
 
   const toggleContent = (): void => {
     if (tabViewVisible) {
-      // [X] toggle left panel content
-      // [X] toggle layer panel buttons
-      // [ ] toggle legend
       dispatch(toggleTabviewPanel(false));
       dispatch(toggleTab(false));
+      mapController.toggleLegend(false);
     } else {
       dispatch(toggleTabviewPanel(true));
       dispatch(toggleTab(true));
+      mapController.toggleLegend(true);
     }
   };
 

--- a/src/js/components/mapWidgets/hideWidget.tsx
+++ b/src/js/components/mapWidgets/hideWidget.tsx
@@ -1,17 +1,37 @@
 import React, { FunctionComponent } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import { toggleTabviewPanel, toggleTab } from 'js/store/appState/actions';
+
+import { RootState } from 'js/store/index';
 
 import { ReactComponent as HideIcon } from '../../../images/hideIcon.svg';
 
 const HideWidget: FunctionComponent = () => {
   // TODO connect to Redux to toggle leftPanel and Legend
+  const dispatch = useDispatch();
+  const { tabViewVisible } = useSelector(
+    (state: RootState) => state.appState.leftPanel
+  );
+
+  const toggleContent = (): void => {
+    if (tabViewVisible) {
+      // [X] toggle left panel content
+      // [ ] toggle layer panel buttons
+      // [ ] toggle legend
+      dispatch(toggleTabviewPanel(false));
+      dispatch(toggleTab(false));
+      // turn off
+    } else {
+      // turn on!
+      dispatch(toggleTabviewPanel(true));
+    }
+  };
 
   return (
     <>
       <div className="widget-container">
-        <button
-          className="image-wrapper"
-          onClick={() => console.log('hide legend and left panel!')}
-        >
+        <button className="image-wrapper" onClick={toggleContent}>
           <HideIcon height={25} width={25} fill={'#555'} />
         </button>
       </div>

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -46,12 +46,14 @@ export class MapController {
   _mapview: MapView | undefined;
   _sketchVM: SketchViewModel | undefined;
   _previousSketchGraphic: any;
+  _legend: Legend | undefined;
 
   constructor() {
     this._map = undefined;
     this._mapview = undefined;
     this._sketchVM = undefined;
     this._previousSketchGraphic = undefined;
+    this._legend = undefined;
   }
 
   initializeMap(domRef: RefObject<any>): void {
@@ -67,11 +69,11 @@ export class MapController {
       container: domRef.current
     });
 
-    const legend = new Legend({
+    this._legend = new Legend({
       view: this._mapview
     });
 
-    this._mapview.ui.add(legend, 'bottom-right');
+    this._mapview.ui.add(this._legend, 'bottom-right');
 
     this._mapview
       .when(
@@ -350,6 +352,16 @@ export class MapController {
   createPolygonSketch = () => {
     this._mapview?.graphics.remove(this._previousSketchGraphic);
     this._sketchVM?.create('polygon', { mode: 'freehand' });
+  };
+
+  toggleLegend = (legendActive: boolean): void => {
+    if (legendActive && this._legend) {
+      this._mapview?.ui.add(this._legend, 'bottom-right');
+    }
+
+    if (legendActive === false && this._legend) {
+      this._mapview?.ui.remove(this._legend);
+    }
   };
 }
 

--- a/src/js/store/appState/actions.ts
+++ b/src/js/store/appState/actions.ts
@@ -1,5 +1,6 @@
 import {
   TOGGLE_TABVIEW_PANEL,
+  TOGGLE_TAB,
   RENDER_MODAL,
   SELECT_ACTIVE_TAB,
   SET_LANGUAGE,
@@ -11,6 +12,13 @@ import {
 export function toggleTabviewPanel(payload: LeftPanel['tabViewVisible']) {
   return {
     type: TOGGLE_TABVIEW_PANEL as typeof TOGGLE_TABVIEW_PANEL,
+    payload: payload
+  };
+}
+
+export function toggleTab(payload: LeftPanel['tabVisible']) {
+  return {
+    type: TOGGLE_TAB as typeof TOGGLE_TAB,
     payload: payload
   };
 }

--- a/src/js/store/appState/reducers.ts
+++ b/src/js/store/appState/reducers.ts
@@ -5,13 +5,15 @@ import {
   SELECT_ACTIVE_TAB,
   SET_LANGUAGE,
   RENDER_MODAL,
-  SET_OPEN_LAYER_GROUP
+  SET_OPEN_LAYER_GROUP,
+  TOGGLE_TAB
 } from './types';
 
 const initialState: AppState = {
   selectedLanguage: 'en',
   renderModal: '',
   leftPanel: {
+    tabVisible: true,
     tabViewVisible: true,
     activeTab: 'layers',
     openLayerGroup: 'GROUP_WEBMAP'
@@ -29,6 +31,14 @@ export function appStateReducer(
         leftPanel: {
           ...state.leftPanel,
           tabViewVisible: action.payload
+        }
+      };
+    case TOGGLE_TAB:
+      return {
+        ...state,
+        leftPanel: {
+          ...state.leftPanel,
+          tabVisible: action.payload
         }
       };
     case RENDER_MODAL:

--- a/src/js/store/appState/types.ts
+++ b/src/js/store/appState/types.ts
@@ -1,4 +1,5 @@
 export interface LeftPanel {
+  tabVisible: boolean;
   tabViewVisible: boolean;
   activeTab: string;
   openLayerGroup: string;
@@ -15,6 +16,7 @@ export const RENDER_MODAL = 'RENDER_MODAL';
 export const SELECT_ACTIVE_TAB = 'SELECT_ACTIVE_TAB';
 export const SET_LANGUAGE = 'SET_LANGUAGE';
 export const TOGGLE_TABVIEW_PANEL = 'TOGGLE_TABVIEW_PANEL';
+export const TOGGLE_TAB = 'TOGGLE_TAB';
 export const SET_OPEN_LAYER_GROUP = 'SET_OPEN_LAYER_GROUP';
 
 interface SetOpenLayerGroup {
@@ -25,6 +27,11 @@ interface SetOpenLayerGroup {
 interface ToggleTabviewPanelAction {
   type: typeof TOGGLE_TABVIEW_PANEL;
   payload: LeftPanel['tabViewVisible'];
+}
+
+interface ToggleTab {
+  type: typeof TOGGLE_TAB;
+  payload: LeftPanel['tabVisible'];
 }
 
 interface RenderModalAction {
@@ -47,4 +54,5 @@ export type AppStateTypes =
   | RenderModalAction
   | SelectActiveTab
   | SetLanguageAction
-  | SetOpenLayerGroup;
+  | SetOpenLayerGroup
+  | ToggleTab;


### PR DESCRIPTION
- `hideWidget.tsx`
    - `toggleContent()` conditionally toggles tabview, tab and legend
        - actionCreator `toggleTabviewPanel()` toggles tabview 
        - actionCreator `toggleTab()` toggles tabs
        - mapController.toggleLegend() toggles legend
- `LeftPanel.tsx` listens to `tabVisible` via `useSelector()` redux hook. `tabVisible` conditionally adds and removes `.tab-header-hidden` (hiding tab header)
- `mapController.js`
    - `this._legend` was hoisted to the global scope in order to toggle it on/off
    - `toggleLegend()` - adds/removes legend instance via `this._mapview?.ui.add` and `this._mapview?.ui.remove`. Uses optional chaining (instead of the non-null operator) to prevent edge cases where the mapview or legend are undefined. Good catch @vaidotasp !
- Redux store logic
    - new actionType `TOGGLE_TAB`
    - new actionCreator`toggleTab()` is used to toggle the left panel tabs
    - `AppState.leftPanel` has new property, `tabVisible` that manages tab state
    - reducer updated with new logic to maintain `tabVisible`


- Fixes https://github.com/wri/gfw-mapbuilder/issues/751