### PR TITLE
Ticket 798 - Search widget logic

### DIFF
--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -17,10 +17,12 @@ import PrintTemplate from 'esri/tasks/support/PrintTemplate';
 import PrintParameters from 'esri/tasks/support/PrintParameters';
 import Basemap from 'esri/Basemap';
 import { once } from 'esri/core/watchUtils';
+
 import { RefObject } from 'react';
 import { densityEnabledLayers } from '../../../configs/layer-config';
 import store from '../store/index';
 import { LayerFactory } from 'js/helpers/LayerFactory';
+import { setLayerSearchSource } from 'js/helpers/mapController/searchSources';
 import {
   allAvailableLayers,
   mapError,
@@ -995,10 +997,13 @@ export class MapController {
     store.dispatch(renderModal(''));
   };
 
-  initializeSearchWidget(searchRef: RefObject<any>): void {
+  async initializeSearchWidget(searchRef: RefObject<any>): Promise<void> {
+    const allSources = await setLayerSearchSource();
+
     new Search({
       view: this._mapview,
-      container: searchRef.current
+      container: searchRef.current,
+      sources: allSources
     });
   }
 

--- a/src/js/helpers/mapController/searchSources.ts
+++ b/src/js/helpers/mapController/searchSources.ts
@@ -1,0 +1,75 @@
+import LayerSearchSource from 'esri/widgets/Search/LayerSearchSource';
+import Layer from 'esri/layers/Layer';
+import FeatureLayer from 'esri/layers/FeatureLayer';
+import MapImageLayer from 'esri/layers/MapImageLayer';
+import Sublayer from 'esri/layers/support/Sublayer';
+
+import { mapController } from 'js/controllers/mapController';
+
+type ArrayOfLayerSources = Array<LayerSearchSource>;
+
+const returnLayerSearchSources = (
+  allFeatureLayers: Array<FeatureLayer>
+): ArrayOfLayerSources => {
+  return allFeatureLayers.map((layer: FeatureLayer) => {
+    return new LayerSearchSource({
+      layer,
+      name: layer.title,
+      placeholder: layer.title,
+      searchFields: [layer.displayField],
+      displayField: layer.displayField,
+      suggestionTemplate: `${layer.displayField.toUpperCase()} {${
+        layer.displayField
+      }}`,
+      exactMatch: false,
+      outFields: ['*'],
+      maxResults: 6,
+      maxSuggestions: 6,
+      suggestionsEnabled: true,
+      minSuggestCharacters: 0
+    });
+  });
+};
+
+const setFeatureLayerSources = (): ArrayOfLayerSources => {
+  const allFeatureLayers = (mapController._map?.allLayers as any).items.filter(
+    (layer: Layer) => layer.type === 'feature'
+  );
+
+  return returnLayerSearchSources(allFeatureLayers);
+};
+
+const setMapImageLayerSources = async (): Promise<ArrayOfLayerSources> => {
+  let allSublayers: Array<Sublayer> = [];
+  const mapImageLayers = (mapController._map?.allLayers as any).items.filter(
+    (layer: Layer) => layer.type === 'map-image'
+  );
+
+  mapImageLayers.forEach((mapImageLayer: MapImageLayer) => {
+    allSublayers = allSublayers.concat(
+      (mapImageLayer.allSublayers as any).items
+    );
+  });
+
+  const featureLayerPromises = allSublayers.map((sublayer: Sublayer) => {
+    const featureLayer = new FeatureLayer({
+      url: (sublayer as any).parent.url,
+      layerId: sublayer.id
+    });
+
+    return featureLayer.load().then((results: FeatureLayer) => results);
+  });
+
+  const allFeatureLayers = await Promise.all(featureLayerPromises);
+
+  return returnLayerSearchSources(allFeatureLayers);
+};
+
+export const setLayerSearchSource = async (): Promise<ArrayOfLayerSources> => {
+  const featureLayerSources = setFeatureLayerSources() as any;
+
+  const mapImageLayerSources = (await setMapImageLayerSources()) as any;
+  // * NOTE: mapImageLayerSources returns console errors RE FeatureLayer
+
+  return [].concat(featureLayerSources, mapImageLayerSources);
+};

--- a/src/js/helpers/mapController/searchSources.ts
+++ b/src/js/helpers/mapController/searchSources.ts
@@ -71,5 +71,5 @@ export const setLayerSearchSource = async (): Promise<ArrayOfLayerSources> => {
   const mapImageLayerSources = (await setMapImageLayerSources()) as any;
   // * NOTE: mapImageLayerSources returns console errors RE FeatureLayer
 
-  return [].concat(featureLayerSources, mapImageLayerSources);
+  return [...featureLayerSources, ...mapImageLayerSources];
 };


### PR DESCRIPTION
This PR dynamically loads custom feature layers and map image layers into the search widget.

Fixes part of #798 

What it accomplishes;
- Creates a `LayerSearchSource` for each feature layer
- Converts map image layers into a FeatureLayer. Then creates a `LayerSearchSource` for each Feature Layer
- Sets search widget `sources` to `LayerSearchSources`

What it does not accomplish;
- Does not implement logic for all layer types
- Does not resolve console errors from the API that are caused by `setMapImageLayerSources()` - even though the logic works
- Does not implement any UI to guide the user's search when they select a layer in the search widget (i.e.; searching by point, objectID, name, etc)
- Does not resolve why 3 REST endpoints (map image layers) aren't queryable via UI or the REST API