### PR TITLE
Ticket 848 - Pen widget - Uploading a shapefile logic

### DIFF
--- a/src/js/components/mapWidgets/widgetContent/penContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/penContent.tsx
@@ -1,6 +1,8 @@
 import React, { FunctionComponent, DragEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
+import UploadFile from 'js/components/sharedComponents/UploadFile';
+
 import { renderModal } from 'js/store/appState/actions';
 
 import { mapController } from 'js/controllers/mapController';
@@ -33,19 +35,6 @@ const PenContent: FunctionComponent = () => {
   const setDrawTool = () => {
     dispatch(renderModal(''));
     mapController.createPolygonSketch();
-  };
-
-  const onDragFile = (event: DragEvent<HTMLDivElement>): void => {
-    event.preventDefault();
-    event.stopPropagation();
-  };
-
-  const onDropFile = (event: DragEvent<HTMLDivElement>): void => {
-    event.preventDefault();
-    event.stopPropagation();
-
-    const file = event.dataTransfer.files[0];
-    console.log('onDropFile()', file);
   };
 
   return (
@@ -90,12 +79,7 @@ const PenContent: FunctionComponent = () => {
           {coordinatesButton}
         </button>
         <hr />
-        <div
-          onDragOver={(e: DragEvent<HTMLDivElement>): void => onDragFile(e)}
-          onDrop={(e: DragEvent<HTMLDivElement>): void => onDropFile(e)}
-        >
-          <span>{shapefileButton}</span>
-        </div>
+        <UploadFile />
         <p className="shapefile-instructions">* {shapefileInstructions}</p>
       </div>
     </div>

--- a/src/js/components/mapWidgets/widgetContent/penContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/penContent.tsx
@@ -45,24 +45,7 @@ const PenContent: FunctionComponent = () => {
     event.stopPropagation();
 
     const file = event.dataTransfer.files[0];
-
-    const formData = new FormData();
-    formData.append('file', file, file.name);
-
-    const xhr = new XMLHttpRequest();
-    const url = 'https://production-api.globalforestwatch.org/v1/ogr/convert';
-    xhr.open('POST', url, true);
-    debugger;
-    xhr.onreadystatechange = (): void => {
-      debugger;
-      if (xhr.readyState === 4 && xhr.status === 200) {
-        debugger;
-        //   const response = geojsonUtil.geojsonToArcGIS(JSON.parse(xhr.responseText).data.attributes);
-        //   this.processGeojson(response);
-        // } else if (xhr.readyState === 4) {
-        //   console.log('Error: shapefile not working');
-      }
-    };
+    console.log('onDropFile()', file);
   };
 
   return (

--- a/src/js/components/mapWidgets/widgetContent/penContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/penContent.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, DragEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { renderModal } from 'js/store/appState/actions';
@@ -33,6 +33,36 @@ const PenContent: FunctionComponent = () => {
   const setDrawTool = () => {
     dispatch(renderModal(''));
     mapController.createPolygonSketch();
+  };
+
+  const onDragFile = (event: DragEvent<HTMLDivElement>): void => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const onDropFile = (event: DragEvent<HTMLDivElement>): void => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const file = event.dataTransfer.files[0];
+
+    const formData = new FormData();
+    formData.append('file', file, file.name);
+
+    const xhr = new XMLHttpRequest();
+    const url = 'https://production-api.globalforestwatch.org/v1/ogr/convert';
+    xhr.open('POST', url, true);
+    debugger;
+    xhr.onreadystatechange = (): void => {
+      debugger;
+      if (xhr.readyState === 4 && xhr.status === 200) {
+        debugger;
+        //   const response = geojsonUtil.geojsonToArcGIS(JSON.parse(xhr.responseText).data.attributes);
+        //   this.processGeojson(response);
+        // } else if (xhr.readyState === 4) {
+        //   console.log('Error: shapefile not working');
+      }
+    };
   };
 
   return (
@@ -77,7 +107,12 @@ const PenContent: FunctionComponent = () => {
           {coordinatesButton}
         </button>
         <hr />
-        <button>{shapefileButton}</button>
+        <div
+          onDragOver={(e: DragEvent<HTMLDivElement>): void => onDragFile(e)}
+          onDrop={(e: DragEvent<HTMLDivElement>): void => onDropFile(e)}
+        >
+          <span>{shapefileButton}</span>
+        </div>
         <p className="shapefile-instructions">* {shapefileInstructions}</p>
       </div>
     </div>

--- a/src/js/components/sharedComponents/UploadFile.tsx
+++ b/src/js/components/sharedComponents/UploadFile.tsx
@@ -1,0 +1,60 @@
+import React, { FunctionComponent, DragEvent } from 'react';
+import { useSelector } from 'react-redux';
+
+function UploadFile(): JSX.Element {
+  const selectedLanguage = useSelector(
+    (state: any) => state.appState.selectedLanguage
+  );
+
+  const uploadContent = {
+    en: {
+      shapefileButton: 'or drop a custom shapefile here'
+    },
+    ka: {
+      shapefileButton: 'ან შემოიტანეთ სხვა შეიპფაილი'
+    },
+    fr: {
+      shapefileButton: 'ou glissez un shapefile ici'
+    },
+    es: {
+      shapefileButton: 'o dejar un shapefile aquí'
+    },
+    pt: {
+      shapefileButton: 'ou soltar aqui um shapefile personalizado'
+    },
+    id: {
+      shapefileButton: 'or drop a custom shapefile here'
+    },
+    zh: {
+      shapefileButton: '或者在这里添加自定义地理信息系统文件（shapefile）'
+    }
+  };
+
+  const { shapefileButton } = uploadContent[selectedLanguage];
+
+  const onDragFile = (event: DragEvent<HTMLDivElement>): void => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const onDropFile = (event: DragEvent<HTMLDivElement>): void => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const file = event.dataTransfer.files[0];
+    console.log('onDropFile()', file);
+  };
+
+  return (
+    <>
+      <div
+        onDragOver={(e: DragEvent<HTMLDivElement>): void => onDragFile(e)}
+        onDrop={(e: DragEvent<HTMLDivElement>): void => onDropFile(e)}
+      >
+        <span>{shapefileButton}</span>
+      </div>
+    </>
+  );
+}
+
+export default UploadFile;


### PR DESCRIPTION
This PR logs when a user has uploaded a file

- Fixes https://github.com/wri/gfw-mapbuilder/issues/848

What it accomplishes;
- Tracks when a user has uploaded a file
- Prevents default browser behavior via `onDragFile()`

What it does not accomplish;
- Desktop/mobile styling
- Logic that adds the shapefile to map