### PR TITLE
Biomass layer support + layer ordering logic

### DIFF
--- a/configs/layer-config.ts
+++ b/configs/layer-config.ts
@@ -1,4 +1,4 @@
-export const allowedLayers = ['feature', 'dynamic', 'loss', 'gain']; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
+export const allowedLayers = ['feature', 'dynamic', 'loss', 'gain', 'image']; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
 
 //Layer controls (IDS)
 export const densityEnabledLayers = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1976,6 +1976,21 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
+    },
+    "@types/lodash-es": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.3.tgz",
+      "integrity": "sha512-iHI0i7ZAL1qepz1Y7f3EKg/zUMDwDfTzitx+AlHhJJvXwenP682ZyGbgPSc5Ej3eEAKVbNWKFuwOadCj5vBbYQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -10441,8 +10456,7 @@
     "lodash-es": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
-      "dev": true
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "lodash.escape": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     ]
   },
   "dependencies": {
+    "lodash-es": "^4.17.15",
     "rc-slider": "^9.2.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
@@ -78,11 +79,12 @@
     "redux-logger": "^3.0.6"
   },
   "devDependencies": {
-    "@types/rc-slider": "^8.6.5",
     "@arcgis/webpack-plugin": "^4.14.0",
     "@svgr/webpack": "^5.0.1",
     "@types/jest": "^24.9.1",
+    "@types/lodash-es": "^4.17.3",
     "@types/node": "^13.1.4",
+    "@types/rc-slider": "^8.6.5",
     "@types/react": "^16.9.17",
     "@types/react-dom": "^16.9.4",
     "@types/react-redux": "^7.1.5",

--- a/src/js/components/mapWidgets/widgetContent/CanopyDensityContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/CanopyDensityContent.tsx
@@ -52,6 +52,7 @@ const CanopyDensityContent = (): JSX.Element => {
     dispatch(setCanopyDensity(value));
     //send % value to modify the layer
     mapController.updateDensityValue(markValueMap[value]);
+    mapController.updateBiodensityValue(value);
   }
 
   return (

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -324,7 +324,7 @@ export class MapController {
             minScale,
             sublayer: true,
             parentID: sub.layer.id,
-            legendInfo: sublayerLegendInfo.legend
+            legendInfo: sublayerLegendInfo?.legend
           });
         });
       } else {
@@ -484,11 +484,27 @@ export class MapController {
                     availableLayer => availableLayer.group !== 'webmap'
                   );
 
-                store.dispatch(
-                  allAvailableLayers([...prevMapObjects, ...mapLayerObjects])
-                );
+                const allLayerObjects = [...prevMapObjects, ...mapLayerObjects];
+
+                store.dispatch(allAvailableLayers(allLayerObjects));
 
                 this._map?.addMany(resourceLayers);
+                //Retrieve sorted layer array
+                const mapLayerIDs = getSortedLayers(
+                  appSettings.layerPanel,
+                  allLayerObjects,
+                  this._map
+                );
+
+                //Reorder layers on the map!
+                this._map?.layers.forEach((layer: any) => {
+                  const layerIndex = mapLayerIDs?.findIndex(
+                    i => i === layer.id
+                  );
+                  if (layerIndex && layerIndex !== -1) {
+                    this._map?.reorder(layer, layerIndex);
+                  }
+                });
               });
             }
           },

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -23,6 +23,7 @@ import { densityEnabledLayers } from '../../../configs/layer-config';
 import store from '../store/index';
 import { LayerFactory } from 'js/helpers/LayerFactory';
 import { setLayerSearchSource } from 'js/helpers/mapController/searchSources';
