### PR TITLE
Ticket 848 - Uploading a shapefile UI and logic

### DIFF
--- a/src/css/uploadFile.scss
+++ b/src/css/uploadFile.scss
@@ -27,6 +27,10 @@
     font-size: 0.75rem;
     margin-left: 3rem;
     margin-right: 3rem;
+
+    &.red {
+      color: red;
+    }
   }
 }
 

--- a/src/js/components/sharedComponents/UploadFile.tsx
+++ b/src/js/components/sharedComponents/UploadFile.tsx
@@ -1,15 +1,24 @@
-import React, { DragEvent } from 'react';
-import { useSelector } from 'react-redux';
+import React, { DragEvent, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import {
+  renderModal,
+  toggleTabviewPanel,
+  selectActiveTab
+} from 'js/store/appState/actions';
+
+import { mapController } from 'js/controllers/mapController';
 
 import { geojsonToArcGIS } from 'js/utils/geojson.config';
-import { mapController } from 'js/controllers/mapController';
 
 import 'css/uploadFile.scss';
 
 const UploadFile = (): JSX.Element => {
+  const dispatch = useDispatch();
   const selectedLanguage = useSelector(
     (state: any) => state.appState.selectedLanguage
   );
+  const [wrongFileType, setWrongFileType] = useState(false);
 
   const uploadContent = {
     en: {
@@ -61,15 +70,18 @@ const UploadFile = (): JSX.Element => {
   const onDropFile = async (
     event: DragEvent<HTMLDivElement>
   ): Promise<void> => {
+    setWrongFileType(false);
     const url = 'https://production-api.globalforestwatch.org/v1/ogr/convert';
     event.preventDefault();
     event.stopPropagation();
     event.persist();
 
     const file = event.dataTransfer.files[0];
+    const isZipfile = file.type === 'application/zip';
+    const isGeoJSON = file.name.includes('geojson'); // * NOTE: geoJSON files don't have a set type
 
-    if (file) {
-      // TODO [ ] - Integrate spinner (separate PR/feature branch)!
+    if (file && (isZipfile || isGeoJSON)) {
+      // TODO - [ ] Turn on spinner!
       const formData = new FormData();
       formData.append('file', file, file.name);
 
@@ -82,13 +94,12 @@ const UploadFile = (): JSX.Element => {
 
       const results = geojsonToArcGIS(featureCollection.data.attributes);
       mapController.processGeojson(results);
-      // TODO [ ] - dispatch to close leftPanel
-      // TODO [ ] - dispatch to close Modal
+      dispatch(toggleTabviewPanel(true));
+      dispatch(selectActiveTab('analysis'));
+      dispatch(renderModal(''));
     } else {
-      // TODO - logic to handle if there is no file
-      //        ? Sweet alert?
-      // TODO [ ] - dispatch to close leftPanel
-      // TODO [ ] - dispatch to close Modal
+      // TODO - [ ] Turn off spinner!
+      setWrongFileType(true);
     }
   };
 
@@ -101,7 +112,9 @@ const UploadFile = (): JSX.Element => {
       >
         <span>{shapefileButton}</span>
       </div>
-      <p className="shapefile-instructions">* {shapefileInstructions}</p>
+      <p className={`shapefile-instructions ${wrongFileType ? 'red' : ''}`}>
+        * {shapefileInstructions}
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
This PR conditionally closes the modal and sets the active tab of the left panel.

Fixes part of https://github.com/wri/gfw-mapbuilder/issues/848

What it accomplishes
- Conditionally closes the modal
- Conditionally renders the analysis tab of the left panel
- Conditionally checks the file type
- Conditionally manages local component state, `wrongFileType` to set the disclaimer in red 

What it does not accomplish
- turning on/off a spinner