### PR TITLE
Ticket 806 - pen widget - user input form

### DIFF
--- a/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
@@ -1,17 +1,10 @@
 import React from 'react';
 
-import { DMSFormValues } from './coordinatesForm';
+import { DMSFormValues, CoordinateProps } from 'js/interfaces/coordinateForm';
 
 import { ReactComponent as TrashCanIcon } from 'images/trashCanIcon.svg';
 
 import 'css/coordinatesForm';
-
-interface CoordinateProps {
-  degree: string;
-  minutes: string;
-  seconds: string;
-  cardinalPoint: string;
-}
 
 interface DMSSectionProps {
   dmsSection: {

--- a/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesDMSSection.tsx
@@ -7,9 +7,9 @@ import { ReactComponent as TrashCanIcon } from 'images/trashCanIcon.svg';
 import 'css/coordinatesForm';
 
 interface CoordinateProps {
-  degree: number;
-  minutes: number;
-  seconds: number;
+  degree: string;
+  minutes: string;
+  seconds: string;
   cardinalPoint: string;
 }
 
@@ -61,7 +61,7 @@ export default function DMSSection(props: DMSSectionProps): JSX.Element {
             value={latitude.degree}
             onChange={(e): void =>
               setDMSFormValues({
-                coordinateValue: Number(e.target.value),
+                coordinateValue: e.target.value,
                 rowNum,
                 coordinateType: 'latitude',
                 degreeType: 'degree'
@@ -75,7 +75,7 @@ export default function DMSSection(props: DMSSectionProps): JSX.Element {
             value={latitude.minutes}
             onChange={(e): void =>
               setDMSFormValues({
-                coordinateValue: Number(e.target.value),
+                coordinateValue: e.target.value,
                 rowNum,
                 coordinateType: 'latitude',
                 degreeType: 'minutes'
@@ -89,7 +89,7 @@ export default function DMSSection(props: DMSSectionProps): JSX.Element {
             value={latitude.seconds}
             onChange={(e): void =>
               setDMSFormValues({
-                coordinateValue: Number(e.target.value),
+                coordinateValue: e.target.value,
                 rowNum,
                 coordinateType: 'latitude',
                 degreeType: 'seconds'
@@ -99,7 +99,7 @@ export default function DMSSection(props: DMSSectionProps): JSX.Element {
           <span className="degree">{secondsSymbol}</span>
           <select
             value={latitude.cardinalPoint}
-            onChange={e =>
+            onChange={(e): void =>
               setDMSCardinalType({
                 specificPoint: e.target.value,
                 rowNum,
@@ -121,7 +121,7 @@ export default function DMSSection(props: DMSSectionProps): JSX.Element {
             value={longitude.degree}
             onChange={(e): void =>
               setDMSFormValues({
-                coordinateValue: Number(e.target.value),
+                coordinateValue: e.target.value,
                 rowNum,
                 coordinateType: 'longitude',
                 degreeType: 'degree'
@@ -135,7 +135,7 @@ export default function DMSSection(props: DMSSectionProps): JSX.Element {
             value={longitude.minutes}
             onChange={(e): void =>
               setDMSFormValues({
-                coordinateValue: Number(e.target.value),
+                coordinateValue: e.target.value,
                 rowNum,
                 coordinateType: 'longitude',
                 degreeType: 'minutes'
@@ -149,7 +149,7 @@ export default function DMSSection(props: DMSSectionProps): JSX.Element {
             value={longitude.seconds}
             onChange={(e): void =>
               setDMSFormValues({
-                coordinateValue: Number(e.target.value),
+                coordinateValue: e.target.value,
                 rowNum,
                 coordinateType: 'longitude',
                 degreeType: 'seconds'
@@ -159,7 +159,7 @@ export default function DMSSection(props: DMSSectionProps): JSX.Element {
           <span className="degree">{secondsSymbol}</span>
           <select
             value={longitude.cardinalPoint}
-            onChange={e =>
+            onChange={(e): void =>
               setDMSCardinalType({
                 specificPoint: e.target.value,
                 rowNum,

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -14,20 +14,20 @@ import 'css/coordinatesForm';
 export interface SpecificDMSSection {
   rowNum: number;
   latitude: {
-    degree: number;
-    minutes: number;
-    seconds: number;
+    degree: string;
+    minutes: string;
+    seconds: string;
     cardinalPoint: string;
   };
   longitude: {
-    degree: number;
-    minutes: number;
-    seconds: number;
+    degree: string;
+    minutes: string;
+    seconds: string;
     cardinalPoint: string;
   };
 }
 export interface DMSFormValues {
-  coordinateValue: number;
+  coordinateValue: string;
   rowNum: number;
   coordinateType: string;
   degreeType: string;
@@ -46,45 +46,45 @@ const CoordinatesForm: FunctionComponent = () => {
     {
       rowNum: 0,
       latitude: {
-        degree: 0,
-        minutes: 0,
-        seconds: 0,
+        degree: '',
+        minutes: '',
+        seconds: '',
         cardinalPoint: 'N'
       },
       longitude: {
-        degree: 0,
-        minutes: 0,
-        seconds: 0,
+        degree: '',
+        minutes: '',
+        seconds: '',
         cardinalPoint: 'E'
       }
     },
     {
       rowNum: 1,
       latitude: {
-        degree: 0,
-        minutes: 0,
-        seconds: 0,
+        degree: '',
+        minutes: '',
+        seconds: '',
         cardinalPoint: 'N'
       },
       longitude: {
-        degree: 0,
-        minutes: 0,
-        seconds: 0,
+        degree: '',
+        minutes: '',
+        seconds: '',
         cardinalPoint: 'E'
       }
     },
     {
       rowNum: 2,
       latitude: {
-        degree: 0,
-        minutes: 0,
-        seconds: 0,
+        degree: '',
+        minutes: '',
+        seconds: '',
         cardinalPoint: 'N'
       },
       longitude: {
-        degree: 0,
-        minutes: 0,
-        seconds: 0,
+        degree: '',
+        minutes: '',
+        seconds: '',
         cardinalPoint: 'E'
       }
     }

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -9,36 +9,13 @@ import { RootState } from 'js/store/index';
 
 import { coordinatesContent } from 'configs/modal.config';
 
+import {
+  SpecificDMSSection,
+  DMSFormValues,
+  DMSCardinalPoint
+} from 'js/interfaces/coordinateForm';
+
 import 'css/coordinatesForm';
-
-export interface SpecificDMSSection {
-  rowNum: number;
-  latitude: {
-    degree: string;
-    minutes: string;
-    seconds: string;
-    cardinalPoint: string;
-  };
-  longitude: {
-    degree: string;
-    minutes: string;
-    seconds: string;
-    cardinalPoint: string;
-  };
-}
-export interface DMSFormValues {
-  coordinateValue: string;
-  rowNum: number;
-  coordinateType: string;
-  degreeType: string;
-  cardinalPoint?: string;
-}
-
-interface DMSCardinalPoint {
-  specificPoint?: string;
-  rowNum?: number;
-  coordinateType?: string;
-}
 
 const CoordinatesForm: FunctionComponent = () => {
   const [selectedFormat, setSelectedFormat] = useState(0);

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -39,7 +39,7 @@ import { OptionType } from 'js/interfaces/measureWidget';
 import { LayerFactoryObject } from 'js/interfaces/mapping';
 import { addPopupWatchUtils } from 'js/helpers/DataPanel';
 
-import { SpecificDMSSection } from 'js/components/mapWidgets/widgetContent/coordinatesForm';
+import { SpecificDMSSection } from 'js/interfaces/coordinateForm';
 
 import { convertDMSToXY } from 'js/utils/helper.config';
 

--- a/src/js/interfaces/coordinateForm.ts
+++ b/src/js/interfaces/coordinateForm.ts
@@ -1,17 +1,14 @@
+interface CoordinateObject {
+  degree: string;
+  minutes: string;
+  seconds: string;
+  cardinalPoint: string;
+}
+
 export interface SpecificDMSSection {
   rowNum: number;
-  latitude: {
-    degree: string;
-    minutes: string;
-    seconds: string;
-    cardinalPoint: string;
-  };
-  longitude: {
-    degree: string;
-    minutes: string;
-    seconds: string;
-    cardinalPoint: string;
-  };
+  latitude: CoordinateObject;
+  longitude: CoordinateObject;
 }
 
 export interface DMSFormValues {

--- a/src/js/interfaces/coordinateForm.ts
+++ b/src/js/interfaces/coordinateForm.ts
@@ -1,0 +1,36 @@
+export interface SpecificDMSSection {
+  rowNum: number;
+  latitude: {
+    degree: string;
+    minutes: string;
+    seconds: string;
+    cardinalPoint: string;
+  };
+  longitude: {
+    degree: string;
+    minutes: string;
+    seconds: string;
+    cardinalPoint: string;
+  };
+}
+
+export interface DMSFormValues {
+  coordinateValue: string;
+  rowNum: number;
+  coordinateType: string;
+  degreeType: string;
+  cardinalPoint?: string;
+}
+
+export interface CoordinateProps {
+  degree: string;
+  minutes: string;
+  seconds: string;
+  cardinalPoint: string;
+}
+
+export interface DMSCardinalPoint {
+  specificPoint?: string;
+  rowNum?: number;
+  coordinateType?: string;
+}

--- a/src/js/utils/helper.config.ts
+++ b/src/js/utils/helper.config.ts
@@ -11,21 +11,27 @@ export const convertDMSToXY = (
     let convertedLongitude;
     if (latitude.cardinalPoint === 'N') {
       convertedLatitude =
-        latitude.seconds / 3600 + latitude.minutes / 60 + latitude.degree;
+        Number(latitude.seconds) / 3600 +
+        Number(latitude.minutes) / 60 +
+        Number(latitude.degree);
     } else {
       convertedLatitude =
-        (longitude.seconds / 3600 - longitude.minutes / 60 + longitude.degree) *
+        (Number(longitude.seconds) / 3600 -
+          Number(longitude.minutes) / 60 +
+          Number(longitude.degree)) *
         -1;
     }
 
     if (longitude.cardinalPoint === 'E') {
       convertedLongitude =
-        longitude.seconds / 3600 + longitude.minutes / 60 + longitude.degree;
+        Number(longitude.seconds) / 3600 +
+        Number(longitude.minutes) / 60 +
+        Number(longitude.degree);
     } else {
       convertedLongitude =
-        longitude.seconds / 3600 +
-        longitude.minutes / 60 +
-        longitude.degree * -1;
+        Number(longitude.seconds) / 3600 +
+        Number(longitude.minutes) / 60 +
+        Number(longitude.degree) * -1;
     }
 
     return new Point({

--- a/src/js/utils/helper.config.ts
+++ b/src/js/utils/helper.config.ts
@@ -1,6 +1,6 @@
 import Point from 'esri/geometry/Point';
 
-import { SpecificDMSSection } from 'js/components/mapWidgets/widgetContent/coordinatesForm';
+import { SpecificDMSSection } from 'js/interfaces/coordinateForm';
 
 export const convertDMSToXY = (
   setDMSForm: Array<SpecificDMSSection>


### PR DESCRIPTION
- swapped `typeof` for input forms from `number` to `string` in `coordinateDMSSection.tsx`
- refactored logic in `helper.config.ts` to convert strings to `Number`
- Default input is empty (matching comps). User can backspace! 
Fixes https://github.com/wri/gfw-mapbuilder/issues/806