### PR TITLE
WIP - Correct Attribute fetching

### DIFF
--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -58,27 +58,39 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
         [key: string]: string;
       }
       const AttributeTable = (props: AttributeObject): JSX.Element => {
+        //If we have fieldNames on activeLayerInfo we use it to map over attributes, otherwise, we use all attributes available
         return (
           <table cellPadding={0} cellSpacing={0}>
             <tbody>
-              {activeLayerInfo.fieldNames?.map((field, i) => {
-                //Grab attribute value irrespective if fieldName is appropriately cased!
-                const attributeKey = Object.keys(props.attributes).find(
-                  a => a.toLowerCase() === field.fieldName.toLowerCase()
-                );
-                if (attributeKey) {
-                  return (
-                    <tr key={i}>
-                      <td className="first-cell">{field.label}</td>
-                      <td className="second-cell">
-                        {props.attributes[attributeKey]}
-                      </td>
-                    </tr>
-                  );
-                } else {
-                  return null;
-                }
-              })}
+              {activeLayerInfo.fieldNames
+                ? activeLayerInfo.fieldNames.map((field, i) => {
+                    //Grab attribute value irrespective if fieldName is appropriately cased!
+                    const attributeKey = Object.keys(props.attributes).find(
+                      a => a.toLowerCase() === field.fieldName.toLowerCase()
+                    );
+                    if (attributeKey) {
+                      return (
+                        <tr key={i}>
+                          <td className="first-cell">{field.label}</td>
+                          <td className="second-cell">
+                            {props.attributes[attributeKey]}
+                          </td>
+                        </tr>
+                      );
+                    } else {
+                      return null;
+                    }
+                  })
+                : Object.keys(props.attributes).map((attribute, i) => {
+                    return (
+                      <tr key={i}>
+                        <td className="first-cell">{attribute}</td>
+                        <td className="second-cell">
+                          {props.attributes[attribute]}
+                        </td>
+                      </tr>
+                    );
+                  })}
             </tbody>
           </table>
         );

--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -61,12 +61,24 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
         return (
           <table cellPadding={0} cellSpacing={0}>
             <tbody>
-              {Object.keys(props.attributes).map((a: string, i: number) => (
-                <tr key={i}>
-                  <td className="first-cell">{a}</td>
-                  <td className="second-cell">{props.attributes[a]}</td>
-                </tr>
-              ))}
+              {activeLayerInfo.fieldNames?.map((field, i) => {
+                //Grab attribute value irrespective if fieldName is appropriately cased!
+                const attributeKey = Object.keys(props.attributes).find(
+                  a => a.toLowerCase() === field.fieldName.toLowerCase()
+                );
+                if (attributeKey) {
+                  return (
+                    <tr key={i}>
+                      <td className="first-cell">{field.label}</td>
+                      <td className="second-cell">
+                        {props.attributes[attributeKey]}
+                      </td>
+                    </tr>
+                  );
+                } else {
+                  return null;
+                }
+              })}
             </tbody>
           </table>
         );

--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -31,8 +31,9 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
 
     //If layer has sublayers, we are using sublayerID to compare, otherwise it is layerID
     function findLayer(f: LayerFeatureResult): boolean {
+      const layerProp = f.sublayerID ? 'sublayerID' : 'layerID';
       const activeLayer = f.sublayerID ? f.sublayerID : f.layerID;
-      return String(activeLayer) === String(activeLayerInfo.sublayerID);
+      return String(activeLayer) === String(activeLayerInfo[layerProp]);
     }
     const activeLayerIndex = activeFeatures.findIndex(findLayer);
     if (activeLayerInfo && activeFeatures[activeLayerIndex]) {

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -66,6 +66,8 @@ interface RemoteDataLayer {
     label: object;
     url: string;
     type: string;
+    popup?: object;
+    sublabel?: object;
     // [key: string]: object
   };
   dataLayer?: {
@@ -200,8 +202,16 @@ export class MapController {
                 let resourceGroup;
                 let url;
                 let type;
-
+                let metadata;
+                let popup;
+                let sublabel;
+                console.log(apiLayer);
                 if (apiLayer.dataLayer) {
+                  console.log('data layer is here');
+                  console.log(apiLayer);
+                  metadata = apiLayer.layer.metadata;
+                  popup = apiLayer.layer.popup;
+                  sublabel = apiLayer.layer.sublabel;
                   resourceId = apiLayer.dataLayer.id;
                   resourceTitle =
                     apiLayer.layer.label[appState.selectedLanguage];
@@ -209,6 +219,8 @@ export class MapController {
                   url = apiLayer.layer.url;
                   type = apiLayer.layer.type;
                 } else {
+                  console.log('data layer IS NOT here');
+                  console.log(apiLayer);
                   resourceId = apiLayer.id;
                   resourceTitle = apiLayer.label[appState.selectedLanguage];
                   resourceGroup = apiLayer.groupId;
@@ -233,7 +245,10 @@ export class MapController {
                   visible: false,
                   definitionExpression: resourceDefinitionExpression,
                   group: resourceGroup,
-                  url: url
+                  url: url,
+                  metadata,
+                  sublabel,
+                  popup
                 });
               });
 

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -58,6 +58,11 @@ interface ZoomParams {
   zoomIn: boolean;
 }
 
+interface Popup {
+  content: any;
+  title: any;
+}
+
 interface RemoteDataLayer {
   // layer: object;
   layer: {
@@ -66,7 +71,7 @@ interface RemoteDataLayer {
     label: object;
     url: string;
     type: string;
-    popup?: object;
+    popup?: Popup;
     sublabel?: object;
     // [key: string]: object
   };
@@ -133,6 +138,9 @@ export class MapController {
         () => {
           store.dispatch(isMapReady(true));
           //Set default language
+          const basemap = Basemap.fromId('osm');
+          //@ts-ignore
+          this._map?.basemap = basemap;
           store.dispatch(setLanguage(appSettings.language));
           this._mapview.popup.highlightEnabled = false;
           this._mapview.on('click', event => {
@@ -205,10 +213,7 @@ export class MapController {
                 let metadata;
                 let popup;
                 let sublabel;
-                console.log(apiLayer);
                 if (apiLayer.dataLayer) {
-                  console.log('data layer is here');
-                  console.log(apiLayer);
                   metadata = apiLayer.layer.metadata;
                   popup = apiLayer.layer.popup;
                   sublabel = apiLayer.layer.sublabel;
@@ -219,8 +224,6 @@ export class MapController {
                   url = apiLayer.layer.url;
                   type = apiLayer.layer.type;
                 } else {
-                  console.log('data layer IS NOT here');
-                  console.log(apiLayer);
                   resourceId = apiLayer.id;
                   resourceTitle = apiLayer.label[appState.selectedLanguage];
                   resourceGroup = apiLayer.groupId;

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -138,9 +138,6 @@ export class MapController {
         () => {
           store.dispatch(isMapReady(true));
           //Set default language
-          const basemap = Basemap.fromId('osm');
-          //@ts-ignore
-          this._map?.basemap = basemap;
           store.dispatch(setLanguage(appSettings.language));
           this._mapview.popup.highlightEnabled = false;
           this._mapview.on('click', event => {

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -580,18 +580,14 @@ export class MapController {
 
       event.graphic.symbol.outline.color = [115, 252, 253];
       event.graphic.symbol.color = [0, 0, 0, 0];
-      //as drawn features do not have user defined fieldNames, we iterate over attributes and each attribute becomes a fieldName
-      const fieldNames = Object.keys(event.graphic.attributes).map(a => {
-        return { fieldName: a, label: a };
-      });
       //Replace all active features with our drawn feature, assigning custom layerID and Title
       const drawnFeatures: LayerFeatureResult = {
         layerID: 'user_features',
         layerTitle: 'User Features',
-        sublayerID: null,
-        sublayerTitle: null,
+        // sublayerID: null,
+        // sublayerTitle: null,
         features: [event.graphic],
-        fieldNames: fieldNames
+        fieldNames: null
       };
 
       store.dispatch(setActiveFeatures([drawnFeatures]));

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -580,14 +580,18 @@ export class MapController {
 
       event.graphic.symbol.outline.color = [115, 252, 253];
       event.graphic.symbol.color = [0, 0, 0, 0];
-
+      //as drawn features do not have user defined fieldNames, we iterate over attributes and each attribute becomes a fieldName
+      const fieldNames = Object.keys(event.graphic.attributes).map(a => {
+        return { fieldName: a, label: a };
+      });
       //Replace all active features with our drawn feature, assigning custom layerID and Title
       const drawnFeatures: LayerFeatureResult = {
         layerID: 'user_features',
         layerTitle: 'User Features',
         sublayerID: null,
         sublayerTitle: null,
-        features: [event.graphic]
+        features: [event.graphic],
+        fieldNames: fieldNames
       };
 
       store.dispatch(setActiveFeatures([drawnFeatures]));

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -40,7 +40,7 @@ import { LayerProps, LayerFeatureResult } from 'js/store/mapview/types';
 import { OptionType } from 'js/interfaces/measureWidget';
 
 import { LayerFactoryObject } from 'js/interfaces/mapping';
-import { queryLayersForFeatures } from 'js/helpers/DataPanel';
+import { queryLayersForFeatures } from 'js/helpers/dataPanel/DataPanel';
 
 import { createAndAddNewGraphic } from 'js/helpers/MapGraphics';
 

--- a/src/js/helpers/DataPanel.ts
+++ b/src/js/helpers/DataPanel.ts
@@ -66,7 +66,6 @@ function getAttributesToFetch(
     enabledFieldInfos = layer.popupTemplate.fieldInfos
       .filter(f => f.visible)
       .map(f => {
-        //Format values if formatting is available!
         return {
           fieldName: f.fieldName,
           label: f.label,
@@ -96,7 +95,6 @@ function getAttributesToFetch(
       return { fieldName: newFieldName, label: f.label };
     });
 
-    //how do we handle no metadata on popup?
     const fieldNamesFromMetadata = fieldsFromMetadataCleaned?.map((f: any) => {
       return f.fieldName.toLowerCase().trim();
     });

--- a/src/js/helpers/DataPanel.ts
+++ b/src/js/helpers/DataPanel.ts
@@ -339,8 +339,6 @@ export async function queryLayersForFeatures(
             layerFeatureResults.push({
               layerID: layer.id,
               layerTitle: layer.title,
-              sublayerID: null,
-              sublayerTitle: null,
               features: features,
               fieldNames
             });
@@ -357,8 +355,6 @@ export async function queryLayersForFeatures(
             layerFeatureResults.push({
               layerID: layer.id,
               layerTitle: layer.title,
-              sublayerID: null,
-              sublayerTitle: null,
               features: features,
               fieldNames
             });

--- a/src/js/helpers/DataPanel.ts
+++ b/src/js/helpers/DataPanel.ts
@@ -1,5 +1,4 @@
 import MapView from 'esri/views/MapView';
-import Point from 'esri/geometry/Point';
 import Map from 'esri/Map';
 import store from 'js/store';
 import QueryTask from 'esri/tasks/QueryTask';
@@ -18,42 +17,38 @@ function esriQuery(url: string, queryParams: any): Promise<__esri.FeatureSet> {
   return result;
 }
 
-//Helper to fetch name field for the objectids due to inconsistent naming and application requiring object id for attachment fetching
-async function getLayerFields(
+//Helper fn to get all available layer fields for the data tab. If layer has fields itself we are using those, but if that is not the case, attempt to fetch it by hitting layer url endpoint with pjson prefix
+async function getAllLayerFields(
   layer: __esri.FeatureLayer
-): Promise<__esri.Field | undefined> {
-  let layerObjectField = {} as __esri.Field | undefined;
+): Promise<__esri.Field[] | undefined> {
+  let layerFields = [] as __esri.Field[] | undefined;
   if (layer.fields) {
-    layerObjectField = layer.fields.find(
-      field =>
-        field.type.toLowerCase() === 'esrifieldtypeoid' ||
-        field.type.toLowerCase() === 'oid'
-    );
+    layerFields = layer.fields;
   } else {
-    layerObjectField = await fetch(`${layer.url}?f=pjson`, {
+    layerFields = await fetch(`${layer.url}?f=pjson`, {
       body: null,
       method: 'GET'
     })
       .then(response => response.json())
       .then(data => {
         if (data?.fields) {
-          const objectidName = data.fields.find(
-            (field: __esri.Field) =>
-              field.type.toLowerCase() === 'esrifieldtypeoid' ||
-              field.type.toLowerCase() === 'oid'
-          );
-          return objectidName;
+          return data.fields;
         }
       });
   }
-  return layerObjectField;
+  return layerFields;
 }
 
+//Helper fn to grab WHICH attributes we want to show in the data panel. Those can be coming from either popupTemplate in case of webmaps or it can also come from layer metadata which is fetched at the layer loading point. This is the case with most non webmap layers.
 interface FieldInfo {
   fieldName: string;
   label: string;
 }
-function getAttributesToFetch(layer: __esri.FeatureLayer): FieldInfo[] | null {
+function getAttributesToFetch(
+  layer: __esri.FeatureLayer | __esri.Sublayer,
+  isSubLayer?: boolean,
+  availableFields?: __esri.Field[] | undefined
+): FieldInfo[] | null {
   //Check for popupTemplate > this handles webmap layers
   let enabledFieldInfos: FieldInfo[] | null = null;
   if (layer.popupTemplate) {
@@ -67,10 +62,50 @@ function getAttributesToFetch(layer: __esri.FeatureLayer): FieldInfo[] | null {
       });
   } else {
     //No popup template found, check the metadata
-    debugger;
-    enabledFieldInfos = [{ fieldName: '*', label: '*' }];
-    console.log('no popupTemplate found, lets dig into metadata');
-    console.log(layer);
+    const { allAvailableLayers } = store.getState().mapviewState;
+    const { selectedLanguage } = store.getState().appState;
+    //@ts-ignore -- weird issue when sublayer suppose to have layer prop but TS does not agree
+    const layerID = isSubLayer ? layer.layer.id : layer.id;
+    const layerInfo = allAvailableLayers.find(l => l.id === layerID);
+
+    //TODO: There is a situation where metada has a field, but layer itself does not, we need to filter those out
+    const availableFieldsNames = availableFields?.map(f =>
+      f.name.toLowerCase().trim()
+    );
+
+    //TODO: 3x supported modifiers on the fieldName eg ACQ_DATE:DateString(hideTime:true), 4x this is no longer supported and modifiers should be added to FieldInfoFormat class. For now we are going to be sanitizing fieldNames that come from metadata (gfw api) so queries do not break. But this would need to be changed on their api end
+    const fieldsFromMetadataCleaned = layerInfo?.popup?.content[
+      selectedLanguage
+    ].map((f: any) => {
+      const newFieldName = f.fieldExpression.includes(':')
+        ? f.fieldExpression.substring(0, f.fieldExpression.indexOf(':'))
+        : f.fieldExpression;
+      return { fieldName: newFieldName, label: f.label };
+    });
+
+    //how do we handle no metadata on popup?
+    const fieldNamesFromMetadata = fieldsFromMetadataCleaned?.map((f: any) => {
+      return f.fieldName.toLowerCase().trim();
+    });
+    // Deal with matching names from metadata and from layer itself
+    if (availableFieldsNames && fieldNamesFromMetadata) {
+      const attributeFieldsToInclude = fieldNamesFromMetadata
+        .filter((f: any) => availableFieldsNames.includes(f))
+        .map((f: any) => {
+          const matchingLabel = availableFields?.find(
+            (allowedField: any) => allowedField.name.toLowerCase() === f
+          );
+          return {
+            fieldName: f,
+            label: matchingLabel?.alias
+          };
+        });
+
+      enabledFieldInfos =
+        attributeFieldsToInclude && attributeFieldsToInclude.length > 0
+          ? attributeFieldsToInclude
+          : [{ fieldName: '*', label: '*' }];
+    }
   }
   return enabledFieldInfos;
 }
@@ -78,7 +113,8 @@ function getAttributesToFetch(layer: __esri.FeatureLayer): FieldInfo[] | null {
 async function fetchQueryTask(
   layer: __esri.FeatureLayer,
   mapview: MapView,
-  event: __esri.MapViewClickEvent
+  event: __esri.MapViewClickEvent,
+  isSubLayer?: boolean
 ): Promise<FeatureResult[]> {
   let featureResult = [] as FeatureResult[];
   const queryParams: any = {
@@ -91,13 +127,26 @@ async function fetchQueryTask(
   };
   const url = layer.url;
   try {
-    const layerFields = await getLayerFields(layer);
-    if (layerFields?.name) {
-      queryParams.outFields.push(layerFields.name);
+    const allLayerFields = await getAllLayerFields(layer);
+    let objectid: string | null = null;
+    if (allLayerFields) {
+      const layerObjectField = allLayerFields.find(
+        field =>
+          field.type.toLowerCase() === 'esrifieldtypeoid' ||
+          field.type.toLowerCase() === 'oid'
+      );
+      if (layerObjectField?.name) {
+        objectid = layerObjectField?.name;
+        queryParams.outFields = [layerObjectField.name];
+      }
     }
-    const attributesToFetch = getAttributesToFetch(layer);
+    const attributesToFetch = getAttributesToFetch(
+      layer,
+      isSubLayer,
+      allLayerFields
+    );
     const newOutFields = attributesToFetch?.map(f => f.fieldName);
-    queryParams.outFields.push(newOutFields);
+    queryParams.outFields = queryParams.outFields.concat(newOutFields);
     const sublayerResult = await esriQuery(url, queryParams);
 
     if (sublayerResult.features.length > 0) {
@@ -105,7 +154,7 @@ async function fetchQueryTask(
         return {
           attributes: f.attributes,
           geometry: f.geometry,
-          objectid: layerFields?.name ? f.attributes[layerFields.name] : null
+          objectid: objectid ? f.attributes[objectid] : null
         };
       });
     }
@@ -130,9 +179,18 @@ async function fetchQueryFeatures(
     returnGeometry: true
   };
   const attributesToFetch = getAttributesToFetch(layer);
-  const layerFields = await getLayerFields(layer);
-  if (layerFields?.name) {
-    queryParams.outFields.push(layerFields.name);
+  const allLayerFields = await getAllLayerFields(layer);
+  let objectid: string | null = null;
+  if (allLayerFields) {
+    const layerObjectField = allLayerFields.find(
+      field =>
+        field.type.toLowerCase() === 'esrifieldtypeoid' ||
+        field.type.toLowerCase() === 'oid'
+    );
+    if (layerObjectField?.name) {
+      objectid = layerObjectField?.name;
+      queryParams.outFields = [layerObjectField.name];
+    }
   }
   const newOutFields = attributesToFetch?.map(f => f.fieldName);
   queryParams.outFields.push(newOutFields);
@@ -144,7 +202,7 @@ async function fetchQueryFeatures(
         return {
           attributes: f.attributes,
           geometry: f.geometry,
-          objectid: layerFields?.name ? f.attributes[layerFields.name] : null
+          objectid: objectid ? f.attributes[objectid] : null
         };
       });
     }
@@ -154,7 +212,7 @@ async function fetchQueryFeatures(
   return featureResult;
 }
 
-//Client Side Feature Fetching
+//Feature Fetching Logic starts
 export async function queryLayersForFeatures(
   mapview: MapView,
   map: Map | undefined,
@@ -180,7 +238,7 @@ export async function queryLayersForFeatures(
         for (const sublayer of layer.sublayers.items) {
           //sublayers do not have a type, so it always defaults to QueryTask
           //use generic QueryTask approach
-          const features = await fetchQueryTask(sublayer, mapview, event);
+          const features = await fetchQueryTask(sublayer, mapview, event, true);
           if (features.length > 0) {
             layerFeatureResults.push({
               layerID: layer.id,
@@ -212,7 +270,7 @@ export async function queryLayersForFeatures(
           }
         } else {
           //use generic QueryTask approach
-          const features = await fetchQueryTask(layer, mapview, event);
+          const features = await fetchQueryTask(layer, mapview, event, false);
           if (features.length > 0) {
             layerFeatureResults.push({
               layerID: layer.id,

--- a/src/js/helpers/DataPanel.ts
+++ b/src/js/helpers/DataPanel.ts
@@ -100,11 +100,13 @@ function getAttributesToFetch(
             label: matchingLabel?.alias
           };
         });
-
       enabledFieldInfos =
         attributeFieldsToInclude && attributeFieldsToInclude.length > 0
           ? attributeFieldsToInclude
           : [{ fieldName: '*', label: '*' }];
+    } else {
+      console.log('no metadata stuff or no fieldnames?');
+      enabledFieldInfos = [{ fieldName: '*', label: '*' }];
     }
   }
   return enabledFieldInfos;

--- a/src/js/helpers/DataPanel.ts
+++ b/src/js/helpers/DataPanel.ts
@@ -198,10 +198,9 @@ async function fetchQueryTask(
     );
     fieldNames = attributesToFetch;
     const newOutFields = attributesToFetch?.map(f => f.fieldName);
-    //TODO: What to do when we have no attributes to fetch if there is no popuptemplate of metadata info? do we even fetch the data display everything? nothing?
     queryParams.outFields = newOutFields
       ? queryParams.outFields.concat(newOutFields)
-      : queryParams.outFields;
+      : ['*'];
     const sublayerResult = await esriQuery(url, queryParams);
 
     if (sublayerResult.features.length > 0) {
@@ -257,17 +256,14 @@ async function fetchQueryFeatures(
     }
   }
   const newOutFields = attributesToFetch?.map(f => f.fieldName);
-  //TODO: What to do when we have no attributes to fetch if there is no popuptemplate of metadata info? do we even fetch the data display everything? nothing?
   queryParams.outFields = newOutFields
     ? [...queryParams.outFields, ...newOutFields]
-    : queryParams.outFields;
+    : ['*'];
   try {
     const featureResults = await layer.queryFeatures(queryParams);
     //Ignore empty results
     if (featureResults.features.length > 0) {
       featureResult = featureResults.features.map((f: any) => {
-        //TODO: How do we read formatting options for attributes that come from metadata? 3x instructions do not work anymore.
-        debugger;
         return {
           attributes: f.attributes,
           geometry: f.geometry,

--- a/src/js/helpers/dataPanel/esriQuery.ts
+++ b/src/js/helpers/dataPanel/esriQuery.ts
@@ -1,0 +1,15 @@
+import QueryTask from 'esri/tasks/QueryTask';
+import Query from 'esri/tasks/support/Query';
+
+//Generic ESRI query helper
+export function esriQuery(
+  url: string,
+  queryParams: any
+): Promise<__esri.FeatureSet> {
+  const qt = new QueryTask({
+    url: url
+  });
+  const query = new Query(queryParams);
+  const result = qt.execute(query);
+  return result;
+}

--- a/src/js/helpers/dataPanel/formatAttributes.ts
+++ b/src/js/helpers/dataPanel/formatAttributes.ts
@@ -1,0 +1,41 @@
+import * as esriIntl from 'esri/intl';
+import { FieldInfo } from './DataPanel';
+
+//Helper to fetch format options for each attribute and format it according to the instruction found
+export function formatAttributeValues(
+  attributes: __esri.Graphic['attributes'],
+  fields: FieldInfo[] | null
+): object {
+  const formatAttributeObject = {} as object;
+  Object.keys(attributes).forEach(attribute => {
+    const attributeField = fields?.find(f => f.fieldName === attribute);
+    if (attributeField?.format?.dateFormat) {
+      //format the date if formatting options exist
+      const dateFormatIntlOptions = esriIntl.convertDateFormatToIntlOptions(
+        attributeField?.format?.dateFormat
+      );
+      const formattedDate = esriIntl.formatDate(
+        Number(attributes[attribute]),
+        dateFormatIntlOptions
+      );
+      formatAttributeObject[attribute] = formattedDate;
+    } else if (attributeField?.format?.digitSeparator) {
+      //format the number if formatting options exist
+      const numberFormatIntlOptions = esriIntl.convertNumberFormatToIntlOptions(
+        {
+          places: attributeField?.format?.places,
+          digitSeparator: attributeField?.format?.digitSeparator
+        }
+      );
+      const formattedNumber = esriIntl.formatNumber(
+        attributes[attribute],
+        numberFormatIntlOptions
+      );
+      formatAttributeObject[attribute] = formattedNumber;
+    } else {
+      //no formatting options found,  use original value
+      formatAttributeObject[attribute] = attributes[attribute];
+    }
+  });
+  return formatAttributeObject;
+}

--- a/src/js/helpers/dataPanel/getAttributes.ts
+++ b/src/js/helpers/dataPanel/getAttributes.ts
@@ -1,0 +1,70 @@
+//Helper fn to grab WHICH attributes we want to show in the data panel. Those can be coming from either popupTemplate in case of webmaps or it can also come from layer metadata which is fetched at the layer loading point. This is the case with most non webmap layers.
+import store from 'js/store';
+
+import { FieldInfo } from './DataPanel';
+
+export function getAttributesToFetch(
+  layer: __esri.FeatureLayer | __esri.Sublayer,
+  isSubLayer?: boolean,
+  availableFields?: __esri.Field[] | undefined
+): FieldInfo[] | null {
+  //Check for popupTemplate > this handles webmap layers
+  let enabledFieldInfos: FieldInfo[] | null = null;
+  if (layer.popupTemplate) {
+    enabledFieldInfos = layer.popupTemplate.fieldInfos
+      .filter(f => f.visible)
+      .map(f => {
+        return {
+          fieldName: f.fieldName,
+          label: f.label,
+          format: f.format
+        };
+      });
+  } else {
+    //No popup template found, check the metadata
+    const { allAvailableLayers } = store.getState().mapviewState;
+    const { selectedLanguage } = store.getState().appState;
+    //@ts-ignore -- weird issue when sublayer suppose to have layer prop but TS does not agree
+    const layerID = isSubLayer ? layer.layer.id : layer.id;
+    const layerInfo = allAvailableLayers.find(l => l.id === layerID);
+
+    //TODO: There is a situation where metada has a field, but layer itself does not, we need to filter those out
+    const availableFieldsNames = availableFields?.map(f =>
+      f.name.toLowerCase().trim()
+    );
+
+    //TODO: 3x supported modifiers on the fieldName eg ACQ_DATE:DateString(hideTime:true), 4x this is no longer supported and modifiers should be added to FieldInfoFormat class. For now we are going to be sanitizing fieldNames that come from metadata (gfw api) so queries do not break. But this would need to be changed on their api end
+    const fieldsFromMetadataCleaned = layerInfo?.popup?.content[
+      selectedLanguage
+    ].map((f: any) => {
+      const newFieldName = f.fieldExpression.includes(':')
+        ? f.fieldExpression.substring(0, f.fieldExpression.indexOf(':'))
+        : f.fieldExpression;
+      return { fieldName: newFieldName, label: f.label };
+    });
+
+    const fieldNamesFromMetadata = fieldsFromMetadataCleaned?.map((f: any) => {
+      return f.fieldName.toLowerCase().trim();
+    });
+    // Deal with matching names from metadata and from layer itself
+    if (availableFieldsNames && fieldNamesFromMetadata) {
+      const attributeFieldsToInclude = fieldNamesFromMetadata
+        .filter((f: any) => availableFieldsNames.includes(f))
+        .map((f: any) => {
+          return {
+            fieldName: f,
+            label: fieldsFromMetadataCleaned.find(
+              (field: any) => field.fieldName.toLowerCase() === f.toLowerCase()
+            ).label
+          };
+        });
+      enabledFieldInfos =
+        attributeFieldsToInclude && attributeFieldsToInclude.length > 0
+          ? attributeFieldsToInclude
+          : null;
+    } else {
+      enabledFieldInfos = null;
+    }
+  }
+  return enabledFieldInfos;
+}

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -59,6 +59,11 @@ export interface MapviewState {
   activeBasemap: string; // * NEW! not in resources.js
 }
 
+interface Popup {
+  content: any;
+  title: any;
+}
+
 export interface LayerProps {
   id: string;
   visible: boolean;
@@ -68,7 +73,7 @@ export interface LayerProps {
   definitionExpression?: string;
   group: string;
   url: string;
-  popup?: object;
+  popup?: Popup;
   metadata?: object;
   sublabel?: object;
 }

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -68,6 +68,9 @@ export interface LayerProps {
   definitionExpression?: string;
   group: string;
   url: string;
+  popup?: object;
+  metadata?: object;
+  sublabel?: object;
 }
 
 interface Attributes {

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -88,12 +88,18 @@ export interface FeatureResult {
   geometry: __esri.Geometry;
 }
 
+export interface FieldName {
+  fieldName: string;
+  label: string;
+}
+
 export interface LayerFeatureResult {
   layerTitle: string;
   layerID: string;
   sublayerTitle: string | null;
   sublayerID: string | null;
   features: FeatureResult[];
+  fieldNames: FieldName[] | null;
 }
 
 //Action types

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -96,8 +96,8 @@ export interface FieldName {
 export interface LayerFeatureResult {
   layerTitle: string;
   layerID: string;
-  sublayerTitle: string | null;
-  sublayerID: string | null;
+  sublayerTitle?: string;
+  sublayerID?: string;
   features: FeatureResult[];
   fieldNames: FieldName[] | null;
 }

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -80,7 +80,7 @@ export interface LayerProps {
 
 interface Attributes {
   [key: string]: any;
-  geostoreId: string;
+  geostoreId?: string;
 }
 
 export interface FeatureResult {


### PR DESCRIPTION
Fixes #888

- Extracting popup information along with other metadata from the point of Layer creation. This information will be used for LegendConfig as well as Data Tab
- Types modifications to include expanded metadata objects
- Reworked DataPanel.ts, feature fetching logic for data panel:
1 . Made queries more sequential and less prone to duplicate.
2. Custom logic to fetch all available fields on the layer in order to extract OBJECTID. We will need object id when to fetch documents
3. Implemented logic where if user have no specified fields in the metadata, we return all fields. Decided to return all fields if there is no config. #895