### PR TITLE
Request geometry buffering

### DIFF
--- a/src/js/helpers/DataPanel.ts
+++ b/src/js/helpers/DataPanel.ts
@@ -24,7 +24,6 @@ async function processSublayers(
   sublayersArray: Sublayer[],
   mapview: MapView
 ): Promise<any> {
-  //Depending on mapzoom level query distance is lower to account for points on the map spacing
   const processedSubsResults: LayerFeatureResult[] = [];
   for await (const sublayer of sublayersArray) {
     const url = sublayer.url;
@@ -78,9 +77,6 @@ async function fetchAsyncServerResults(
     //We need to convert Collection of sublayers to regular array for async processing
     const sublayersArray: any[] = sublayers.items.map((sl: Sublayer) => sl);
 
-    //TODO: Better way to handle mouse click buffering?
-    // const distance = mapview.resolution * 0.005;
-    // const geometry = geometryEngine.buffer(mapPoint, distance, 'miles');
     const processedSubs: LayerFeatureResult[] = await processSublayers(
       mapPoint,
       sublayersArray,

--- a/src/js/helpers/DataPanel.ts
+++ b/src/js/helpers/DataPanel.ts
@@ -25,19 +25,6 @@ async function processSublayers(
   mapview: MapView
 ): Promise<any> {
   //Depending on mapzoom level query distance is lower to account for points on the map spacing
-  function calcDistance(): number {
-    if (mapview.zoom < 10) {
-      return 2;
-    } else if (mapview.zoom >= 10 && mapview.zoom <= 13) {
-      return 0.8;
-    } else if (mapview.zoom > 13 && mapview.zoom <= 15) {
-      return 0.3;
-    } else {
-      return 0.03;
-    }
-  }
-
-  const bufferedDistance = calcDistance();
   const processedSubsResults: LayerFeatureResult[] = [];
   for await (const sublayer of sublayersArray) {
     const url = sublayer.url;
@@ -45,7 +32,7 @@ async function processSublayers(
       where: '1=1',
       outFields: ['*'],
       units: 'miles',
-      distance: bufferedDistance,
+      distance: 0.02 * mapview.resolution,
       geometry: geometry,
       returnGeometry: false
     };

--- a/src/js/helpers/DataPanel.ts
+++ b/src/js/helpers/DataPanel.ts
@@ -28,7 +28,7 @@ async function processSublayers(
   function calcDistance(): number {
     if (mapview.zoom < 10) {
       return 2;
-    } else if (mapview.zoom > 10 && mapview.zoom <= 13) {
+    } else if (mapview.zoom >= 10 && mapview.zoom <= 13) {
       return 0.8;
     } else if (mapview.zoom > 13 && mapview.zoom <= 15) {
       return 0.3;


### PR DESCRIPTION
* Fixes #812 
Adding a function to determine `distance` in `miles` based on `mapview.zoom` for our server side queries.

This works relatively well to account for zoom level and precision clicking issue with small points on the map.