### PR TITLE
Generate Graphic - logic consolidation

### DIFF
--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -36,9 +36,9 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
     }
     const activeLayerIndex = activeFeatures.findIndex(findLayer);
     if (activeLayerInfo && activeFeatures[activeLayerIndex]) {
-      const activeFeature = [
+      const activeFeature = new Array(
         activeFeatures[activeLayerIndex].features[activeFeatureIndex[1]]
-      ];
+      );
       mapController.drawGraphic(activeFeature);
     }
 

--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -36,6 +36,10 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
     }
     const activeLayerIndex = activeFeatures.findIndex(findLayer);
     if (activeLayerInfo && activeFeatures[activeLayerIndex]) {
+      const test = [
+        activeFeatures[activeLayerIndex].features[activeFeatureIndex[1]]
+      ];
+      debugger;
       mapController.drawGraphic(
         activeFeatures[activeLayerIndex].features[activeFeatureIndex[1]]
           .geometry

--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -36,14 +36,10 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
     }
     const activeLayerIndex = activeFeatures.findIndex(findLayer);
     if (activeLayerInfo && activeFeatures[activeLayerIndex]) {
-      const test = [
+      const activeFeature = [
         activeFeatures[activeLayerIndex].features[activeFeatureIndex[1]]
       ];
-      debugger;
-      mapController.drawGraphic(
-        activeFeatures[activeLayerIndex].features[activeFeatureIndex[1]]
-          .geometry
-      );
+      mapController.drawGraphic(activeFeature);
     }
 
     const LayerAttributesElement = (props: {
@@ -54,6 +50,10 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
 
       function turnAttributeTablePage(forward: boolean): void {
         const newPage = forward ? page + 1 : page - 1;
+        const activeFeature = new Array(
+          activeFeatures[activeLayerIndex].features[newPage]
+        );
+        mapController.drawGraphic(activeFeature);
         dispatch(setActiveFeatureIndex([activeLayerIndex, newPage]));
       }
 

--- a/src/js/components/mapWidgets/widgetContent/penContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/penContent.tsx
@@ -34,6 +34,8 @@ const PenContent: FunctionComponent = () => {
 
   const setDrawTool = () => {
     dispatch(renderModal(''));
+    // TODO [ ] - clear activeFeatures
+    // TODO [ ] - delete previous polygons
     mapController.createPolygonSketch();
   };
 

--- a/src/js/components/mapWidgets/widgetContent/penContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/penContent.tsx
@@ -34,8 +34,6 @@ const PenContent: FunctionComponent = () => {
 
   const setDrawTool = () => {
     dispatch(renderModal(''));
-    // TODO [ ] - clear activeFeatures
-    // TODO [ ] - delete previous polygons
     mapController.createPolygonSketch();
   };
 

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -42,7 +42,7 @@ import { OptionType } from 'js/interfaces/measureWidget';
 import { LayerFactoryObject } from 'js/interfaces/mapping';
 import { queryLayersForFeatures } from 'js/helpers/DataPanel';
 
-import { createAndAddNewGraphic } from 'js/helpers/MapGraphics';
+import { createAndAddNewGraphic, setNewGraphic } from 'js/helpers/MapGraphics';
 
 import { getCustomSymbol } from 'js/helpers/generateSymbol';
 
@@ -482,6 +482,7 @@ export class MapController {
 
   drawGraphic(geometry: __esri.Geometry): void {
     if (this._map) {
+      // setNewGraphic(this._map, geometry);
       createAndAddNewGraphic(this._map, geometry);
     }
   }
@@ -967,18 +968,20 @@ export class MapController {
   processGeojson(esriJson: any): any {
     this._mapview.graphics.removeAll();
     const graphics: Array<Graphic> = [];
-    esriJson.forEach((feature: any) => {
-      const graphic = new Graphic({
-        geometry: new Polygon(feature.geometry),
-        symbol: getCustomSymbol(),
-        attributes: feature.attributes
-        // source: attributes.SOURCE_UPLOAD
-        // * NOTE: ^ this was in original version
-      });
-      graphics.push(graphic);
-      this._mapview.graphics.add(graphic);
-    });
-    this._mapview.goTo(graphics);
+    setNewGraphic(this._map, this._mapview, esriJson);
+
+    // esriJson.forEach((feature: any) => {
+    //   const graphic = new Graphic({
+    //     geometry: new Polygon(feature.geometry),
+    //     symbol: getCustomSymbol(),
+    //     attributes: feature.attributes
+    //     // source: attributes.SOURCE_UPLOAD
+    //     // * NOTE: ^ this was in original version
+    //   });
+    //   graphics.push(graphic);
+    //   this._mapview.graphics.add(graphic);
+    // });
+    // this._mapview.goTo(graphics);
 
     // ? Do we need the v1 logic below?
 

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -480,10 +480,9 @@ export class MapController {
     }
   }
 
-  drawGraphic(geometry: __esri.Geometry): void {
+  drawGraphic(specificFeature: any): void {
     if (this._map) {
-      // setNewGraphic(this._map, geometry);
-      createAndAddNewGraphic(this._map, geometry);
+      setNewGraphic(this._map, this._mapview, specificFeature);
     }
   }
 

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -36,13 +36,17 @@ import {
   setMeasureResults,
   setLanguage
 } from 'js/store/appState/actions';
-import { LayerProps, LayerFeatureResult } from 'js/store/mapview/types';
+import {
+  LayerProps,
+  LayerFeatureResult,
+  FeatureResult
+} from 'js/store/mapview/types';
 import { OptionType } from 'js/interfaces/measureWidget';
 
 import { LayerFactoryObject } from 'js/interfaces/mapping';
 import { queryLayersForFeatures } from 'js/helpers/DataPanel';
 
-import { createAndAddNewGraphic, setNewGraphic } from 'js/helpers/MapGraphics';
+import { setNewGraphic } from 'js/helpers/MapGraphics';
 
 import { getCustomSymbol } from 'js/helpers/generateSymbol';
 
@@ -480,9 +484,14 @@ export class MapController {
     }
   }
 
-  drawGraphic(specificFeature: any): void {
+  drawGraphic(specificFeature: Array<FeatureResult>): void {
     if (this._map) {
-      setNewGraphic(this._map, this._mapview, specificFeature);
+      setNewGraphic({
+        map: this._map,
+        mapview: this._mapview,
+        allFeatures: specificFeature,
+        isUploadFile: false
+      });
     }
   }
 
@@ -964,23 +973,16 @@ export class MapController {
     }
   }
 
-  processGeojson(esriJson: any): any {
+  processGeojson(esriJson: Array<FeatureResult>): void {
     this._mapview.graphics.removeAll();
-    const graphics: Array<Graphic> = [];
-    setNewGraphic(this._map, this._mapview, esriJson);
-
-    // esriJson.forEach((feature: any) => {
-    //   const graphic = new Graphic({
-    //     geometry: new Polygon(feature.geometry),
-    //     symbol: getCustomSymbol(),
-    //     attributes: feature.attributes
-    //     // source: attributes.SOURCE_UPLOAD
-    //     // * NOTE: ^ this was in original version
-    //   });
-    //   graphics.push(graphic);
-    //   this._mapview.graphics.add(graphic);
-    // });
-    // this._mapview.goTo(graphics);
+    if (this._map) {
+      setNewGraphic({
+        map: this._map,
+        mapview: this._mapview,
+        allFeatures: esriJson,
+        isUploadFile: true
+      });
+    }
 
     // ? Do we need the v1 logic below?
 

--- a/src/js/helpers/MapGraphics.ts
+++ b/src/js/helpers/MapGraphics.ts
@@ -11,11 +11,6 @@ export function createAndAddNewGraphic(
 ): void {
   if (!geometry) return;
   let graphicsLayer: any = map.findLayerById('active-feature-layer');
-  // * NOTE TO SELF - we're adding one graphic to an array
-  // * each time this function fires
-  // ? Could we scope a GraphicLayer with ID of 'active-feature-layer'
-  // ? to maintain an array of Graphics when uploading a file
-  // ? with many polygons?
 
   if (graphicsLayer) {
     graphicsLayer.removeAll(); //TODO: We may need to support multiple selected features in future
@@ -57,13 +52,6 @@ export function createAndAddNewGraphic(
 
 export function setNewGraphic(map: any, mapview: any, allFeatures: any): any {
   let graphicsLayer: any = map.findLayerById('active-feature-layer');
-  // * NOTE TO SELF - we're adding one graphic to an array
-  // * each time this function fires
-  // ? Could we scope a GraphicLayer with ID of 'active-feature-layer'
-  // ? to maintain an array of Graphics when uploading a file
-  // ? with many polygons?
-  const graphics: Array<Graphic> = [];
-
   if (graphicsLayer) {
     graphicsLayer.removeAll(); //TODO: We may need to support multiple selected features in future
   } else {
@@ -77,6 +65,7 @@ export function setNewGraphic(map: any, mapview: any, allFeatures: any): any {
       feature.geometry.type === 'polygon'
         ? getCustomSymbol()
         : getImagerySymbol();
+
     const symbol = feature.geometry.rings
       ? getCustomSymbol()
       : polygonOrPointSymbol;
@@ -86,13 +75,12 @@ export function setNewGraphic(map: any, mapview: any, allFeatures: any): any {
       attributes: feature.attributes,
       symbol: symbol
     });
-    graphics.push(featureGraphic);
-    mapview.graphics.add(featureGraphic);
+
+    graphicsLayer.graphics.push(featureGraphic);
   });
 
-  // map.add(graphicsLayer.graphics);
-  // mapview.goTo(graphicsLayer.graphics);
-  mapview.goTo(graphics);
+  map.add(graphicsLayer);
+  mapview.goTo(graphicsLayer.graphics);
 }
 
 export function processGeojsonNotes(esriJson: any): any {

--- a/src/js/helpers/MapGraphics.ts
+++ b/src/js/helpers/MapGraphics.ts
@@ -1,57 +1,28 @@
 import Map from 'esri/Map';
+import Mapview from 'esri/views/MapView';
 import GraphicsLayer from 'esri/layers/GraphicsLayer';
 import Graphic from 'esri/Graphic';
 import Polygon from 'esri/geometry/Polygon';
+
 import { getCustomSymbol, getImagerySymbol } from 'js/helpers/generateSymbol';
 
-export function createAndAddNewGraphic(
-  map: Map,
-  geometry?: __esri.Geometry,
-  attributes?: Graphic['attributes']
-): void {
-  if (!geometry) return;
-  let graphicsLayer: any = map.findLayerById('active-feature-layer');
+import { FeatureResult } from 'js/store/mapview/types';
 
-  if (graphicsLayer) {
-    graphicsLayer.removeAll(); //TODO: We may need to support multiple selected features in future
-  } else {
-    graphicsLayer = new GraphicsLayer({
-      id: 'active-feature-layer'
-    });
-    map.add(graphicsLayer);
-  }
-
-  const symbol: any = {
-    color: [0, 0, 0, 0],
-    outline: {
-      color: [115, 252, 253],
-      width: 1.5
-    }
-  };
-  //determine if we need fill or marker
-  if (geometry.type === 'polygon') {
-    symbol.type = 'simple-fill';
-    symbol.style = 'solid';
-  } else {
-    symbol.type = 'simple-marker';
-    symbol.style = 'circle';
-    symbol.size = '12px';
-  }
-
-  const featureGraphic = new Graphic({
-    geometry: geometry,
-    symbol: symbol
-  });
-
-  if (attributes) {
-    featureGraphic.attributes = attributes;
-  }
-
-  graphicsLayer.add(featureGraphic);
+interface GraphicConfig {
+  map: Map;
+  mapview: Mapview;
+  allFeatures: Array<FeatureResult>;
+  isUploadFile: boolean;
 }
 
-export function setNewGraphic(map: any, mapview: any, allFeatures: any): any {
+export function setNewGraphic({
+  map,
+  mapview,
+  allFeatures,
+  isUploadFile
+}: GraphicConfig): void {
   let graphicsLayer: any = map.findLayerById('active-feature-layer');
+
   if (graphicsLayer) {
     graphicsLayer.removeAll(); //TODO: We may need to support multiple selected features in future
   } else {
@@ -60,13 +31,13 @@ export function setNewGraphic(map: any, mapview: any, allFeatures: any): any {
     });
   }
 
-  allFeatures.forEach((feature: any) => {
+  allFeatures.forEach((feature: FeatureResult) => {
     const polygonOrPointSymbol =
       feature.geometry.type === 'polygon'
         ? getCustomSymbol()
         : getImagerySymbol();
 
-    const symbol = feature.geometry.rings
+    const symbol = (feature.geometry as any).rings
       ? getCustomSymbol()
       : polygonOrPointSymbol;
 
@@ -80,25 +51,8 @@ export function setNewGraphic(map: any, mapview: any, allFeatures: any): any {
   });
 
   map.add(graphicsLayer);
-  mapview.goTo(graphicsLayer.graphics);
-}
 
-export function processGeojsonNotes(esriJson: any): any {
-  /**
-   * * processGeojson()
-   *  Iterates over an array of ArcGIS data
-   *  Creates a new graphic
-   *  Pushes graphic to array of graphics
-   *  adds graphic to this._mapview.graphics
-   *  goes to graphics
-   */
-  /**
-   * * createAndAddNewGraphic()
-   *  conditionally removes all graphics of graphic layer
-   *  OR creates new graphic layer with ID of 'active-feature-layer'
-   *  adds graphic layer to map
-   *  conditionally assigns symbol a line or symbol
-   *  creates a new graphic
-   *  Adds graphic to graphicLayer
-   */
+  if (isUploadFile) {
+    mapview.goTo(graphicsLayer.graphics);
+  }
 }


### PR DESCRIPTION
This PR consolidates logic of `createAndSetNewGraphic()` and `processGeojson()`

What it accomplishes;
- Consolidates logic to ensure we're dynamically creating/setting a new `Graphic` in one place
- Is reusable logic (for file uploads and selecting features on a map via `onClick()`
- Ensures file uploads are tracked/maintained via a `GraphicsLayer` with an ID of `active-feature-layer`

What it does not accomplish;
- N/A