### PR TITLE
Ticket 760 - change onBlur() to onChange()

### DIFF
--- a/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
@@ -99,7 +99,7 @@ export default function DMSSection(props: DMSSectionProps): JSX.Element {
           <span className="degree">{secondsSymbol}</span>
           <select
             value={latitude.cardinalPoint}
-            onBlur={e =>
+            onChange={e =>
               setDMSCardinalType({
                 specificPoint: e.target.value,
                 rowNum,
@@ -159,7 +159,7 @@ export default function DMSSection(props: DMSSectionProps): JSX.Element {
           <span className="degree">{secondsSymbol}</span>
           <select
             value={longitude.cardinalPoint}
-            onBlur={e =>
+            onChange={e =>
               setDMSCardinalType({
                 specificPoint: e.target.value,
                 rowNum,

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -212,7 +212,7 @@ const CoordinatesForm: FunctionComponent = () => {
           <h4 className="title">{title}</h4>
           <p>{dropdownTitle}</p>
         </div>
-        <select onBlur={e => setSelectedFormat(Number(e.target.value))}>
+        <select onChange={e => setSelectedFormat(Number(e.target.value))}>
           {decimalOptions.map((option: string, index: number) => (
             <option value={index} key={index}>
               {option}

--- a/src/js/components/mapWidgets/widgetContent/measureContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/measureContent.tsx
@@ -229,7 +229,6 @@ const MeasureContent: FunctionComponent = () => {
                 | DistanceMeasurement2D['unit']
             )
           }
-          onBlur={(): void => console.log('Bonjour, onBlur!')}
           disabled={activeButton === '' ? true : false}
         >
           {returnDropdown()}

--- a/src/js/components/mapWidgets/widgetContent/printContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/printContent.tsx
@@ -27,10 +27,7 @@ const PrintContent: FunctionComponent = () => {
     <div>
       <div className="directions">
         <p>{buttonLabel}</p>
-        <select
-          onBlur={(e): Promise<void> => printMap(e.target.value)}
-          onChange={(e): Promise<void> => printMap(e.target.value)}
-        >
+        <select onChange={(e): Promise<void> => printMap(e.target.value)}>
           <option value={''}>{dropdownLabel}</option>
           {printOptions.map((printOption: string, index: string) => {
             return <option key={index}>{printOption}</option>;


### PR DESCRIPTION
- Replace `onBlur` with `onChange` since `onBlur` event listener doesn't manage state consistently and fires functions in `select` dropdowns when the user clicks outside of the select dropdown to close it.
- Fixes https://github.com/wri/gfw-mapbuilder/issues/760