### PR TITLE
Ticket 818 - onShare, update URL to include X/Y/Z coordinates and visibleLayer IDs

### DIFF
--- a/src/js/components/mapWidgets/widgetContent/shareContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/shareContent.tsx
@@ -55,14 +55,11 @@ const ShareContent: FunctionComponent = () => {
   };
 
   const returnURL = (): string => {
-    const { latitude, longitude, zoom } = mapController.setMapviewCoordinates();
+    const { latitude, longitude, zoom } = mapController.getMapviewCoordinates();
     const visibleLayersURL = allAvailableLayers
       .filter(layer => layer.visible)
       .map(layer => layer.id)
-      .join(',');
-
-    // * NOTE - Sample URL;
-    // http://blueraster.teaches-yoga.com/CMR?x=12.37&y=6.44&z=8&l=en&b=wri_contextual&t=INFO_WINDOW&a=atlas_forestier_en_9979_36%2Catlas_forestier_en_9979_37%2Catlas_forestier_en_9979_13%2Catlas_forestier_en_9979_38%2Catlas_forestier_en_9979_35%2Catlas_forestier_en_9979_47%2Catlas_forestier_en_9979_49&o=1%2C1%2C1%2C1%2C1%2C1%2C1
+      .join('%2C');
 
     return `${window.location.href}&lat=${latitude}&lon=${latitude}&z=${zoom}&activeLayers=${visibleLayersURL}`;
   };

--- a/src/js/components/mapWidgets/widgetContent/shareContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/shareContent.tsx
@@ -6,10 +6,15 @@ import { RootState } from 'js/store/index';
 import { ReactComponent as TwitterIcon } from 'src/images/twitterIcon.svg';
 import { ReactComponent as FacebookIcon } from 'src/images/facebookIcon.svg';
 
+import { mapController } from 'js/controllers/mapController';
+
 import { shareContent } from '../../../../../configs/modal.config';
 
 const ShareContent: FunctionComponent = () => {
   const urlRef = useRef() as React.MutableRefObject<HTMLInputElement>;
+  const { allAvailableLayers } = useSelector(
+    (state: RootState) => state.mapviewState
+  );
   const selectedLanguage = useSelector(
     (state: RootState) => state.appState.selectedLanguage
   );
@@ -49,18 +54,26 @@ const ShareContent: FunctionComponent = () => {
     // * because it doesn't support localhost URLs
   };
 
+  const returnURL = (): string => {
+    const { latitude, longitude, zoom } = mapController.setMapviewCoordinates();
+    const visibleLayersURL = allAvailableLayers
+      .filter(layer => layer.visible)
+      .map(layer => layer.id)
+      .join(',');
+
+    // * NOTE - Sample URL;
+    // http://blueraster.teaches-yoga.com/CMR?x=12.37&y=6.44&z=8&l=en&b=wri_contextual&t=INFO_WINDOW&a=atlas_forestier_en_9979_36%2Catlas_forestier_en_9979_37%2Catlas_forestier_en_9979_13%2Catlas_forestier_en_9979_38%2Catlas_forestier_en_9979_35%2Catlas_forestier_en_9979_47%2Catlas_forestier_en_9979_49&o=1%2C1%2C1%2C1%2C1%2C1%2C1
+
+    return `${window.location.href}&lat=${latitude}&lon=${latitude}&z=${zoom}&activeLayers=${visibleLayersURL}`;
+  };
+
   return (
     <div className="modal-content-container">
       <div className="directions">
         <h4 className="title">{title}</h4>
         <p>{instructions}</p>
         <div className="copy-link-wrapper">
-          <input
-            type="text"
-            readOnly
-            value={window.location.href}
-            ref={urlRef}
-          ></input>
+          <input type="text" readOnly value={returnURL()} ref={urlRef}></input>
           <button onClick={(): void => copyURLToClipboard()}>COPY</button>
         </div>
         <div className="share-button-wrapper">

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -867,7 +867,7 @@ export class MapController {
     store.dispatch(renderModal(''));
   }
 
-  setMapviewCoordinates(): URLCoordinates {
+  getMapviewCoordinates(): URLCoordinates {
     const { zoom } = this._mapview;
     const { latitude, longitude } = this._mapview.center;
 

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -45,6 +45,12 @@ import { convertDMSToXY } from 'js/utils/helper.config';
 
 const allowedLayers = ['feature', 'dynamic', 'loss', 'gain']; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
 
+interface URLCoordinates {
+  zoom: number;
+  latitude: string;
+  longitude: string;
+}
+
 interface ZoomParams {
   zoomIn: boolean;
 }
@@ -859,6 +865,20 @@ export class MapController {
       }
     );
     store.dispatch(renderModal(''));
+  }
+
+  setMapviewCoordinates(): URLCoordinates {
+    const { zoom } = this._mapview;
+    const { latitude, longitude } = this._mapview.center;
+
+    const subStringLatitude = latitude.toString().substring(0, 7);
+    const subStringLongitude = longitude.toString().substring(0, 7);
+
+    return {
+      latitude: subStringLatitude,
+      longitude: subStringLongitude,
+      zoom
+    };
   }
 }
 


### PR DESCRIPTION
This PR generates a URL with the map's latitude/longitude coordinates, zoom level and activeLayers in the share widget. This is a first step to enabling users to load a map with the specific configurations they configured.

Fixes https://github.com/wri/gfw-mapbuilder/issues/818

What it accomplishes
- generating a URL that includes latitude/longitude coordinates, zoom level and activeLayers in the share widget

What it does not accomplish
- opening the custom URL. App does not have logic to leverage URL params to update mapview's lat/long, zoom level and active layers.