### PR TITLE
Returned feature missing layer info bug

### DIFF
--- a/src/js/components/App.tsx
+++ b/src/js/components/App.tsx
@@ -9,6 +9,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import 'arcgis-js-api/themes/light/main.scss';
 import 'css/index.scss';
 import resources from '../../../configs/resources';
+import cameroon from '../../../configs/cameroon';
 import { overwriteSettings } from 'js/store/appSettings/actions';
 import { AppSettings } from 'js/store/appSettings/types';
 
@@ -33,7 +34,7 @@ const App = (props: AppSettings | any): JSX.Element => {
       //
       //Determine which resources we are reading from
       //Read our local resources.js file And any external library resources (which are prioritized)
-      dispatch(overwriteSettings({ ...resources, ...props }));
+      dispatch(overwriteSettings({ ...cameroon, ...props }));
       //Send that to our redux appSettings overwriting whatever is there
       setShowGlobalSpinner(false);
     }, 500);

--- a/src/js/components/App.tsx
+++ b/src/js/components/App.tsx
@@ -9,7 +9,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import 'arcgis-js-api/themes/light/main.scss';
 import 'css/index.scss';
 import resources from '../../../configs/resources';
-import cameroon from '../../../configs/cameroon';
 import { overwriteSettings } from 'js/store/appSettings/actions';
 import { AppSettings } from 'js/store/appSettings/types';
 
@@ -34,7 +33,7 @@ const App = (props: AppSettings | any): JSX.Element => {
       //
       //Determine which resources we are reading from
       //Read our local resources.js file And any external library resources (which are prioritized)
-      dispatch(overwriteSettings({ ...cameroon, ...props }));
+      dispatch(overwriteSettings({ ...resources, ...props }));
       //Send that to our redux appSettings overwriting whatever is there
       setShowGlobalSpinner(false);
     }, 500);

--- a/src/js/helpers/DataPanel.ts
+++ b/src/js/helpers/DataPanel.ts
@@ -94,10 +94,13 @@ async function fetchAsyncServerResults(
   layerFeatureResults: LayerFeatureResult[]
 ): Promise<any> {
   if (map) {
-    //Iterate over map layers, filter out turned off layers and non map-image layers
+    const processedLayersByClientQuery = layerFeatureResults.map(
+      f => f.layerID
+    );
     const visibleServerLayers = map.layers
-      .filter(l => l.visible && l.type === 'map-image')
-      .filter(l => layerFeatureResults.map(f => f.layerID).includes(l.id)); //the second filter here ensures that we do not double count, for some reason 'map-image' was being processed twice, at the client side (popup promise) and server side too. TODO: This may need further investigation, debugging with variuos county configs!
+      .filter(l => l.visible)
+      .filter(l => !processedLayersByClientQuery.includes(l.id));
+    //the second filter here ensures that we do not double count, for some reason some layers were being processed twice, at the client side (popup promise) and server side too. TODO: This may need further investigation, debugging with variuos county configs!
     //Extract all sublayers
     const sublayers: any = visibleServerLayers
       .flatten((item: any) => item.sublayers)

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -43,6 +43,8 @@ interface FeatureResult {
 export interface LayerFeatureResult {
   layerTitle: string;
   layerID: string;
+  sublayerTitle: string | null;
+  sublayerID: string | null;
   features: FeatureResult[];
 }
 


### PR DESCRIPTION
Fix for #834

Adding check if client side feature does not have layer info, we assume it comes through with the `sourceLayer` and we can get all appropriate information from that object. Tracking layer id, title and sublayer id, title (if available) in redux.

Discovered a strange behavior where queries for features happened twice, client side popup promises were firing and server side query for the same layer was firing. Assumption was made that client side would not process `map-image` types but it was wrong. Added additional check for double queries. May need to be addressed down the line.
https://github.com/wri/gfw-mapbuilder/compare/clean-slate...834-layer-sublayer-query?expand=1#diff-fa1c44fea8601fa048fe926fe7f9d0c2R100