### PR TITLE
Ticket 861 - MyGFW Subscriptions logic

### DIFF
--- a/src/css/modalCard.scss
+++ b/src/css/modalCard.scss
@@ -229,6 +229,10 @@
     float: right;
     margin-left: 10px;
     margin-top: 4px;
+
+    &.active-subscription {
+      background-color: rgb(240, 171, 0);
+    }
   }
 
   .subscription-unconfirmed {

--- a/src/css/modalCard.scss
+++ b/src/css/modalCard.scss
@@ -231,7 +231,7 @@
     margin-top: 4px;
 
     &.active-subscription {
-      background-color: rgb(240, 171, 0);
+      background-color: $base-yellow;
     }
   }
 

--- a/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
@@ -47,13 +47,6 @@ interface SubscriptionAttributes {
   userId: string;
   resource: SubscriptionResource;
   datasets: string[];
-  params: {
-    geostore: any;
-    iso: {
-      country: string;
-      region: string;
-    };
-  };
   confirmed: boolean;
   language: string;
   params: SubscriptionParams;

--- a/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
@@ -13,6 +13,11 @@ import { ReactComponent as WorldShape } from 'images/worldShape.svg';
 import { ReactComponent as DeleteIcon } from 'images/deleteIcon.svg';
 
 import { RootState } from 'js/store/index';
+import {
+  UserSubscription,
+  SubscriptionParams,
+  SubscriptionAttributes
+} from 'js/store/mapview/types';
 
 //TODO: Investigate if this is exhaustive list or needs to be configed out somehow
 const datasetMap = [
@@ -25,52 +30,10 @@ const datasetMap = [
   { id: 'prodes-loss', label: 'PRODES deforestation data' }
 ];
 
-interface SubscriptionParams {
-  iso: {
-    country: string;
-    region: string;
-  };
-  wdpaid: any;
-  use: any;
-  useid: any;
-  geostore: string;
-}
-
-interface SubscriptionResource {
-  type: string;
-  content: string;
-}
-
-interface SubscriptionAttributes {
-  name: string;
-  createdAt: string;
-  userId: string;
-  resource: SubscriptionResource;
-  datasets: string[];
-  confirmed: boolean;
-  language: string;
-  params: SubscriptionParams;
-  // datasets: Array<string>;
-  // resource: {type: "EMAIL", content: "lc07@uw.edu"}
-  // datasets: (2) ["umd-loss-gain", "glad-alerts"]
-}
-
-interface Subscription {
-  attributes: SubscriptionAttributes;
-  type: string;
-  id: string;
-  key: number;
-}
-
-interface SubscriptionProps {
-  subscription: Subscription;
-  userSubscriptions: Array<Subscription>;
-}
-
 interface JSONData {
-  datasets: Array<string>;
+  datasets: string[];
   language: string;
-  resource: SubscriptionResource;
+  resource: SubscriptionAttributes['resource'];
   params: SubscriptionParams;
 }
 
@@ -83,7 +46,7 @@ const SubscriptionContent: FunctionComponent = () => {
   interface DatasetAlertsProps {
     dataset: string;
     datasetLabel: string;
-    subscription: Subscription;
+    subscription: UserSubscription;
   }
   const DatasetAlerts = (props: DatasetAlertsProps): JSX.Element => {
     const { subscription, datasetLabel, dataset } = props;
@@ -160,10 +123,12 @@ const SubscriptionContent: FunctionComponent = () => {
     );
   };
 
-  const SubscriptionDetails = (
-    props: SubscriptionProps,
-    key: number
-  ): JSX.Element => {
+  interface SubscriptionProps {
+    subscription: UserSubscription;
+    userSubscriptions: UserSubscription[];
+  }
+
+  const SubscriptionDetails = (props: SubscriptionProps): JSX.Element => {
     const { subscription, userSubscriptions } = props;
 
     const date = new Date(subscription.attributes.createdAt);
@@ -186,7 +151,7 @@ const SubscriptionContent: FunctionComponent = () => {
     const subscribeUrl = `https://production-api.globalforestwatch.org/v1/subscriptions/${subscription.id}/send_confirmation`;
 
     const zoomToSubscription = async (
-      subscription: Subscription
+      subscription: UserSubscription
     ): Promise<void> => {
       // TODO [ ] - Integrate spinner!
       const geostoreID = subscription.attributes.params.geostore;
@@ -234,7 +199,7 @@ const SubscriptionContent: FunctionComponent = () => {
         .then(response => {
           if (response.status === 200) {
             const updatedSubscriptions = userSubscriptions.filter(
-              (s: Subscription) => s.id !== subscriptionID
+              (s: UserSubscription) => s.id !== subscriptionID
             );
 
             dispatch(setUserSubscriptions(updatedSubscriptions));
@@ -247,7 +212,7 @@ const SubscriptionContent: FunctionComponent = () => {
     };
 
     return (
-      <div key={key} className="source-row subscribe-row">
+      <div className="source-row subscribe-row">
         <div className="subscribe-button-container">
           <div className="subscription-unconfirmed">
             <div
@@ -318,10 +283,10 @@ const SubscriptionContent: FunctionComponent = () => {
         To add new subscriptions select a feature on the map and click on
         Subscribe in the info window.
       </p>
-      {userSubscriptions.map((subscription: any, i: number) => (
+      {userSubscriptions.map((subscription: UserSubscription, i: number) => (
         <SubscriptionDetails
-          subscription={subscription as Subscription}
-          userSubscriptions={userSubscriptions as Array<Subscription>}
+          subscription={subscription}
+          userSubscriptions={userSubscriptions}
           key={i}
         />
       ))}

--- a/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
@@ -89,7 +89,7 @@ const SubscriptionContent: FunctionComponent = () => {
     const { subscription, datasetLabel, dataset } = props;
     console.log('datasetNamedatasetName', props.datasetLabel);
 
-    const colorTheme = '#929292';
+    // const colorTheme = '#929292';
     // const { customColorTheme } = this.context.settings;
     // if (subscription.attributes.datasets.indexOf(dataset) !== -1 && customColorTheme && customColorTheme !== '') {
     //     colorTheme = customColorTheme;
@@ -109,12 +109,10 @@ const SubscriptionContent: FunctionComponent = () => {
       const datasetOn = subscription.attributes.datasets.includes(dataset);
 
       if (datasetOn) {
-        console.log('TURNING OFF');
         jsonData.datasets = subscription.attributes.datasets.filter(
           datasetID => datasetID !== dataset
         );
       } else {
-        console.log('TURNING ON');
         subscription.attributes.datasets.push(dataset);
         jsonData.datasets = subscription.attributes.datasets;
       }
@@ -133,24 +131,16 @@ const SubscriptionContent: FunctionComponent = () => {
         .then(response => (response.status === 200 ? response.json() : null))
         .then(results => {
           if (results) {
-            const original = userSubscriptions.find(
-              sub => sub.id === results.data.id
-            ) as Subscription;
-            const originalIndex = userSubscriptions.indexOf(original);
-            userSubscriptions[originalIndex] = { ...results.data };
+            const index = userSubscriptions.findIndex(
+              u => u.id === results.data.id
+            );
+            userSubscriptions[index] = { ...results.data };
             dispatch(setUserSubscriptions(userSubscriptions));
-            // TODO [X] - update the Redux store
-            // TODO [ ] - confirm that all objects in userSubscriptions are unique
-            // ? How do we dynamically check if userSubscriptions are unique?
-            // ? new Set() ?
-            // ? is there a better way of updating userSubscriptions
-            // TODO confirm change on myGFW
+          } else {
+            // TODO [ ] - dispatch error UI
           }
         })
-        .catch(e => {
-          console.log('error in updateDataset()', e);
-          // TODO [ ] - dispatch error UI
-        });
+        .catch(e => console.log('error in updateDataset()', e));
     };
 
     return (
@@ -158,7 +148,6 @@ const SubscriptionContent: FunctionComponent = () => {
         {datasetLabel}
         <span
           onClick={(): void => updateDataset()}
-          style={{ backgroundColor: `${colorTheme}` }}
           className={`toggle-switch-subscription pointer ${
             subscription.attributes.datasets.indexOf(props.dataset) === -1
               ? ''

--- a/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/SubscriptionContent.tsx
@@ -94,11 +94,12 @@ const SubscriptionContent: FunctionComponent = () => {
         .then(response => (response.status === 200 ? response.json() : null))
         .then(results => {
           if (results) {
-            const index = userSubscriptions.findIndex(
+            const copyUserSubscriptions = [...userSubscriptions];
+            const index = copyUserSubscriptions.findIndex(
               u => u.id === results.data.id
             );
-            userSubscriptions[index] = { ...results.data };
-            dispatch(setUserSubscriptions(userSubscriptions));
+            copyUserSubscriptions[index] = { ...results.data };
+            dispatch(setUserSubscriptions(copyUserSubscriptions));
           } else {
             // TODO [ ] - dispatch error UI
           }

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -15,8 +15,35 @@ export interface MeasureContent {
   coordinatePointerMoveResults?: any; // ClickResults | undefined | Point;
 }
 
-interface UserSubscription {
-  attributes: object;
+export interface SubscriptionResource {
+  type: string;
+  content: string;
+}
+
+export interface SubscriptionParams {
+  iso: {
+    country: string;
+    region: string;
+  };
+  wdpaid: any;
+  use: any;
+  useid: any;
+  geostore: string;
+}
+
+export interface SubscriptionAttributes {
+  name: string;
+  createdAt: string;
+  userId: string;
+  resource: SubscriptionResource;
+  datasets: string[];
+  confirmed: boolean;
+  language: string;
+  params: SubscriptionParams;
+}
+
+export interface UserSubscription {
+  attributes: SubscriptionAttributes;
   id: string;
   type: string;
 }


### PR DESCRIPTION
This PR implements logic to toggle datasets on and off for each subscriptions

Fixes part of #861 

What it accomplishes;
- makes a `PATCH` request with updated `datasets` for a specific subscription
- updated Redux store if `response.status` is `200`
- leverages TS interfaces
- applies styling via conditionally applied class, `.active-subscription`

<br/>

What it does not accomplish;
- desktop/mobile styling
- error-handling UI