### PR TITLE
Ticket 803 - coordinateForm.tsx - DD logic

### DIFF
--- a/src/js/components/mapWidgets/widgetContent/coordinatesDDSection.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesDDSection.tsx
@@ -5,7 +5,7 @@ import { SpecificDDSection } from './coordinatesForm';
 import { ReactComponent as TrashCanIcon } from 'images/trashCanIcon.svg';
 
 interface DDFormValues {
-  userInput: number;
+  userInput: string;
   rowNum: number;
   coordinateType: string;
 }
@@ -52,7 +52,7 @@ export default function DDSection(props: DDSectionProps): JSX.Element {
               max={90}
               onChange={(e): void =>
                 setDDFormValues({
-                  userInput: Number(e.target.value),
+                  userInput: e.target.value,
                   rowNum,
                   coordinateType: 'latitude'
                 })
@@ -73,7 +73,7 @@ export default function DDSection(props: DDSectionProps): JSX.Element {
               max={180}
               onChange={(e): void =>
                 setDDFormValues({
-                  userInput: Number(e.target.value),
+                  userInput: e.target.value,
                   rowNum,
                   coordinateType: 'longitude'
                 })

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -6,6 +6,8 @@ import DDSection from 'js/components/mapWidgets/widgetContent/coordinatesDDSecti
 
 import { mapController } from 'js/controllers/mapController';
 
+import { convertXYToPoint, convertDMSToXY } from 'js/utils/helper.config';
+
 import { RootState } from 'js/store/index';
 
 import { coordinatesContent } from 'configs/modal.config';
@@ -30,8 +32,8 @@ export interface SpecificDMSSection {
 
 export interface SpecificDDSection {
   rowNum: number;
-  latitude: number;
-  longitude: number;
+  latitude: string;
+  longitude: string;
 }
 export interface DMSFormValues {
   coordinateValue: string;
@@ -52,18 +54,18 @@ const CoordinatesForm: FunctionComponent = () => {
   const [ddSections, setDDForm] = useState([
     {
       rowNum: 0,
-      latitude: 0,
-      longitude: 0
+      latitude: '',
+      longitude: ''
     },
     {
       rowNum: 1,
-      latitude: 0,
-      longitude: 0
+      latitude: '',
+      longitude: ''
     },
     {
       rowNum: 2,
-      latitude: 0,
-      longitude: 0
+      latitude: '',
+      longitude: ''
     }
   ]);
   const [dmsSections, setDMSForm] = useState([
@@ -127,7 +129,7 @@ const CoordinatesForm: FunctionComponent = () => {
     rowNum,
     coordinateType
   }: {
-    userInput: number;
+    userInput: string;
     rowNum: number;
     coordinateType: string;
   }): void => {
@@ -170,11 +172,6 @@ const CoordinatesForm: FunctionComponent = () => {
     setDMSForm(sections);
   };
 
-  const setShape = (): void => {
-    console.log('setShape()', dmsSections);
-    // TODO create polygon from formvalues!
-  };
-
   const addOrRemoveSection = (
     // allSections: Array<SpecificDDSection> | Array<SpecificDMSSection>,
     allSections: Array<any>,
@@ -206,6 +203,16 @@ const CoordinatesForm: FunctionComponent = () => {
         addSection
       ) as Array<SpecificDDSection>;
       setDDForm(updatedSections);
+    }
+  };
+
+  const setShape = (): void => {
+    if (decimalOptions[selectedFormat].includes('DMS')) {
+      const points = convertDMSToXY(dmsSections);
+      mapController.setPolygon(points);
+    } else {
+      const points = convertXYToPoint(ddSections);
+      mapController.setPolygon(points);
     }
   };
 
@@ -255,10 +262,7 @@ const CoordinatesForm: FunctionComponent = () => {
           })}
         <div className="buttons-wrapper">
           <button onClick={(): void => setSection(true)}>Add more</button>
-          <button
-            className="orange-button"
-            onClick={(): void => mapController.setPolygon(dmsSections)}
-          >
+          <button className="orange-button" onClick={(): void => setShape()}>
             Make shape
           </button>
         </div>

--- a/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
+++ b/src/js/components/mapWidgets/widgetContent/coordinatesForm.tsx
@@ -198,13 +198,13 @@ const CoordinatesForm: FunctionComponent = () => {
   };
 
   const setShape = (): void => {
+    let points = [];
     if (decimalOptions[selectedFormat].includes('DMS')) {
-      const points = convertDMSToXY(dmsSections);
-      mapController.setPolygon(points);
+      points = convertDMSToXY(dmsSections);
     } else {
-      const points = convertXYToPoint(ddSections);
-      mapController.setPolygon(points);
+      points = convertXYToPoint(ddSections);
     }
+    mapController.setPolygon(points);
   };
 
   return (

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -785,7 +785,7 @@ export class MapController {
     }
   };
 
-  setPolygon = (setDMSForm: Array<SpecificDMSSection>): void => {
+  setPolygon = (points: Array<Point>): void => {
     const simpleFillSymbol = {
       type: 'simple-fill', // autocasts as new SimpleFillSymbol()
       color: [240, 171, 0, 0.0],
@@ -797,8 +797,6 @@ export class MapController {
     };
 
     this._mapview.graphics.removeAll();
-
-    const points = convertDMSToXY(setDMSForm);
 
     const polygon = new Polygon().addRing(points);
 

--- a/src/js/utils/helper.config.ts
+++ b/src/js/utils/helper.config.ts
@@ -1,6 +1,9 @@
 import Point from 'esri/geometry/Point';
 
-import { SpecificDMSSection } from 'js/components/mapWidgets/widgetContent/coordinatesForm';
+import {
+  SpecificDMSSection,
+  SpecificDDSection
+} from 'js/components/mapWidgets/widgetContent/coordinatesForm';
 
 export const convertDMSToXY = (
   setDMSForm: Array<SpecificDMSSection>
@@ -37,6 +40,19 @@ export const convertDMSToXY = (
     return new Point({
       latitude: convertedLatitude,
       longitude: convertedLongitude
+    });
+  });
+};
+
+export const convertXYToPoint = (
+  setDDForm: Array<SpecificDDSection>
+): Array<Point> => {
+  return setDDForm.map(point => {
+    const { latitude, longitude } = point;
+
+    return new Point({
+      latitude: Number(latitude),
+      longitude: Number(longitude)
     });
   });
 };


### PR DESCRIPTION
This PR builds logic for the decimal degree form of the pen widget. This means it enables users to draw polygons using latitudinal/longitudinal inputs.

Fixes https://github.com/wri/gfw-mapbuilder/issues/803

What it accomplishes
- Allows user to draw polygons using latitudinal/longitudinal inputs.

What it does not accomplish
- Mobile-responsiveness
- Desktop styling identical to mapbuilder v1