### PR TITLE
Ticket 845 - GFW default basemaps

### DIFF
--- a/configs/leftPanel.config.ts
+++ b/configs/leftPanel.config.ts
@@ -186,3 +186,50 @@ export const analysisContent = {
     建议文件大小应小于1MB。ESRI文件必须为压缩文件（.zip）,GeoJSON 文件必须为后缀.json的文件。`
   }
 };
+
+export const basemapLayersContent = {
+  defaultESRIBasemaps: [
+    {
+      id: 'satellite',
+      thumbnailUrl:
+        'https://my.gfw-mapbuilder.org/js/arcgis-api-mapbuilder-1.2/esri/images/basemap/satellite.jpg',
+      title: {
+        en: 'Imagery',
+        ka: 'Imagery',
+        fr: 'Imagery',
+        es: 'Imagery',
+        pt: 'Imagery',
+        id: 'Imagery',
+        zh: 'Imagery'
+      }
+    },
+    {
+      id: 'hybrid',
+      thumbnailUrl:
+        'https://my.gfw-mapbuilder.org/js/arcgis-api-mapbuilder-1.2/esri/images/basemap/hybrid.jpg',
+      title: {
+        en: 'Imagery with Labels',
+        ka: 'Imagery with Labels',
+        fr: 'Imagery with Labels',
+        es: 'Imagery with Labels',
+        pt: 'Imagery with Labels',
+        id: 'Imagery with Labels',
+        zh: 'Imagery with Labels'
+      }
+    },
+    {
+      id: 'osm',
+      thumbnailUrl:
+        'https://my.gfw-mapbuilder.org/js/arcgis-api-mapbuilder-1.2/esri/images/basemap/osm.jpg',
+      title: {
+        en: 'Open Street Map',
+        ka: 'Open Street Map',
+        fr: 'Open Street Map',
+        es: 'Open Street Map',
+        pt: 'Open Street Map',
+        id: 'Open Street Map',
+        zh: 'Open Street Map'
+      }
+    }
+  ]
+};

--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -192,6 +192,9 @@
   display: flex;
   align-items: center;
   border-bottom: 1px solid #aaa;
+  font-family: $fira-sans;
+  font-size: 0.85rem;
+
   img {
     border-radius: 50px;
     width: 44px;

--- a/src/js/components/leftPanel/layersPanel/BasemapLayersGroup.tsx
+++ b/src/js/components/leftPanel/layersPanel/BasemapLayersGroup.tsx
@@ -12,6 +12,7 @@ interface DefaultBasemapProps {
     id: string;
     thumbnailUrl: string;
     title: string;
+    activeBasemap: string;
   };
 }
 
@@ -29,10 +30,10 @@ const BaseLayerControl = (props: any) => {
 const GenericBaseLayerControl = ({
   layerInfo
 }: DefaultBasemapProps): JSX.Element => {
-  const { id, thumbnailUrl, title } = layerInfo;
+  const { id, thumbnailUrl, title, activeBasemap } = layerInfo;
   return (
     <div
-      className="layer-basemap"
+      className={`layer-basemap ${activeBasemap === id ? 'selected' : ''}`}
       onClick={(): void => mapController.setActiveBasemap(id)}
     >
       <img src={thumbnailUrl} alt="basemap" />
@@ -49,6 +50,9 @@ interface LayerGroupProps {
 const BasemapLayersGroup = (props: LayerGroupProps): React.ReactElement => {
   const { selectedLanguage, leftPanel } = useSelector(
     (store: RootState) => store.appState
+  );
+  const { activeBasemap } = useSelector(
+    (store: RootState) => store.mapviewState
   );
 
   const dispatch = useDispatch();
@@ -80,7 +84,8 @@ const BasemapLayersGroup = (props: LayerGroupProps): React.ReactElement => {
         layerInfo={{
           id: baselayer.id,
           thumbnailUrl: baselayer.thumbnailUrl,
-          title: baselayer.title[selectedLanguage]
+          title: baselayer.title[selectedLanguage],
+          activeBasemap
         }}
       />
     )

--- a/src/js/components/leftPanel/layersPanel/BasemapLayersGroup.tsx
+++ b/src/js/components/leftPanel/layersPanel/BasemapLayersGroup.tsx
@@ -3,6 +3,18 @@ import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from 'js/store';
 import { setOpenLayerGroup } from 'js/store/appState/actions';
 
+import { mapController } from 'js/controllers/mapController';
+
+import { basemapLayersContent } from 'configs/leftPanel.config';
+
+interface DefaultBasemapProps {
+  layerInfo: {
+    id: string;
+    thumbnailUrl: string;
+    title: string;
+  };
+}
+
 const BaseLayerControl = (props: any) => {
   const { id, thumbnailUrl, templateUrl, title, years } = props.layerInfo;
   return (
@@ -10,6 +22,21 @@ const BaseLayerControl = (props: any) => {
       <img src={thumbnailUrl} alt="basemap" />
       <span>{title[props.selectedLanguage]}</span>
       {years && <div>year dropdown</div>}
+    </div>
+  );
+};
+
+const GenericBaseLayerControl = ({
+  layerInfo
+}: DefaultBasemapProps): JSX.Element => {
+  const { id, thumbnailUrl, title } = layerInfo;
+  return (
+    <div
+      className="layer-basemap"
+      onClick={(): void => mapController.setActiveBasemap(id)}
+    >
+      <img src={thumbnailUrl} alt="basemap" />
+      <span>{title}</span>
     </div>
   );
 };
@@ -37,12 +64,27 @@ const BasemapLayersGroup = (props: LayerGroupProps): React.ReactElement => {
   };
 
   const basemapsToRender = layerGroupConfig.layers.map((baselayer: any) => (
+    // * NOTE: these are custom Basemap layers that are set via resources.js
     <BaseLayerControl
       key={baselayer.id}
       layerInfo={baselayer}
       selectedLanguage={selectedLanguage}
     />
   ));
+
+  const esriBasemapsToRender = basemapLayersContent.defaultESRIBasemaps.map(
+    // * NOTE: these are generic Basemap layers that exist across custom maps
+    (baselayer: any) => (
+      <GenericBaseLayerControl
+        key={baselayer.id}
+        layerInfo={{
+          id: baselayer.id,
+          thumbnailUrl: baselayer.thumbnailUrl,
+          title: baselayer.title[selectedLanguage]
+        }}
+      />
+    )
+  );
 
   return (
     <div className="layer-group-container">
@@ -58,6 +100,7 @@ const BasemapLayersGroup = (props: LayerGroupProps): React.ReactElement => {
       </div>
       <div className={groupOpen ? 'layers-control-container' : 'hidden'}>
         {basemapsToRender}
+        {esriBasemapsToRender}
       </div>
     </div>
   );

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -29,6 +29,7 @@ import {
   setActiveFeatures
 } from 'js/store/mapview/actions';
 
+import { setSelectedBasemap } from 'js/store/mapview/actions';
 import {
   renderModal,
   selectActiveTab,
@@ -891,6 +892,7 @@ export class MapController {
     if (this._map) {
       const basemap = Basemap.fromId(id);
       this._map.basemap = basemap;
+      store.dispatch(setSelectedBasemap(id));
     }
   }
 }

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -14,6 +14,7 @@ import Point from 'esri/geometry/Point';
 import PrintTask from 'esri/tasks/PrintTask';
 import PrintTemplate from 'esri/tasks/support/PrintTemplate';
 import PrintParameters from 'esri/tasks/support/PrintParameters';
+import Basemap from 'esri/Basemap';
 import { once } from 'esri/core/watchUtils';
 
 import { RefObject } from 'react';
@@ -884,6 +885,13 @@ export class MapController {
       longitude: subStringLongitude,
       zoom
     };
+  }
+
+  setActiveBasemap(id: string): void {
+    if (this._map) {
+      const basemap = Basemap.fromId(id);
+      this._map.basemap = basemap;
+    }
   }
 }
 

--- a/src/js/store/mapview/actions.ts
+++ b/src/js/store/mapview/actions.ts
@@ -4,6 +4,7 @@ import {
   ALL_AVAILABLE_LAYERS,
   SET_ACTIVE_FEATURES,
   SET_ACTIVE_FEATURE_INDEX,
+  SET_ACTIVE_BASEMAP,
   MapviewState
 } from './types';
 
@@ -43,5 +44,12 @@ export function setActiveFeatureIndex(
   return {
     type: SET_ACTIVE_FEATURE_INDEX as typeof SET_ACTIVE_FEATURE_INDEX,
     payload
+  };
+}
+
+export function setSelectedBasemap(basemapID: MapviewState['activeBasemap']) {
+  return {
+    type: SET_ACTIVE_BASEMAP as typeof SET_ACTIVE_BASEMAP,
+    payload: basemapID
   };
 }

--- a/src/js/store/mapview/reducers.ts
+++ b/src/js/store/mapview/reducers.ts
@@ -5,7 +5,8 @@ import {
   MAP_ERROR,
   ALL_AVAILABLE_LAYERS,
   SET_ACTIVE_FEATURES,
-  SET_ACTIVE_FEATURE_INDEX
+  SET_ACTIVE_FEATURE_INDEX,
+  SET_ACTIVE_BASEMAP
 } from './types';
 
 const initialState: MapviewState = {
@@ -13,7 +14,8 @@ const initialState: MapviewState = {
   loadError: false,
   allAvailableLayers: [],
   activeFeatures: [],
-  activeFeatureIndex: [0, 0] //first element is the index of the layer, second is the index of feature
+  activeFeatureIndex: [0, 0], //first element is the index of the layer, second is the index of feature
+  activeBasemap: ''
 };
 
 export function mapviewReducer(
@@ -31,6 +33,8 @@ export function mapviewReducer(
       return { ...state, activeFeatures: action.payload };
     case SET_ACTIVE_FEATURE_INDEX:
       return { ...state, activeFeatureIndex: action.payload };
+    case SET_ACTIVE_BASEMAP:
+      return { ...state, activeBasemap: action.payload };
     default:
       return state;
   }

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -22,6 +22,7 @@ export interface MapviewState {
   allAvailableLayers: LayerProps[];
   activeFeatures: LayerFeatureResult[];
   activeFeatureIndex: number[];
+  activeBasemap: string; // * NEW! not in resources.js
 }
 
 export interface LayerProps {
@@ -52,6 +53,7 @@ export const MAP_ERROR = 'MAP_ERROR';
 export const ALL_AVAILABLE_LAYERS = 'ALL_AVAILABLE_LAYERS';
 export const SET_ACTIVE_FEATURES = 'SET_ACTIVE_FEATURES';
 export const SET_ACTIVE_FEATURE_INDEX = 'SET_ACTIVE_FEATURE_INDEX';
+export const SET_ACTIVE_BASEMAP = 'SET_ACTIVE_BASEMAP';
 
 interface MapIsReadyAction {
   type: typeof MAP_READY;
@@ -73,6 +75,11 @@ interface SetActiveFeaturesAction {
   payload: MapviewState['activeFeatures'];
 }
 
+interface SetSelectedAction {
+  type: typeof SET_ACTIVE_BASEMAP;
+  payload: MapviewState['activeBasemap'];
+}
+
 interface SetActiveFeatureIndex {
   type: typeof SET_ACTIVE_FEATURE_INDEX;
   payload: MapviewState['activeFeatureIndex'];
@@ -83,4 +90,5 @@ export type MapviewStateTypes =
   | MapErrorAction
   | AllAvailableLayersAction
   | SetActiveFeaturesAction
-  | SetActiveFeatureIndex;
+  | SetActiveFeatureIndex
+  | SetSelectedAction;


### PR DESCRIPTION
This PR renders generic ESRI basemaps in the Left Panel, and configures the logic for these basemaps

- Fixes https://github.com/wri/gfw-mapbuilder/issues/845

What it accomplishes;
- Renders default, generic basemap layer buttons in the left panel
- Sets the map's active basemap
- Styles `font-family` & `font-size`

What it does not accomplish
- Mobile styling/pixel-by-pixel styling
- Logic to update the map when a user selects WRI's custom basemaps
- Maintaining a source of truth RE basemap layer content in `resources.js` or `leftPanel.config.js`  - @SwampGuzzler gave me the green light to store the default basemap configs in `leftPanel.config.js`, since it looks like these options exist across custom maps. This means we won't need to update/customize it, unlike the info in `resources.js`