### PR TITLE
Ticket 848 - Uploading a shapefile logic 

### DIFF
--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -42,10 +42,9 @@ import { OptionType } from 'js/interfaces/measureWidget';
 import { LayerFactoryObject } from 'js/interfaces/mapping';
 import { addPopupWatchUtils } from 'js/helpers/DataPanel';
 
-import { SpecificDMSSection } from 'js/interfaces/coordinateForm';
-
-import { convertDMSToXY } from 'js/utils/helper.config';
 import { createAndAddNewGraphic } from 'js/helpers/MapGraphics';
+
+import { getCustomSymbol } from 'js/utils/symbol.config';
 
 const allowedLayers = ['feature', 'dynamic', 'loss', 'gain']; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
 
@@ -901,6 +900,65 @@ export class MapController {
       this._map.basemap = basemap;
       store.dispatch(setSelectedBasemap(id));
     }
+  }
+
+  processGeojson(esriJson: any): any {
+    const graphics: Array<Graphic> = [];
+    esriJson.forEach((feature: any) => {
+      const graphic = new Graphic({
+        geometry: new Polygon(feature.geometry),
+        symbol: getCustomSymbol(),
+        attributes: feature.attributes
+        // source: attributes.SOURCE_UPLOAD
+        // * NOTE: ^ this was in original version
+      });
+      graphics.push(graphic);
+      this._mapview.graphics.add(graphic);
+    });
+    this._mapview.goTo(graphics);
+
+    // ? Do we need the v1 logic below?
+
+    // const graphicsExtent = graphicsUtils.graphicsExtent(graphics);
+    // const layer = this.context.map.getLayer(layerKeys.USER_FEATURES);
+    // if (layer) {
+    //   this.context.map.setExtent(graphicsExtent, true);
+
+    //   const geometryService = new GeometryService(
+    //     'https://utility.arcgisonline.com/ArcGIS/rest/services/Geometry/GeometryServer'
+    //   );
+    //   var params = new ProjectParameters();
+
+    //   // Set the projection of the geometry for the image server
+    //   params.outSR = new SpatialReference(102100);
+    //   params.geometries = [];
+
+    //   graphics.forEach(feature => {
+    //     params.geometries.push(feature.geometry);
+    //   });
+
+    //   // update the graphics geometry with the new projected geometry
+    //   const successfullyProjected = geometries => {
+    //     graphics.forEach((graphic, i) => {
+    //       graphic.geometry = geometries[i];
+    //       layer.add(graphic);
+    //       if (i === geometries.length - 1) {
+    //         geometryUtils
+    //           .generateDrawnPolygon(graphic.geometry)
+    //           .then(registeredGraphic => {
+    //             this.context.map.infoWindow.setFeatures([registeredGraphic]);
+    //           });
+    //       }
+    //     });
+    //   };
+    //   const failedToProject = err => {
+    //     console.log('Failed to project the geometry: ', err);
+    //   };
+    //   geometryService
+    //     .project(params)
+    //     .then(successfullyProjected, failedToProject);
+    // }
+    // this.setState({ isUploading: false });
   }
 }
 

