### PR TITLE
Ticket 878 - polygon delete logic

### DIFF
--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -7,6 +7,7 @@ import { mapController } from 'js/controllers/mapController';
 import { RootState } from 'js/store';
 import { useSelector, useDispatch } from 'react-redux';
 import { setActiveFeatures } from 'js/store/mapview/actions';
+import { selectActiveTab, toggleTabviewPanel } from 'js/store/appState/actions';
 import { registerGeometry } from 'js/helpers/geometryRegistration';
 import VegaChart from './VegaChartContainer';
 
@@ -106,6 +107,13 @@ const BaseAnalysis = (): JSX.Element => {
     }
   };
 
+  const setDelete = (): void => {
+    mapController.deleteSketchVM();
+    dispatch(selectActiveTab('analysis'));
+    dispatch(toggleTabviewPanel(true));
+    dispatch(setActiveFeatures([]));
+  };
+
   return (
     <>
       {geostoreReady ? (
@@ -115,6 +123,7 @@ const BaseAnalysis = (): JSX.Element => {
           ) : (
             <button onClick={(): void => setActiveButton()}>Save</button>
           )}
+          <button onClick={(): void => setDelete()}>Delete</button>
           <AnalysisOptions />
           {vegaSpec && <VegaChart spec={vegaSpec} />}
           <button onClick={runAnalysis}>RUN ANALYSIS</button>

--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -109,8 +109,6 @@ const BaseAnalysis = (): JSX.Element => {
 
   const setDelete = (): void => {
     mapController.deleteSketchVM();
-    dispatch(selectActiveTab('analysis'));
-    dispatch(toggleTabviewPanel(true));
     dispatch(setActiveFeatures([]));
   };
 

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -530,6 +530,10 @@ export class MapController {
     this._sketchVM?.complete();
   }
 
+  deleteSketchVM(): void {
+    this._sketchVM?.emit('delete');
+  }
+
   updateSketchVM(): any {
     if (this._sketchVM && this._map && this._sketchVMGraphicsLayer) {
       this._sketchVM?.update(this._sketchVMGraphicsLayer.graphics['items'][0], {
@@ -539,6 +543,12 @@ export class MapController {
         enableScaling: false,
         preserveAspectRatio: false
       });
+    }
+  }
+
+  listenToSketchDelete(): any {
+    if (this._sketchVMGraphicsLayer) {
+      this._sketchVMGraphicsLayer.graphics['items'] = [];
     }
   }
 
@@ -584,6 +594,10 @@ export class MapController {
 
     this._sketchVM?.on('create', (event: any) => {
       this.listenToSketchCreate(event);
+    });
+
+    this._sketchVM?.on('delete', () => {
+      this.listenToSketchDelete();
     });
   }
 

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -548,6 +548,8 @@ export class MapController {
 
   listenToSketchDelete(): any {
     if (this._sketchVMGraphicsLayer) {
+      store.dispatch(setActiveFeatures([]));
+      store.dispatch(setActiveFeatureIndex([0, 0]));
       this._sketchVMGraphicsLayer.graphics['items'] = [];
     }
   }
@@ -602,6 +604,7 @@ export class MapController {
   }
 
   createPolygonSketch = (): void => {
+    this.deleteSketchVM();
     this._sketchVM?.create('polygon', { mode: 'freehand' });
   };
 


### PR DESCRIPTION
This PR implements logic to delete a user-drawn polygon from the map

Fixes part of https://github.com/wri/gfw-mapbuilder/issues/871

What it accomplishes;
- Deleting the polygon from the map, and clearing `activeFeatures` so the default analysis tab renders

What it does not accomplish;
- Any UI/styling
- Doesn't resolve why we have to leverage `.emit('delete')` instead of `.delete()`
