### PR TITLE
Upload file types breaking deploy

### DIFF
--- a/src/js/components/sharedComponents/UploadFile.tsx
+++ b/src/js/components/sharedComponents/UploadFile.tsx
@@ -131,11 +131,10 @@ const UploadFile = (): JSX.Element => {
             const shapeFileFeatures: LayerFeatureResult = {
               layerID: 'upload_file_features',
               layerTitle: 'Upload File Features',
-              sublayerID: null,
-              sublayerTitle: null,
               features: arcGISResults.map((g: __esri.Graphic) => {
                 return { attributes: g.attributes, geometry: g.geometry };
-              })
+              }),
+              fieldNames: null
             };
 
             dispatch(setActiveFeatureIndex([0, 0]));


### PR DESCRIPTION
- Removed sublayer related properties as we no longer need to set those to `null`
- added fieldNames to follow same way we create objects when we draw shape on the map