### PR TITLE
Ticket 833 - Mapbuilder footer 

### DIFF
--- a/src/css/footer.scss
+++ b/src/css/footer.scss
@@ -1,0 +1,14 @@
+.footer-container {
+  display: flex;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.5);
+  height: 1.5rem;
+  padding: 0.25rem;
+  align-items: center;
+
+  p {
+    margin: 0 1rem 0 1rem;
+  }
+}

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -14,14 +14,6 @@ body,
 .mapview-container {
   position: absolute;
   top: 0;
-
-  .mapview
-    > .esri-view-root
-    > .esri-ui
-    > .esri-ui-manual-container
-    > .esri-attribution {
-    display: none;
-  }
 }
 
 button {

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -14,6 +14,14 @@ body,
 .mapview-container {
   position: absolute;
   top: 0;
+
+  .mapview
+    > .esri-view-root
+    > .esri-ui
+    > .esri-ui-manual-container
+    > .esri-attribution {
+    display: none;
+  }
 }
 
 button {

--- a/src/js/components/Footer.tsx
+++ b/src/js/components/Footer.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import 'css/footer.scss';
+
+const Footer = (): JSX.Element => {
+  return (
+    <div className="footer-container">
+      <p>
+        <a
+          href="https://www.wri.org/about/privacy-policy"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          WRI Privacy Policy
+        </a>
+      </p>
+      <span> | </span>
+      <p>
+        <a
+          href="https://www.globalforestwatch.org/terms"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GFW Terms of Service
+        </a>
+      </p>
+    </div>
+  );
+};
+
+export default Footer;

--- a/src/js/components/MapContent.tsx
+++ b/src/js/components/MapContent.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from 'react';
 import Mapview from '../components/mapview/Mapview';
 import MapWidgets from './mapWidgets/mapWidgets';
 import LeftPanel from './leftPanel/LeftPanel';
+import Footer from './Footer';
 
 const MapContent: FunctionComponent = () => {
   return (
@@ -10,6 +11,7 @@ const MapContent: FunctionComponent = () => {
       <LeftPanel />
       <MapWidgets />
       <Mapview />
+      <Footer />
     </>
   );
 };

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -122,6 +122,7 @@ export class MapController {
 
     this._mapview.ui.add(this._legend, 'bottom-right');
     this._mapview.ui.remove('zoom');
+    this._mapview.ui.remove('attribution');
 
     this._mapview
       .when(


### PR DESCRIPTION
This PR integrates a footer component, which renders the WRI privacy policy and the GFW terms of service.

Fixes https://github.com/wri/gfw-mapbuilder/issues/833

What it accomplishes;
- Renders the WRI privacy policy and the GFW terms of service
- Minimally styles `Footer.tsx`

What it does not accomplish;
- Mobile-responsiveness
- UI/wireframe implementation - we don't have a wireframe/sketch to work from, so it's possible the styling will change later on.
- URLs are not confirmed - @SwampGuzzler gave me the green light to make this PR and update the URLs later, as needed, via a separate PR request. Thanks @SwampGuzzler !