+import { getSortedLayers } from 'js/helpers/mapController/layerSorting';
 import {
   allAvailableLayers,
   mapError,
@@ -54,7 +55,6 @@ import { queryLayersForFeatures } from 'js/helpers/dataPanel/DataPanel';
 import { setNewGraphic } from 'js/helpers/MapGraphics';
 import { fetchLegendInfo } from 'js/helpers/legendInfo';
 import { allowedLayers } from '../../../configs/layer-config';
-import { sortBy, flatten } from 'lodash-es';
 
 interface URLCoordinates {
   zoom: number;
@@ -257,56 +257,18 @@ export class MapController {
             });
 
             this._map?.addMany(mapLayers);
-            //Lets order layers groups first
-            const orderedGroups = sortBy(
-              Object.keys(appSettings.layerPanel),
-              key => {
-                return appSettings.layerPanel[key].order;
-              }
+
+            //Retrieve sorted layer array
+            const mapLayerIDs = getSortedLayers(
+              appSettings.layerPanel,
+              allLayerObjects,
+              this._map
             );
-            //Order layers within layer groups
-            const orderedLayerGroups = orderedGroups
-              .map(group => {
-                //jam in webmap layers in here as they do not appear in settings
-                if (group === 'GROUP_WEBMAP') {
-                  return allLayerObjects.filter(o => o.group === 'webmap');
-                }
-                const layersInGroup = sortBy(
-                  appSettings.layerPanel[group].layers,
-                  l => {
-                    return l.order;
-                  }
-                );
-                return layersInGroup;
-              })
-              .filter(group => group?.length);
-            const flattenedLayerGroups = flatten(orderedLayerGroups);
 
-            let mapLayerIDs = [] as any[];
-
-            flattenedLayerGroups.forEach(layerGroup => {
-              //attempt to grab layer id  from the map
-              const layer = this._map?.findLayerById(layerGroup.id);
-              if (layer) {
-                //layer exist, likely dealing with normal layer
-                mapLayerIDs.push(layer.id);
-              } else if (!layer && layerGroup.sublayer) {
-                //we did not find it because it was sublayer and we need to find the parent layer
-                const layer = this._map?.findLayerById(layerGroup.parentID);
-                mapLayerIDs.push(layer?.id);
-              }
-            });
-
-            mapLayerIDs = mapLayerIDs
-              .filter(
-                (id: string, index: number) => mapLayerIDs.indexOf(id) === index
-              )
-              .reverse();
-
-            //finally let's reorder layers on the map!
+            //Reorder layers on the map!
             this._map?.layers.forEach((layer: any) => {
-              const layerIndex = mapLayerIDs.findIndex(i => i === layer.id);
-              if (layerIndex !== -1) {
+              const layerIndex = mapLayerIDs?.findIndex(i => i === layer.id);
+              if (layerIndex && layerIndex !== -1) {
                 this._map?.reorder(layer, layerIndex);
               }
             });

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -53,8 +53,7 @@ import { queryLayersForFeatures } from 'js/helpers/dataPanel/DataPanel';
 
 import { setNewGraphic } from 'js/helpers/MapGraphics';
 import { fetchLegendInfo } from 'js/helpers/legendInfo';
-
-const allowedLayers = ['feature', 'dynamic', 'loss', 'gain']; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
+import { allowedLayers } from '../../../configs/layer-config';
 
 interface URLCoordinates {
   zoom: number;
@@ -1046,7 +1045,7 @@ export class MapController {
   updateDensityValue(value: number): void {
     densityEnabledLayers.forEach((layerId: string) => {
       const layer: any = this._map?.findLayerById(layerId);
-      if (layer) {
+      if (layer && layer.id !== 'AG_BIOMASS' && layer.urlTemplate) {
         layer.urlTemplate = layer.urlTemplate.replace(
           /(tc)(?:[^\/]+)/,
           `tc${value}`
@@ -1054,6 +1053,14 @@ export class MapController {
         layer.refresh();
       }
     });
+  }
+
+  updateBiodensityValue(value: number): void {
+    const bioLayer: any = this._map?.findLayerById('AG_BIOMASS');
+    if (bioLayer) {
+      bioLayer.mosaicRule.where = `OBJECTID = ${value}`;
+      bioLayer.refresh();
+    }
   }
 
   getMapviewCoordinates(): URLCoordinates {

--- a/src/js/helpers/LayerFactory.ts
+++ b/src/js/helpers/LayerFactory.ts
@@ -1,10 +1,11 @@
-// import MapView from 'esri/views/MapView';
 import Layer from 'esri/layers/Layer';
 import ImageryLayer from 'esri/layers/ImageryLayer';
 import FeatureLayer from 'esri/layers/FeatureLayer';
 import MapImageLayer from 'esri/layers/MapImageLayer';
+import MosaicRule from 'esri/layers/support/MosaicRule';
 import { TreeCoverLossLayer } from 'js/layers/TreeCoverLossLayer';
 import { TreeCoverGainLayer } from 'js/layers/TreeCoverGainLayer';
+import store from 'js/store/index';
 
 import { LayerFactoryObject } from 'js/interfaces/mapping';
 
@@ -25,10 +26,16 @@ export function LayerFactory(
     case 'image':
       esriLayer = new ImageryLayer({
         id: layerConfig.id,
-        title: layerConfig.title,
         visible: layerConfig.visible,
         url: layerConfig.url
       });
+      if (layerConfig.id === 'AG_BIOMASS') {
+        //biomass layer expects object id that maps to canopy density values
+        const { appState } = store.getState();
+        esriLayer.mosaicRule = new MosaicRule({
+          where: `OBJECTID = ${appState.leftPanel.density}`
+        });
+      }
       break;
     case 'feature':
       esriLayer = new FeatureLayer({

--- a/src/js/helpers/mapController/layerSorting.ts
+++ b/src/js/helpers/mapController/layerSorting.ts
@@ -1,0 +1,49 @@
+import Map from 'esri/Map';
+import { sortBy, flatten } from 'lodash-es';
+//Sorts layers by sorting configuration defined in resources
+//takes into account group sorting first and then individual layer sorting
+//returns an array of layer ids in order of priority
+export function getSortedLayers(
+  layerPanelSettings: object,
+  allLayerObjects: any[],
+  map?: Map
+): string[] | undefined {
+  if (!map) return;
+  let mapLayerIDs = [] as string[];
+  //Lets order layers groups first
+  const orderedGroups = sortBy(Object.keys(layerPanelSettings), key => {
+    return layerPanelSettings[key].order;
+  });
+  //Order layers within layer groups
+  const orderedLayerGroups = orderedGroups
+    .map(group => {
+      //jam in webmap layers in here as they do not appear in settings
+      if (group === 'GROUP_WEBMAP') {
+        return allLayerObjects.filter(o => o.group === 'webmap');
+      }
+      const layersInGroup = sortBy(layerPanelSettings[group].layers, l => {
+        return l.order;
+      });
+      return layersInGroup;
+    })
+    .filter(group => group?.length);
+  const flattenedLayerGroups = flatten(orderedLayerGroups);
+
+  flattenedLayerGroups.forEach(layerGroup => {
+    //attempt to grab layer id  from the map
+    const layer = map.findLayerById(layerGroup.id);
+    if (layer) {
+      //layer exist, likely dealing with normal layer
+      mapLayerIDs.push(layer.id);
+    } else if (!layer && layerGroup.sublayer) {
+      //we did not find it because it was sublayer and we need to find the parent layer
+      const layer = map.findLayerById(layerGroup.parentID);
+      mapLayerIDs.push(layer?.id);
+    }
+  });
+  mapLayerIDs = mapLayerIDs
+    .filter((id: string, index: number) => mapLayerIDs.indexOf(id) === index)
+    .reverse();
+
+  return mapLayerIDs;
+}

--- a/src/js/store/appState/types.ts
+++ b/src/js/store/appState/types.ts
@@ -4,7 +4,7 @@ export interface LeftPanel {
   tabViewVisible: boolean;
   activeTab: string;
   openLayerGroup: string;
-  density: number;
+  density: 1 | 2 | 3 | 4 | 5 | 6 | 7 | number; //careful about introducing any more density numbers, AG_BIOMASS layer depends on those to render and update
 }
 
 interface SpecificAreaResults {


### PR DESCRIPTION
Partial fix for #763
Support new layer type that is tracked in #817

In scope:
- Added biodensity layer support (also should work with other ImageryLayers but needs testing)
- Added ability to control biodensity layer through canopy density slider
- Added lodash dependency for easier sorting
- Added layer ordering function and logic

Out of scope:
- Changing language flow does not respect layer ordering function for some reason.