### PR TITLE
Ticket 861 - MyGFW Subscriptions logic

### DIFF
--- a/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
@@ -121,14 +121,19 @@ const SubscriptionContent: FunctionComponent = () => {
           credentials: 'include'
         }
       )
-        .then(response => response.json())
-        .catch(e => console.log('error in deleteSubscription()', e));
+        .then(response => {
+          if (response.status === 200) {
+            const updatedSubscriptions = userSubscriptions.filter(
+              (s: Subscription) => s.id !== subscriptionID
+            );
 
-      const updatedSubscriptions = userSubscriptions.filter(
-        (s: Subscription) => s.id !== subscriptionID
-      );
-
-      dispatch(setUserSubscriptions(updatedSubscriptions));
+            dispatch(setUserSubscriptions(updatedSubscriptions));
+          }
+        })
+        .catch(e => {
+          console.log('error in deleteSubscription()', e);
+          // TODO [ ] - Need UI error handling logic!
+        });
     };
 
     return (

--- a/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
@@ -26,6 +26,7 @@ interface SubscriptionAttributes {
   userId: string;
   resource: object;
   datasets: string[];
+  confirmed: boolean;
   // datasets: Array<string>;
   // resource: {type: "EMAIL", content: "lc07@uw.edu"}
   // datasets: (2) ["umd-loss-gain", "glad-alerts"]
@@ -36,6 +37,11 @@ interface Subscription {
   type: string;
   id: string;
   key: number;
+}
+
+interface SubscriptionProps {
+  subscription: Subscription;
+  userSubscriptions: Array<Subscription>;
 }
 
 const SubscriptionContent: FunctionComponent = () => {
@@ -80,7 +86,10 @@ const SubscriptionContent: FunctionComponent = () => {
     );
   };
 
-  const SubscriptionDetails = (props: any, key: number): any => {
+  const SubscriptionDetails = (
+    props: SubscriptionProps,
+    key: number
+  ): JSX.Element => {
     const { subscription, userSubscriptions } = props;
 
     const date = new Date(subscription.attributes.createdAt);
@@ -116,7 +125,7 @@ const SubscriptionContent: FunctionComponent = () => {
         .catch(e => console.log('error in deleteSubscription()', e));
 
       const updatedSubscriptions = userSubscriptions.filter(
-        (s: any) => s.id !== subscriptionID
+        (s: Subscription) => s.id !== subscriptionID
       );
 
       dispatch(setUserSubscriptions(updatedSubscriptions));
@@ -192,8 +201,8 @@ const SubscriptionContent: FunctionComponent = () => {
       </p>
       {userSubscriptions.map((subscription: any, i: number) => (
         <SubscriptionDetails
-          subscription={subscription}
-          userSubscriptions={userSubscriptions}
+          subscription={subscription as Subscription}
+          userSubscriptions={userSubscriptions as Array<Subscription>}
           key={i}
         />
       ))}

--- a/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
@@ -111,10 +111,8 @@ const SubscriptionContent: FunctionComponent = () => {
     //TODO: May need to push into the config
     const subscribeUrl = `https://production-api.globalforestwatch.org/v1/subscriptions/${subscription.id}/send_confirmation`;
 
-    const deleteSubscription = async (
-      subscriptionID: string
-    ): Promise<void> => {
-      await fetch(
+    const deleteSubscription = (subscriptionID: string): void => {
+      fetch(
         `https://production-api.globalforestwatch.org/v1/subscriptions/${subscriptionID}`,
         {
           method: 'DELETE',
@@ -169,7 +167,7 @@ const SubscriptionContent: FunctionComponent = () => {
           <div className="delete-row">
             <button
               title="Delete subscription"
-              onClick={(): Promise<void> => deleteSubscription(subscription.id)}
+              onClick={(): void => deleteSubscription(subscription.id)}
               className="btn-delete-subscription"
             >
               <DeleteIcon height={25} width={25} fill={'#555'} />

--- a/src/js/components/mapWidgets/widgetContent/myGFWContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/myGFWContent.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from 'js/store';
-import { userSubscriptions } from 'js/store/mapview/actions';
+import { setUserSubscriptions } from 'js/store/mapview/actions';
 import { renderModal } from 'js/store/appState/actions';
 
 const MyGFWContent: FunctionComponent = () => {
@@ -32,7 +32,7 @@ const MyGFWContent: FunctionComponent = () => {
       })
         .then(response => {
           response.json().then(json => {
-            dispatch(userSubscriptions(json.data));
+            dispatch(setUserSubscriptions(json.data));
             dispatch(renderModal('SubscriptionWidget'));
           });
         })

--- a/src/js/store/mapview/actions.ts
+++ b/src/js/store/mapview/actions.ts
@@ -23,7 +23,9 @@ export function mapError(payload: MapviewState['loadError']) {
   };
 }
 
-export function userSubscriptions(payload: MapviewState['userSubscriptions']) {
+export function setUserSubscriptions(
+  payload: MapviewState['userSubscriptions']
+) {
   return {
     type: USER_SUBSCRIPTIONS as typeof USER_SUBSCRIPTIONS,
     payload

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -80,7 +80,7 @@ interface AllAvailableLayersAction {
   payload: MapviewState['allAvailableLayers'];
 }
 
-interface UserSubscriptionsAction {
+interface SetUserSubscriptionsAction {
   type: typeof USER_SUBSCRIPTIONS;
   payload: MapviewState['userSubscriptions'];
 }
@@ -102,7 +102,7 @@ interface SetActiveFeatureIndex {
 export type MapviewStateTypes =
   | MapIsReadyAction
   | MapErrorAction
-  | UserSubscriptionsAction
+  | SetUserSubscriptionsAction
   | AllAvailableLayersAction
   | SetActiveFeaturesAction
   | SetActiveFeatureIndex


### PR DESCRIPTION
This PR handles logic to delete MyGFW subscriptions

Fixes part of https://github.com/wri/gfw-mapbuilder/issues/861

What it accomplishes;
- makes a `DELETE` request of the specific subscription
- updates Redux property (as opposed to refetching the remote subscriptions)
- typesafes delete logic and parent component
- updates actionCreator `userSubscriptions()` to `setUserSubscriptions()`

What it does not accomplish;
- does not fetch remote subscriptions _after_ deletion to confirm the update was successfully implemented. This is intentional as it optimizes performance
