### PR TITLE
Query feature optimization

### DIFF
--- a/src/js/components/legend/Legend.tsx
+++ b/src/js/components/legend/Legend.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from 'js/store';
-import 'css/legend.scss';
 import LegendItems from './generateLegendItems';
-import { LayerProps } from 'js/store/mapview/types';
+import { layerIsInScale } from 'js/helpers/layerScaleCheck';
+import 'css/legend.scss';
 
 const Legend = (): JSX.Element => {
   const { hideWidgetActive, selectedLanguage } = useSelector(
@@ -14,28 +14,10 @@ const Legend = (): JSX.Element => {
     (store: RootState) => store.mapviewState
   );
 
-  //handle scale visibility too, this only addresses webmaps but not the GFW API layers!
-  function layerIsInScale(layer: LayerProps): boolean {
-    if (layer.hasOwnProperty('minScale') && layer.hasOwnProperty('maxScale')) {
-      if (layer.minScale === 0 && layer.maxScale === 0) {
-        return true;
-        //@ts-ignore -- TS is not understanding the above check for properties for some reason.
-      } else if (layer.maxScale < scale && layer.minScale > scale) {
-        //Our mapview is within the scale that is defined! show this legend item
-        return true;
-      } else {
-        //legend item is outside the scale parameters, we do not want it!
-        return false;
-      }
-    } else {
-      // if no maxmin scale defined, we want to show those layers in legend
-      return true;
-    }
-  }
   //TODO: order should be applied here I think!
   const visibleLayers = allAvailableLayers
     .filter(l => l.visible)
-    .filter(layerIsInScale);
+    .filter(l => layerIsInScale(l, scale));
 
   const [legendOpen, setLegendOpen] = useState(!hideWidgetActive);
 

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -152,7 +152,12 @@ export class MapController {
             store.dispatch(setActiveFeatures([]));
             store.dispatch(setActiveFeatureIndex([0, 0]));
             store.dispatch(selectActiveTab('data'));
-            queryLayersForFeatures(this._mapview, this._map, event);
+            queryLayersForFeatures(
+              this._mapview,
+              this._map,
+              event,
+              this._mapview.scale
+            );
           });
 
           const mapLayerObjects: LayerProps[] = this.extractLayerObjects();

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -152,12 +152,7 @@ export class MapController {
             store.dispatch(setActiveFeatures([]));
             store.dispatch(setActiveFeatureIndex([0, 0]));
             store.dispatch(selectActiveTab('data'));
-            queryLayersForFeatures(
-              this._mapview,
-              this._map,
-              event,
-              this._mapview.scale
-            );
+            queryLayersForFeatures(this._mapview, this._map, event);
           });
 
           const mapLayerObjects: LayerProps[] = this.extractLayerObjects();

--- a/src/js/helpers/dataPanel/DataPanel.ts
+++ b/src/js/helpers/dataPanel/DataPanel.ts
@@ -168,8 +168,7 @@ async function fetchQueryFeatures(
 export async function queryLayersForFeatures(
   mapview: MapView,
   map: Map | undefined,
-  event: __esri.MapViewClickEvent,
-  scale: number
+  event: __esri.MapViewClickEvent
 ): Promise<void> {
   const layerFeatureResults: LayerFeatureResult[] = [];
 
@@ -183,7 +182,7 @@ export async function queryLayersForFeatures(
         l.type !== 'base-tile' &&
         l.type !== 'imagery'
     )
-    .filter((l: any) => layerIsInScale(l, scale))
+    .filter((l: any) => layerIsInScale(l, mapview.scale))
     .toArray();
   if (allLayersVisibleLayers) {
     for await (const layer of allLayersVisibleLayers) {

--- a/src/js/helpers/layerScaleCheck.ts
+++ b/src/js/helpers/layerScaleCheck.ts
@@ -1,0 +1,24 @@
+import { LayerProps } from 'js/store/mapview/types';
+/*
+ * Helper function to determine if layer is in mapview scale
+ */
+export function layerIsInScale(
+  layer: LayerProps,
+  currentScale: number
+): boolean {
+  if (layer.hasOwnProperty('minScale') && layer.hasOwnProperty('maxScale')) {
+    if (layer.minScale === 0 && layer.maxScale === 0) {
+      return true;
+      //@ts-ignore -- TS is not understanding the above check for properties for some reason.
+    } else if (layer.maxScale < currentScale && layer.minScale > currentScale) {
+      //Our mapview is within the scale that is defined! show this legend item
+      return true;
+    } else {
+      //legend item is outside the scale parameters, we do not want it!
+      return false;
+    }
+  } else {
+    // if no maxmin scale defined, we want to show those layers in legend
+    return true;
+  }
+}


### PR DESCRIPTION
This PR does not have corresponding issue but improves performance for query feature workflow.

- extracted function to check if layer is in scale into a helper to be reusable
- query for features is aware of the layer scale and does not query those layers that are visible but out of scale
- query for features is also aware of sublayer visibility, previously it was not.

