### PR TITLE
Conditionally hide the coordinate widget button

### DIFF
--- a/src/js/components/mapWidgets/widgetContent/measureContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/measureContent.tsx
@@ -112,9 +112,6 @@ const ReturnDropdown: FunctionComponent = () => {
     case 'distance':
       selectedDropdown = distanceUnitsOfLength;
       break;
-    case 'coordinates':
-      selectedDropdown = [];
-      break;
     default:
       selectedDropdown = defaultOption;
       break;
@@ -204,8 +201,6 @@ const MeasureContent: FunctionComponent = () => {
         return selectedAreaUnit;
       case 'distance':
         return selectedDistanceUnit;
-      case 'coordinates':
-        return selectedCoordinatesUnit;
       default:
         return '';
     }
@@ -232,20 +227,26 @@ const MeasureContent: FunctionComponent = () => {
             activeButton === 'coordinates' ? 'selected' : ''
           }`}
         />
-        <span>|</span>
-        <select
-          value={returnSelectedUnit()}
-          onChange={(e): void =>
-            setMeasurementUnit(
-              e.target.value as
-                | AreaMeasurement2D['unit']
-                | DistanceMeasurement2D['unit']
-            )
-          }
-          disabled={activeButton === '' ? true : false}
-        >
-          <ReturnDropdown />
-        </select>
+        {(activeButton === 'area' ||
+          activeButton === 'distance' ||
+          activeButton === '') && (
+          <>
+            <span>|</span>
+            <select
+              value={returnSelectedUnit()}
+              onChange={(e): void =>
+                setMeasurementUnit(
+                  e.target.value as
+                    | AreaMeasurement2D['unit']
+                    | DistanceMeasurement2D['unit']
+                )
+              }
+              disabled={activeButton === '' ? true : false}
+            >
+              <ReturnDropdown />
+            </select>
+          </>
+        )}
       </div>
       <p>Measurement Result</p>
       <hr />


### PR DESCRIPTION
This PR removes references to `activeButton` type of `coordinates` where necessary. Also ensures the `select` dropdown is hidden when the user selects the coordinates button.

This PR supports #897 

What it accomplishes;
- `select` dropdown is hidden when the user selects the coordinates button.
- removes references to `activeButton` type of `coordinates` where necessary

What it doesn't accomplish;
- Doesn't update the content config in case we need a custom solution down the line