--- a/src/js/utils/geojson.config.ts
+++ b/src/js/utils/geojson.config.ts
@@ -1,0 +1,193 @@
+import { Geometry } from 'esri/geometry';
+
+interface SpatialReference {
+  wkid: number;
+}
+
+interface GenericProperties {
+  AFFGEOID?: string;
+  GEOID?: string;
+  NAME?: string;
+}
+
+interface FeatureResult {
+  geometry?: Geometry;
+  attributes: GenericProperties;
+  id?: number | string; // ? What's the type? Haven't been able to determine this
+}
+
+interface GenericPolygonResult {
+  rings?: Array<Array<number>>;
+  spatialReference?: SpatialReference;
+}
+
+interface PointResult {
+  x: number;
+  y: number;
+  spatialReference?: SpatialReference;
+}
+
+interface MultiPointResult {
+  points: any;
+  // ? What's the type? Haven't been able to determine this
+  // TODO typesafe paths
+  spatialReference?: SpatialReference;
+}
+
+interface GenericStringResult {
+  paths: Array<any>;
+  // ? What's the type? Haven't been able to determine this
+  // TODO typesafe paths
+  spatialReference?: SpatialReference;
+}
+
+// checks if 2 x,y points are equal
+const pointsEqual = (a: Array<number>, b: Array<number>): boolean => {
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+// checks if the first and last points of a ring are equal and closes the ring
+const closeRing = (coordinates: Array<Array<number>>): Array<Array<number>> => {
+  if (!pointsEqual(coordinates[0], coordinates[coordinates.length - 1])) {
+    coordinates.push(coordinates[0]);
+  }
+  return coordinates;
+};
+
+// determine if polygon ring coordinates are clockwise. clockwise signifies outer ring, counter-clockwise an inner ring
+// or hole. this logic was found at http://stackoverflow.com/questions/1165647/how-to-determine-if-a-list-of-polygon-
+// points-are-in-clockwise-order
+const ringIsClockwise = (ringToTest: Array<Array<number>>): boolean => {
+  let total = 0;
+  let i = 0;
+  let pt1 = ringToTest[i];
+  let pt2;
+  for (i; i < ringToTest.length - 1; i++) {
+    pt2 = ringToTest[i + 1];
+    total += (pt2[0] - pt1[0]) * (pt2[1] + pt1[1]);
+    pt1 = pt2;
+  }
+  return total >= 0;
+};
+
+const orientRings = (poly: any): any => {
+  // * NOTE: haven't been able to typesafe param/return
+  // * without TS Errors
+  // TODO [ ] - typesafe param & return
+  const output = [];
+  const polygon = poly.slice(0);
+  const outerRing = closeRing(polygon.shift().slice(0));
+  if (outerRing.length >= 4) {
+    if (!ringIsClockwise(outerRing)) {
+      outerRing.reverse();
+    }
+
+    output.push(outerRing);
+
+    for (let i = 0; i < polygon.length; i++) {
+      const hole = closeRing(polygon[i].slice(0));
+      if (hole.length >= 4) {
+        if (ringIsClockwise(hole)) {
+          hole.reverse();
+        }
+        output.push(hole);
+      }
+    }
+  }
+  return output;
+};
+
+// This function flattens holes in multipolygons to one array of polygons
+// used for converting GeoJSON Polygons to ArcGIS Polygons
+const flattenMultiPolygonRings = (
+  rings: Array<Array<number>>
+): Array<Array<number>> => {
+  const output = [];
+  for (let i = 0; i < rings.length; i++) {
+    const polygon = orientRings(rings[i]);
+    for (let x = polygon.length - 1; x >= 0; x--) {
+      const ring = polygon[x].slice(0);
+      output.push(ring);
+    }
+  }
+  return output;
+};
+
+export const geojsonToArcGIS = (
+  geojson: any,
+  // * NOTE: cannot typesafe param geojson without TS errors
+  // TODO [ ] - typesafe geojson
+  idAttribute = 'OBJECTID'
+): any => {
+  const spatialReference = { wkid: 4326 };
+  let result;
+  let i;
+
+  switch (geojson.type) {
+    case 'FeatureCollection':
+      result = [];
+      for (i = 0; i < geojson.features.length; i++) {
+        result.push(geojsonToArcGIS(geojson.features[i], idAttribute));
+      }
+      break;
+    case 'Feature':
+      result = {} as FeatureResult;
+      if (geojson.geometry) {
+        result.geometry = geojsonToArcGIS(geojson.geometry, idAttribute);
+      }
+      result.attributes = geojson.properties
+        ? { ...geojson.properties } // shallowClone(geojson.properties)
+        : {};
+
+      if (geojson.id) {
+        result.attributes[idAttribute] = geojson.id;
+      }
+      break;
+    case 'MultiPolygon':
+      result = {} as GenericPolygonResult;
+      result.rings = flattenMultiPolygonRings(geojson.coordinates.slice(0));
+      result.spatialReference = spatialReference;
+      break;
+    case 'Point':
+      result = {} as PointResult;
+      result.x = geojson.coordinates[0];
+      result.y = geojson.coordinates[1];
+      result.spatialReference = spatialReference;
+      break;
+    case 'MultiPoint':
+      result = {} as MultiPointResult;
+      result.points = geojson.coordinates.slice(0);
+      result.spatialReference = spatialReference;
+      break;
+    case 'LineString':
+      result = {} as GenericStringResult;
+      result.paths = [geojson.coordinates.slice(0)];
+      result.spatialReference = spatialReference;
+      break;
+    case 'MultiLineString':
+      result = {} as GenericStringResult;
+      result.paths = geojson.coordinates.slice(0);
+      result.spatialReference = spatialReference;
+      break;
+    case 'Polygon':
+      if (geojson.coordinates.length > 0) {
+        result = {} as GenericPolygonResult;
+        result.rings = orientRings(geojson.coordinates.slice(0));
+        result.spatialReference = spatialReference;
+      }
+      break;
+    case 'GeometryCollection':
+      result = [];
+      for (i = 0; i < geojson.geometries.length; i++) {
+        result.push(geojsonToArcGIS(geojson.geometries[i], idAttribute));
+      }
+      break;
+  }
+
+  return result;
+};

--- a/src/js/utils/symbol.config.ts
+++ b/src/js/utils/symbol.config.ts
@@ -1,38 +1,25 @@
 import SimpleFillSymbol from 'esri/symbols/SimpleFillSymbol';
 
-let customSymbol: undefined | SimpleFillSymbol = undefined;
-let imagerySymbol: undefined | SimpleFillSymbol = undefined;
-
-export const getCustomSymbol = (): any => {
-  if (customSymbol) {
-    return customSymbol;
-  } else {
-    customSymbol = new SimpleFillSymbol({
-      style: 'solid',
-      color: [210, 210, 210, 0.0],
-      outline: {
-        // autocasts as new SimpleLineSymbol()
-        color: [3, 188, 255],
-        width: 3
-      }
-    });
-    return customSymbol;
-  }
+export const getCustomSymbol = (): SimpleFillSymbol => {
+  return new SimpleFillSymbol({
+    style: 'solid',
+    color: [210, 210, 210, 0.0],
+    outline: {
+      // autocasts as new SimpleLineSymbol()
+      color: [3, 188, 255],
+      width: 3
+    }
+  });
 };
 
-export const getImagerySymbol = (): any => {
-  if (imagerySymbol) {
-    return imagerySymbol;
-  } else {
-    imagerySymbol = new SimpleFillSymbol({
-      style: 'solid',
-      color: [210, 210, 210, 0.0],
-      outline: {
-        // autocasts as new SimpleLineSymbol()
-        color: [210, 210, 210, 0],
-        width: 1
-      }
-    });
-    return imagerySymbol;
-  }
+export const getImagerySymbol = (): SimpleFillSymbol => {
+  return new SimpleFillSymbol({
+    style: 'solid',
+    color: [210, 210, 210, 0.0],
+    outline: {
+      // autocasts as new SimpleLineSymbol()
+      color: [210, 210, 210, 0],
+      width: 1
+    }
+  });
 };

--- a/src/js/utils/symbol.config.ts
+++ b/src/js/utils/symbol.config.ts
@@ -1,0 +1,38 @@
+import SimpleFillSymbol from 'esri/symbols/SimpleFillSymbol';
+
+let customSymbol: undefined | SimpleFillSymbol = undefined;
+let imagerySymbol: undefined | SimpleFillSymbol = undefined;
+
+export const getCustomSymbol = (): any => {
+  if (customSymbol) {
+    return customSymbol;
+  } else {
+    customSymbol = new SimpleFillSymbol({
+      style: 'solid',
+      color: [210, 210, 210, 0.0],
+      outline: {
+        // autocasts as new SimpleLineSymbol()
+        color: [3, 188, 255],
+        width: 3
+      }
+    });
+    return customSymbol;
+  }
+};
+
+export const getImagerySymbol = (): any => {
+  if (imagerySymbol) {
+    return imagerySymbol;
+  } else {
+    imagerySymbol = new SimpleFillSymbol({
+      style: 'solid',
+      color: [210, 210, 210, 0.0],
+      outline: {
+        // autocasts as new SimpleLineSymbol()
+        color: [210, 210, 210, 0],
+        width: 1
+      }
+    });
+    return imagerySymbol;
+  }
+};


### PR DESCRIPTION
This PR integrates logic from `v1` to upload zipped shapefiles via `UploadFile.tsx`.

Fixes part of #848 

What it accomplishes;
- Fetches `geojson` version of zipped shapefile, converts to necessary ArcGIS modules and adds their graphics to the map. Does this by leveraging `v1` logic
- Adds `TODO`s of next steps as needed
- Organizes `v1` logic into `.config.ts` files as needed

What it does not accomplish;
- Does not fully integrate `v1` logic of `processGeojson()` since we haven't determined if *...
    - commented out logic exists to account for other types of file uploads
    - commented out logic exists to account for regressions

_* Just a note_ - `processGeojson()` `v1` logic isn't fully integrated to keep the logic as lean as possible. For example, some of the code that's been commented out is logic that was replaced by `this._mapview.graphics.add(graphic)` and `this._mapview.goTo(graphics)`. As we gain a better understanding of the upload file feature, it's possible we'll need to integrate more of the original logic. 