### PR TITLE
Ticket 848 - Uploading a shapefile logic

### DIFF
--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -923,6 +923,7 @@ export class MapController {
   }
 
   processGeojson(esriJson: any): any {
+    this._mapview.graphics.removeAll();
     const graphics: Array<Graphic> = [];
     esriJson.forEach((feature: any) => {
       const graphic = new Graphic({


### PR DESCRIPTION
This PR removes graphics before adding an uploaded shapefile's graphics to the map.

Fixes part of #848 

What it accomplishes;
- removes all graphics from the mapview

What it does not accomplish;
- Doesn't anticipate potential instances where we may be inadvertently removing graphics tied to a separate feature of the app. I also haven't come across a workflow where this happens, so once I find one, I'll make a separate ticket and resolve it.