### PR TITLE
Data tab remove attribute functionality

### DIFF
--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -155,9 +155,19 @@
 
 .data-tabview-container {
   .layer-feature-group {
-    .layer-controls {
+    .layer-control-container {
+      .remove-attribute-button {
+        display: flex;
+        justify-content: flex-end;
+        button {
+          -webkit-appearance: none;
+          outline: none;
+          border: 0;
+        }
+      }
+    }
+    .layer-control {
       display: flex;
-      padding-top: 15px;
       justify-content: space-around;
       margin-bottom: 10px;
       select {

--- a/src/images/closeIcon.svg
+++ b/src/images/closeIcon.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg class="svg-icon">
+  <svg id="icon-close" viewBox="0 0 25 25">
+    <title>Close</title>
+    <path 
+      class="path1" 
+      d="M 5 19 L 19 5 L 21 7 L 7 21 L 5 19 ZM 7 5 L 21 19 L 19 21 L 5 7 L 7 5 Z">
+    </path>
+  </svg>
+</svg>

--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from 'js/store';
-import { setActiveFeatureIndex } from 'js/store/mapview/actions';
+import {
+  setActiveFeatureIndex,
+  setActiveFeatures
+} from 'js/store/mapview/actions';
 import DataTabFooter from './DataTabFooter';
 import DefaultTabView from './DefaultTabView';
 import LayerSelector from './LayerSelector';
@@ -56,11 +59,32 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
         );
       };
 
-      function removeAttribute() {
-        console.log('removing attribute');
+      function removeAttribute(): void {
+        const oldActiveFeatures = [...activeFeatures];
+        // if we are removing last feature from the layer group, remove the whole layer
+        if (activeFeatures[activeLayerIndex].features.length === 1) {
+          //remove the whole layer
+          oldActiveFeatures.splice(activeLayerIndex, 1);
+          //update redux store with new features
+          dispatch(setActiveFeatures(oldActiveFeatures));
+          //update active layerindex as the old one does not exit anymore
+          dispatch(setActiveFeatureIndex([0, 0]));
+        } else {
+          //remove only one feature and keep everything else intact
+          oldActiveFeatures[activeLayerIndex].features.splice(
+            activeFeatureIndex[1],
+            1
+          );
+          //update redux
+          dispatch(setActiveFeatures(oldActiveFeatures));
+          //new active page depends if we are on first page or not, if we are on first page, we keep same page, if not we decrement by one
+          const newActivePage =
+            activeFeatureIndex[1] === 0 ? 0 : activeFeatureIndex[1] - 1;
+          dispatch(setActiveFeatureIndex([activeLayerIndex, newActivePage]));
+        }
       }
 
-      function handleLayerSwitch(layerID: string) {
+      function handleLayerSwitch(layerID: string): void {
         //Upon layer selection switch, we update the index of the activefeature's layer and zero out the feature itself
         const newLayerIndex = activeFeatures.findIndex(
           f => f.layerID === layerID

--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -1,36 +1,41 @@
 import * as React from 'react';
-import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from 'js/store';
+import { setActiveFeatureIndex } from 'js/store/mapview/actions';
 import DataTabFooter from './DataTabFooter';
 import DefaultTabView from './DefaultTabView';
 import LayerSelector from './LayerSelector';
+import { ReactComponent as CloseAttribute } from '../../../../images/closeIcon.svg';
 
 interface DataTabProps {
   key: string;
   label: string;
 }
-const DataTabView = (props: DataTabProps) => {
+const DataTabView = (props: DataTabProps): JSX.Element => {
+  const dispatch = useDispatch();
   const { activeTab, tabViewVisible } = useSelector(
     (store: RootState) => store.appState.leftPanel
   );
 
-  const { activeFeatures } = useSelector(
+  const { activeFeatures, activeFeatureIndex } = useSelector(
     (store: RootState) => store.mapviewState
   );
 
   const FeatureDataView = (): any => {
-    const [activeLayer, setActiveLayer] = useState(activeFeatures[0].layerID);
+    const activeLayer = activeFeatures[activeFeatureIndex[0]].layerID;
     const activeLayerInfo = activeFeatures.find(f => f.layerID === activeLayer);
-
+    const activeLayerIndex = activeFeatures.findIndex(
+      f => f.layerID === activeLayer
+    );
     const LayerAttributesElement = (props: {
       activeLayerInfo: any;
+      activeLayerIndex: number;
     }): JSX.Element => {
-      const [page, setPage] = useState(0);
+      const page = activeFeatureIndex[1];
 
       function turnAttributeTablePage(forward: boolean): void {
         const newPage = forward ? page + 1 : page - 1;
-        setPage(newPage);
+        dispatch(setActiveFeatureIndex([activeLayerIndex, newPage]));
       }
 
       interface AttributeObject {
@@ -51,35 +56,54 @@ const DataTabView = (props: DataTabProps) => {
         );
       };
 
+      function removeAttribute() {
+        console.log('removing attribute');
+      }
+
+      function handleLayerSwitch(layerID: string) {
+        //Upon layer selection switch, we update the index of the activefeature's layer and zero out the feature itself
+        const newLayerIndex = activeFeatures.findIndex(
+          f => f.layerID === layerID
+        );
+        dispatch(setActiveFeatureIndex([newLayerIndex, 0]));
+      }
+
       //determine if next/prev buttons are enabled or disabled
       const prevBtn = page === 0 ? 'disabled' : '';
       const nextBtn =
         page === props.activeLayerInfo.features.length - 1 ? 'disabled' : '';
       return (
         <div className="layer-feature-group">
-          <div className="layer-controls">
-            <LayerSelector
-              activeFeatures={activeFeatures}
-              activeLayerInfo={activeLayerInfo}
-              handleLayerSelection={(layerID: string): void =>
-                setActiveLayer(layerID)
-              }
-            />
-            <div className="attribute-page-buttons">
-              <button
-                className={`attribute-page-button ${prevBtn}`}
-                disabled={page === 0}
-                onClick={() => turnAttributeTablePage(false)}
-              >
-                Prev
+          <div className="layer-control-container">
+            <div className="remove-attribute-button">
+              <button id="remove-attr-btn" onClick={removeAttribute}>
+                <CloseAttribute width={25} height={25} />
               </button>
-              <button
-                className={`attribute-page-button ${nextBtn}`}
-                disabled={page === props.activeLayerInfo.features.length - 1}
-                onClick={() => turnAttributeTablePage(true)}
-              >
-                Next
-              </button>
+            </div>
+            <div className="layer-control">
+              <LayerSelector
+                activeFeatures={activeFeatures}
+                activeLayerInfo={activeLayerInfo}
+                handleLayerSelection={(layerID: string): void =>
+                  handleLayerSwitch(layerID)
+                }
+              />
+              <div className="attribute-page-buttons">
+                <button
+                  className={`attribute-page-button ${prevBtn}`}
+                  disabled={page === 0}
+                  onClick={() => turnAttributeTablePage(false)}
+                >
+                  Prev
+                </button>
+                <button
+                  className={`attribute-page-button ${nextBtn}`}
+                  disabled={page === props.activeLayerInfo.features.length - 1}
+                  onClick={() => turnAttributeTablePage(true)}
+                >
+                  Next
+                </button>
+              </div>
             </div>
           </div>
           <div className="page-numbers">
@@ -96,7 +120,10 @@ const DataTabView = (props: DataTabProps) => {
     //TODO: needs to be active language aware
     return (
       <div className="data-tabview-container">
-        <LayerAttributesElement activeLayerInfo={activeLayerInfo} />
+        <LayerAttributesElement
+          activeLayerIndex={activeLayerIndex}
+          activeLayerInfo={activeLayerInfo}
+        />
         <DataTabFooter />
       </div>
     );

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -23,7 +23,9 @@ import { LayerFactory } from 'js/helpers/LayerFactory';
 import {
   allAvailableLayers,
   mapError,
-  isMapReady
+  isMapReady,
+  setActiveFeatureIndex,
+  setActiveFeatures
 } from 'js/store/mapview/actions';
 
 import {
@@ -127,7 +129,12 @@ export class MapController {
       .when(
         () => {
           store.dispatch(isMapReady(true));
-          this._mapview?.on('click', event => {
+          this._mapview.popup.highlightEnabled = false;
+          this._mapview.on('click', event => {
+            //TODO: We need a better loading handling, probably a spinner!
+            //clean active indexes for data tab and activeFeatures
+            store.dispatch(setActiveFeatures([]));
+            store.dispatch(setActiveFeatureIndex([0, 0]));
             addPopupWatchUtils(this._mapview, this._map, event.mapPoint);
           });
 

--- a/src/js/store/mapview/actions.ts
+++ b/src/js/store/mapview/actions.ts
@@ -3,6 +3,7 @@ import {
   MAP_READY,
   ALL_AVAILABLE_LAYERS,
   SET_ACTIVE_FEATURES,
+  SET_ACTIVE_FEATURE_INDEX,
   MapviewState
 } from './types';
 
@@ -32,6 +33,15 @@ export function allAvailableLayers(
 export function setActiveFeatures(payload: MapviewState['activeFeatures']) {
   return {
     type: SET_ACTIVE_FEATURES as typeof SET_ACTIVE_FEATURES,
+    payload
+  };
+}
+
+export function setActiveFeatureIndex(
+  payload: MapviewState['activeFeatureIndex']
+) {
+  return {
+    type: SET_ACTIVE_FEATURE_INDEX as typeof SET_ACTIVE_FEATURE_INDEX,
     payload
   };
 }

--- a/src/js/store/mapview/reducers.ts
+++ b/src/js/store/mapview/reducers.ts
@@ -4,14 +4,16 @@ import {
   MAP_READY,
   MAP_ERROR,
   ALL_AVAILABLE_LAYERS,
-  SET_ACTIVE_FEATURES
+  SET_ACTIVE_FEATURES,
+  SET_ACTIVE_FEATURE_INDEX
 } from './types';
 
 const initialState: MapviewState = {
   isMapReady: false,
   loadError: false,
   allAvailableLayers: [],
-  activeFeatures: []
+  activeFeatures: [],
+  activeFeatureIndex: [0, 0] //first element is the index of the layer, second is the index of feature
 };
 
 export function mapviewReducer(
@@ -27,6 +29,8 @@ export function mapviewReducer(
       return { ...state, allAvailableLayers: action.payload };
     case SET_ACTIVE_FEATURES:
       return { ...state, activeFeatures: action.payload };
+    case SET_ACTIVE_FEATURE_INDEX:
+      return { ...state, activeFeatureIndex: action.payload };
     default:
       return state;
   }

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -1,5 +1,3 @@
-import Graphic from 'esri/Graphic';
-
 interface SpecificAreaResults {
   area: string;
   perimeter: string;
@@ -23,6 +21,7 @@ export interface MapviewState {
   loadError: boolean;
   allAvailableLayers: LayerProps[];
   activeFeatures: LayerFeatureResult[];
+  activeFeatureIndex: number[];
 }
 
 export interface LayerProps {
@@ -52,6 +51,7 @@ export const MAP_READY = 'MAP_READY';
 export const MAP_ERROR = 'MAP_ERROR';
 export const ALL_AVAILABLE_LAYERS = 'ALL_AVAILABLE_LAYERS';
 export const SET_ACTIVE_FEATURES = 'SET_ACTIVE_FEATURES';
+export const SET_ACTIVE_FEATURE_INDEX = 'SET_ACTIVE_FEATURE_INDEX';
 
 interface MapIsReadyAction {
   type: typeof MAP_READY;
@@ -73,8 +73,14 @@ interface SetActiveFeaturesAction {
   payload: MapviewState['activeFeatures'];
 }
 
+interface SetActiveFeatureIndex {
+  type: typeof SET_ACTIVE_FEATURE_INDEX;
+  payload: MapviewState['activeFeatureIndex'];
+}
+
 export type MapviewStateTypes =
   | MapIsReadyAction
   | MapErrorAction
   | AllAvailableLayersAction
-  | SetActiveFeaturesAction;
+  | SetActiveFeaturesAction
+  | SetActiveFeatureIndex;


### PR DESCRIPTION
Part of #782
Fixes #831

- Added redux parts to track `active layer` index and active `feature index` instead of utilizing local state
- Added close button to data tab
- Close button removes current active feature from data tab and redux `activeFeatures` array
- If user removed last feature from a layer group, layer group gets removed
- If there are no other layer groups, tab displays `default` view