### PR TITLE
Ticket 789 - Typesafe this._selectedWidget 

### DIFF
--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -94,10 +94,6 @@ export class MapController {
   _printTask: PrintTask | undefined;
   _legend: Legend | undefined;
   _selectedWidget: DistanceMeasurement2D | AreaMeasurement2D | undefined;
-  // _selectedWidget: any; // DistanceMeasurement2D | AreaMeasurement2D | undefined;
-  // * NOTE - _selectedWidget is typed as any
-  // * because ESRI's TS types measurementLabel as a string
-  // * when AreaMeasurement2D.viewModel.measurementLabel is an object
 
   constructor() {
     this._map = undefined;

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -93,7 +93,8 @@ export class MapController {
   _pointerMoveEventListener: EventListener | any;
   _printTask: PrintTask | undefined;
   _legend: Legend | undefined;
-  _selectedWidget: any; // DistanceMeasurement2D | AreaMeasurement2D | undefined;
+  _selectedWidget: DistanceMeasurement2D | AreaMeasurement2D | undefined;
+  // _selectedWidget: any; // DistanceMeasurement2D | AreaMeasurement2D | undefined;
   // * NOTE - _selectedWidget is typed as any
   // * because ESRI's TS types measurementLabel as a string
   // * when AreaMeasurement2D.viewModel.measurementLabel is an object
@@ -555,12 +556,14 @@ export class MapController {
       if (state === 'measured') {
         if (optionType === 'area') {
           areaResults = {
-            area: this._selectedWidget.viewModel.measurementLabel.area,
-            perimeter: this._selectedWidget.viewModel.measurementLabel.perimeter
+            area: this._selectedWidget?.viewModel.measurementLabel['area'],
+            perimeter: this._selectedWidget?.viewModel.measurementLabel[
+              'perimeter'
+            ]
           };
         } else if (optionType === 'distance') {
           distanceResults = {
-            length: this._selectedWidget.viewModel.measurementLabel
+            length: this._selectedWidget?.viewModel.measurementLabel
           };
         }
 
@@ -632,8 +635,10 @@ export class MapController {
       switch (optionType) {
         case 'area':
           areaResults = {
-            area: this._selectedWidget.viewModel.measurementLabel.area,
-            perimeter: this._selectedWidget.viewModel.measurementLabel.perimeter
+            area: this._selectedWidget.viewModel.measurementLabel['area'],
+            perimeter: this._selectedWidget.viewModel.measurementLabel[
+              'perimeter'
+            ]
           };
           break;
         case 'distance':


### PR DESCRIPTION
This PR typesafes `this._selectedWidget` so we can leverage intellisense to access information on the distance or area widgets

Fixes https://github.com/wri/gfw-mapbuilder/issues/789

What it accomplishes;
    - Refactors code to leverage optional parameters & indirectly access properties to resolve TS errors

What it does not accomplish
    - Doesn't explain why accessing a property with `[]`bracket syntax overrides TSlint