### PR TITLE
Ticket 891 - rc-slider, LayerTransparencySlider.tsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12477,9 +12477,9 @@
       }
     },
     "rc-tooltip": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-4.0.1.tgz",
-      "integrity": "sha512-R+Ift6SwD2bJKhlYgKXyklvurnYwGzNMfRIPBqv0qoG0SYcVJDVuECL73dcRm2+CCik3YYn1ZGZLPjRRrUkAIw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-4.0.2.tgz",
+      "integrity": "sha512-Ko56IK1U/CD2rSbfQsaVwOK/wHRGbCGpXEThUvsa3KZqe8ShAB/psMj0woR6IUxRBgYO8ZYS1n2KTm7qLLXnjQ==",
       "requires": {
         "rc-trigger": "^4.0.0"
       }
@@ -12498,9 +12498,9 @@
       }
     },
     "rc-util": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.20.0.tgz",
-      "integrity": "sha512-rUqk4RqtDe4OfTsSk2GpbvIQNVtfmmebw4Rn7ZAA1TO1zLMLfyOF78ZyrEKqs8RDwoE3S1aXp0AX0ogLfSxXrQ==",
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.20.1.tgz",
+      "integrity": "sha512-EGlDg9KPN0POzmAR2hk9ZyFc3DmJIrXwlC8NoDxJguX2LTINnVqwadLIVauLfYgYISMiFYFrSHiFW+cqUhZ5dA==",
       "requires": {
         "add-dom-event-listener": "^1.1.0",
         "babel-runtime": "6.x",

--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -191,9 +191,7 @@
 .transparency-slider {
   display: flex;
   flex-wrap: wrap;
-  flex-direction: row;
-  padding: 0 1.5rem;
-  width: 100%;
+  padding: 0 2rem;
 }
 
 .info-icon-container {

--- a/src/js/components/leftPanel/layersPanel/LayerTransparencySlider.tsx
+++ b/src/js/components/leftPanel/layersPanel/LayerTransparencySlider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Slider from 'rc-slider';
+import Slider, { createSliderWithTooltip } from 'rc-slider';
 
 import { mapController } from 'js/controllers/mapController';
 
@@ -7,6 +7,8 @@ interface LayerTransparencyProps {
   layerID: string;
   layerOpacity: number | undefined;
 }
+
+const SliderWithTooltip = createSliderWithTooltip(Slider);
 
 const LayerTransparencySlider = (
   props: LayerTransparencyProps
@@ -19,11 +21,12 @@ const LayerTransparencySlider = (
 
   return (
     <div className="transparency-slider">
-      <Slider
+      <SliderWithTooltip
         min={0}
         max={1}
         step={0.05}
         value={layerOpacity}
+        tipFormatter={(val: number): string => `${val * 100}%`}
         onChange={handleOpacityChange}
         railStyle={{ height: 5, backgroundColor: 'rgb(240, 171, 0)' }}
         trackStyle={{ backgroundColor: '#e9e9e9', height: 5 }}

--- a/src/js/components/leftPanel/layersPanel/LayerTransparencySlider.tsx
+++ b/src/js/components/leftPanel/layersPanel/LayerTransparencySlider.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import Slider from 'rc-slider';
+
 import { mapController } from 'js/controllers/mapController';
 
 interface LayerTransparencyProps {
@@ -11,21 +13,33 @@ const LayerTransparencySlider = (
 ): React.ReactElement => {
   const { layerID, layerOpacity } = props;
 
-  function handleOpacityChange(e: any) {
-    mapController.setLayerOpacity(layerID, e.target.value);
-  }
+  const handleOpacityChange = (eventValue: any): void => {
+    mapController.setLayerOpacity(layerID, eventValue);
+  };
 
   return (
     <div className="transparency-slider">
-      <input
-        type="range"
-        min="0.1"
-        max="1"
-        step="0.05"
-        name="tslider"
-        id=""
+      <Slider
+        min={0}
+        max={1}
+        step={0.05}
         value={layerOpacity}
         onChange={handleOpacityChange}
+        railStyle={{ height: 5, backgroundColor: 'rgb(240, 171, 0)' }}
+        trackStyle={{ backgroundColor: '#e9e9e9', height: 5 }}
+        dotStyle={{
+          border: `2px solid rgb(240, 171, 0)`,
+          height: 10,
+          width: 10,
+          bottom: -6
+        }}
+        handleStyle={[
+          {
+            border: `2px solid rgb(240, 171, 0)`,
+            height: 15,
+            width: 15
+          }
+        ]}
       />
     </div>
   );


### PR DESCRIPTION
This PR integrates `rc-slider` with `LayerTransparencySlider`

Fixes part of #891 

What it accomplishes;
- Sets range from 0 to 1
- Implements style scaffolding for the slider
- Slider is visible only when layer is visible (thanks to @vaidotasp 's previous work with the layer toggles)
- All layers have transparency sliders
- Sets `value` to opacity from `allAvailableLayers`

What it does not accomplish;
- Pixel-by-pixel styling
- Mobile/tablet-friendly styling