### PR TITLE
Sublayer duplication fix

### DIFF
--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -107,6 +107,12 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
       const prevBtn = page === 0 ? 'disabled' : '';
       const nextBtn =
         page === props.activeLayerInfo.features.length - 1 ? 'disabled' : '';
+
+      // if we have sublayer title, show it as well
+      const layerTitle = props.activeLayerInfo.sublayerTitle
+        ? `${props.activeLayerInfo.layerTitle}: ${props.activeLayerInfo.sublayerTitle}`
+        : props.activeLayerInfo.layerTitle;
+
       return (
         <div className="layer-feature-group">
           <div className="layer-control-container">
@@ -144,7 +150,7 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
           <div className="page-numbers">
             {page + 1} / {props.activeLayerInfo.features.length}
           </div>
-          <div className="layer-title">{props.activeLayerInfo.layerTitle}</div>
+          <div className="layer-title">{layerTitle}</div>
           <hr />
           <AttributeTable
             attributes={props.activeLayerInfo.features[page].attributes}

--- a/src/js/components/leftPanel/dataPanel/LayerSelector.tsx
+++ b/src/js/components/leftPanel/dataPanel/LayerSelector.tsx
@@ -8,9 +8,15 @@ interface LayerSelectorProps {
 }
 const LayerSelector = (props: LayerSelectorProps): JSX.Element => {
   const options = props.activeFeatures.map(f => {
+    // const subtitle = f.sublayerTitle ? f.sublayerTitle : '';
+    // if we have sublayer title, show it as well
+    const layerTitle = f.sublayerTitle
+      ? `${f.layerTitle}: ${f.sublayerTitle}`
+      : f.layerTitle;
+
     return (
       <option value={f.layerID} key={f.layerID}>
-        {`${f.layerTitle} (${f.features.length})`}
+        {layerTitle}
       </option>
     );
   });

--- a/src/js/components/leftPanel/layersPanel/ImageryLayersGroup.tsx
+++ b/src/js/components/leftPanel/layersPanel/ImageryLayersGroup.tsx
@@ -45,9 +45,7 @@ const ImageryLayersGroup = (props: LayerGroupProps): React.ReactElement => {
         </button>
       </div>
       <div className={groupOpen ? 'layers-control-container' : 'hidden'}>
-        {allAvailableLayers.map(layer => (
-          <GenericLayerControl id={layer.id} key={layer.id} />
-        ))}
+        {allAvailableLayers.map(layer => null)}
       </div>
     </div>
   );

--- a/src/js/helpers/DataPanel.ts
+++ b/src/js/helpers/DataPanel.ts
@@ -5,7 +5,6 @@ import store from 'js/store';
 import QueryTask from 'esri/tasks/QueryTask';
 import Query from 'esri/tasks/support/Query';
 import Graphic from 'esri/Graphic';
-import Sublayer from 'esri/layers/support/Sublayer';
 import { once } from 'esri/core/watchUtils';
 import { setActiveFeatures } from 'js/store/mapview/actions';
 import { LayerFeatureResult } from 'js/store/mapview/types';
@@ -28,7 +27,7 @@ function extractLayerInfo(
     output.sublayerID = null;
   } else {
     //assume that we are in sublayer situation
-    output.layerID = featureObject[0].sourceLayer.layer.title;
+    output.layerID = featureObject[0].sourceLayer.layer.id;
     output.layerTitle = featureObject[0].sourceLayer.layer.title;
     output.sublayerTitle = featureObject[0].sourceLayer.title;
     output.sublayerID = featureObject[0].sourceLayer.id;
@@ -45,46 +44,75 @@ function esriQuery(url: string, queryParams: any): Promise<__esri.FeatureSet> {
   return result;
 }
 
-async function processSublayers(
+async function processLayers(
+  mapview: MapView,
   geometry: Point,
-  sublayersArray: Sublayer[],
-  mapview: MapView
+  layersCollection: __esri.Collection<any>
 ): Promise<any> {
-  const processedSubsResults: LayerFeatureResult[] = [];
-  for await (const sublayer of sublayersArray) {
-    const url = sublayer.url;
-    const qParams = {
-      where: '1=1',
-      outFields: ['*'],
-      units: 'miles',
-      distance: 0.02 * mapview.resolution,
-      geometry: geometry,
-      returnGeometry: true
-    };
-    try {
-      const sublayerResult = await esriQuery(url, qParams);
-      //if no features are found, skip it
-      if (sublayerResult.features.length !== 0) {
-        const features = sublayerResult.features.map(f => {
-          return {
-            attributes: f.attributes,
-            geometry: f.geometry //this is either null or geometry depending on our query!
-          };
-        });
-        const subCleanedResult = {
-          layerID: sublayer.layer.id,
-          layerTitle: sublayer.layer.title,
-          sublayerID: null,
-          sublayerTitle: null,
-          features: features
-        };
-        processedSubsResults.push(subCleanedResult);
+  const processedLayersResult: LayerFeatureResult[] = [];
+  const layersArray = layersCollection.toArray();
+  const queryParams = {
+    where: '1=1',
+    outFields: ['*'],
+    units: 'miles',
+    distance: 0.02 * mapview.resolution,
+    geometry: geometry,
+    returnGeometry: true
+  };
+  //if layer has sublayers, we query those
+  for await (const layer of layersArray) {
+    const url = layer.url;
+    if (layer.sublayers && layer.sublayers.length !== 0) {
+      for (const sublayer of layer.sublayers.items) {
+        const subUrl = sublayer.url;
+        try {
+          const sublayerResult = await esriQuery(subUrl, queryParams);
+          if (sublayerResult.features.length !== 0) {
+            const features = sublayerResult.features.map(f => {
+              return {
+                attributes: f.attributes,
+                geometry: f.geometry
+              };
+            });
+            const layerResultObject = {
+              layerID: layer.id,
+              layerTitle: layer.title,
+              sublayerID: sublayer.id,
+              sublayerTitle: sublayer.title,
+              features: features
+            };
+            processedLayersResult.push(layerResultObject);
+          }
+        } catch (e) {
+          console.error(e);
+        }
       }
-    } catch (e) {
-      console.log(e);
+    } else {
+      // no subs found on layer, query layer itself!
+      try {
+        const layerResult = await esriQuery(url, queryParams);
+        if (layerResult.features.length !== 0) {
+          const features = layerResult.features.map(f => {
+            return {
+              attributes: f.attributes,
+              geometry: f.geometry //this is either null or geometry depending on our query!
+            };
+          });
+          const layerResultObject = {
+            layerID: layer.id,
+            layerTitle: layer.title,
+            sublayerID: null,
+            sublayerTitle: null,
+            features: features
+          };
+          processedLayersResult.push(layerResultObject);
+        }
+      } catch (e) {
+        console.error(`Failed to query layer, ${layer.id}`);
+      }
     }
   }
-  return processedSubsResults;
+  return processedLayersResult;
 }
 
 async function fetchAsyncServerResults(
@@ -94,28 +122,16 @@ async function fetchAsyncServerResults(
   layerFeatureResults: LayerFeatureResult[]
 ): Promise<any> {
   if (map) {
-    const processedLayersByClientQuery = layerFeatureResults.map(
-      f => f.layerID
-    );
+    const processedLayerInfo = layerFeatureResults.map(f => f.layerID);
     const visibleServerLayers = map.layers
-      .filter(l => l.visible)
-      .filter(l => l.type !== 'graphics')
-      .filter(l => !processedLayersByClientQuery.includes(l.id));
-    //the third filter here ensures that we do not double count, for some reason some layers were being processed twice, at the client side (popup promise) and server side too. TODO: This may need further investigation, debugging with variuos county configs!
-    //Extract all sublayers
-    const sublayers: any = visibleServerLayers
-      .flatten((item: any) => item.sublayers)
-      .filter((l: any) => !l.sublayers);
-
-    //We need to convert Collection of sublayers to regular array for async processing
-    const sublayersArray: any[] = sublayers.items.map((sl: Sublayer) => sl);
-
-    const processedSubs: LayerFeatureResult[] = await processSublayers(
+      .filter(l => l.visible && l.type !== 'graphics')
+      .filter(l => !processedLayerInfo.includes(l.id));
+    const processedLayers = await processLayers(
+      mapview,
       mapPoint,
-      sublayersArray,
-      mapview
+      visibleServerLayers
     );
-    return processedSubs;
+    return processedLayers;
   }
 }
 


### PR DESCRIPTION
Fix #837
Part of #782
This PR addresses the scenario where we can have layers or its sublayers that contain information (features) we want to display in the data panel.
- Reworked layer query to account for both scenarios, tested with CMR config.
- Accounting for sublayer titles in data tab as well.

This may need further improvements, refactoring down the line when we pull in more layers from country configs. For now it seems to be working well with server and client layers.