### PR TITLE
Last feature highlight bug

### DIFF
--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -31,12 +31,14 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
     const activeLayerIndex = activeFeatures.findIndex(
       f => f.layerID === activeLayer
     );
+
     if (activeLayerInfo) {
       mapController.drawGraphic(
         activeFeatures[activeLayerIndex].features[activeFeatureIndex[1]]
           .geometry
       );
     }
+
     const LayerAttributesElement = (props: {
       activeLayerInfo: any;
       activeLayerIndex: number;
@@ -76,6 +78,8 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
           dispatch(setActiveFeatures(oldActiveFeatures));
           //update active layerindex as the old one does not exit anymore
           dispatch(setActiveFeatureIndex([0, 0]));
+          //clean out graphics layer from all leftover highligh graphics
+          mapController.removeAllGraphics('active-feature-layer');
         } else {
           //remove only one feature and keep everything else intact
           oldActiveFeatures[activeLayerIndex].features.splice(

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -470,6 +470,13 @@ export class MapController {
     store.dispatch(allAvailableLayers(newLayersArray));
   }
 
+  removeAllGraphics(layerID: string): void {
+    const layer: any = this._map?.findLayerById(layerID);
+    if (layer) {
+      layer.removeAll();
+    }
+  }
+
   drawGraphic(geometry: __esri.Geometry): void {
     if (this._map) {
       createAndAddNewGraphic(this._map, geometry);

--- a/src/js/helpers/MapGraphics.ts
+++ b/src/js/helpers/MapGraphics.ts
@@ -1,4 +1,3 @@
-//@ts-nocheck
 import Map from 'esri/Map';
 import GraphicsLayer from 'esri/layers/GraphicsLayer';
 import Graphic from 'esri/Graphic';
@@ -8,7 +7,7 @@ export function createAndAddNewGraphic(
   geometry?: __esri.Geometry
 ): void {
   if (!geometry) return;
-  let graphicsLayer = map.findLayerById('active-feature-layer');
+  let graphicsLayer: any = map.findLayerById('active-feature-layer');
   if (graphicsLayer) {
     graphicsLayer.removeAll(); //TODO: We may need to support multiple selected features in future
   } else {
@@ -18,7 +17,7 @@ export function createAndAddNewGraphic(
     map.add(graphicsLayer);
   }
 
-  const symbol = {
+  const symbol: any = {
     color: [0, 0, 0, 0],
     outline: {
       color: [115, 252, 253],


### PR DESCRIPTION
Fixes: #855

- Added a helper in mapcontroller that removes all graphics from passed layer id
- data tab now successfully clears last feature from the map