### PR TITLE
Ticket 867 - Update FB shareable link

### DIFF
--- a/src/js/components/mapWidgets/widgetContent/shareContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/shareContent.tsx
@@ -37,21 +37,13 @@ const ShareContent: FunctionComponent = () => {
   };
 
   const shareFacebook = (): void => {
-    const appID = 10000000000;
-    // TODO the appID needs to be generated/registered
-    // TODO through FB's developer site
+    // https://www.facebook.com/sharer.php?u=http://bit.ly/2I6y3Te
 
     window.open(
-      `https://www.facebook.com/dialog/feed?
-      app_id=${appID}
-      &link=${window.location.href}
-      &redirect_uri=${window.location.href}`,
+      `https://www.facebook.com/sharer.php?u=${window.location.href}`,
       'Facebook',
       popupDimensions
     );
-    // * NOTE; FB share button will open with error
-    // * 'Parameter 'href' should represent a valid URL'
-    // * because it doesn't support localhost URLs
   };
 
   const returnURL = (): string => {


### PR DESCRIPTION
This PR updates the shareable link to a new shareable link that doesn't require any developer keys

Fixes #867 

What it accomplishes;
- Updates the shareable link, and opens to a new tab

What it does not accomplish;
- Dynamically generating window location into a Bitly link
- Configuring share link to handle `localhost` URLs (doesn't appear possible). To test, swap out `${window.location.href}` with the alpha build.