### PR TITLE
Ticket 716 - i button, left panel

### DIFF
--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -207,6 +207,7 @@
     .layer-label {
       font-size: 0.8rem;
       margin-left: 0.5rem;
+      max-width: 12rem;
     }
 
     .info-ifon-container,

--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -256,6 +256,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .hidden {

--- a/src/css/modalCard.scss
+++ b/src/css/modalCard.scss
@@ -32,6 +32,11 @@
     }
   }
 
+  &.info-content {
+    width: 30rem;
+    margin-left: -15rem;
+  }
+
   &.pen-widget {
     height: 30rem;
     top: 30%;

--- a/src/css/modalCard.scss
+++ b/src/css/modalCard.scss
@@ -34,7 +34,9 @@
 
   &.info-content {
     width: 31.25rem;
+    height: 25rem;
     margin-left: -15.625rem;
+    margin-top: -15.625rem;
     font-family: $fira-sans;
     padding: 1rem;
 

--- a/src/css/modalCard.scss
+++ b/src/css/modalCard.scss
@@ -33,8 +33,95 @@
   }
 
   &.info-content {
-    width: 30rem;
-    margin-left: -15rem;
+    width: 31.25rem;
+    margin-left: -15.625rem;
+    font-family: $fira-sans;
+    padding: 1rem;
+
+    .info-content-container {
+      padding: 1rem;
+
+      .header {
+        h2 {
+          text-transform: uppercase;
+          line-height: 1rem;
+          font-weight: 500;
+          font-size: 1rem;
+          display: block;
+          color: $dark-grey;
+        }
+
+        h3 {
+          font-weight: normal;
+          color: #aaa;
+          line-height: 1rem;
+          font-size: 0.8rem;
+          margin-top: 0.75rem;
+          color: $medium-dark-grey;
+        }
+      }
+      .button-container {
+        border-top: 1px solid #e5e5df;
+
+        .orange-button {
+          width: 7.75rem;
+          font-size: 0.85rem;
+        }
+      }
+
+      table,
+      .overview-container,
+      .citation-container {
+        padding-top: 1rem;
+      }
+
+      .citation-container {
+        padding-top: 1rem;
+        color: #aaa;
+        font-size: 0.75rem;
+      }
+
+      table {
+        border-collapse: collapse;
+        font-size: 0.7rem;
+
+        tr:nth-child(even) {
+          background-color: rgb(242, 242, 243);
+        }
+
+        tr {
+          td.label {
+            line-height: 1rem;
+            text-transform: uppercase;
+            font-weight: 500;
+            font-size: 0.7rem;
+            width: 120px; // * pixels are required
+            border-right: 1px solid #e5e5df;
+            border-bottom: 1px solid #e5e5df;
+            padding: 0.65rem;
+          }
+
+          td.label-info {
+            line-height: 1rem;
+            border-bottom: 1px solid #e5e5df;
+            padding-left: 0.85rem;
+          }
+        }
+      }
+    }
+
+    .overview-container {
+      font-size: 0.8rem;
+      h3 {
+        font-weight: 500;
+        font-size: 1rem;
+      }
+
+      div > p {
+        line-height: 1.25rem;
+        margin-top: 0.75rem;
+      }
+    }
   }
 
   &.pen-widget {

--- a/src/js/components/leftPanel/layersPanel/DateRange.tsx
+++ b/src/js/components/leftPanel/layersPanel/DateRange.tsx
@@ -19,7 +19,6 @@ const returnDateToday = (): string => {
 
 const DateRange = (props: DateRangeProps): JSX.Element => {
   const { layer } = props;
-  console.log('<DateRange/>', layer);
 
   const [startDate, setStartDate] = useState(returnDateToday());
   const [endDate, setEndDate] = useState(returnDateToday());

--- a/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
+++ b/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
@@ -40,11 +40,12 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
   };
 
   const setInfoModal = (): void => {
-    if (!layer) {
-      return;
+    if (layer) {
+      dispatch(renderModal('InfoContent'));
+      dispatch(renderInfoModal(layer.id));
     }
-    dispatch(renderModal('InfoContent'));
-    dispatch(renderInfoModal(layer.id));
+
+    return;
   };
 
   return (

--- a/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
+++ b/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
@@ -6,7 +6,7 @@ import LayerTransparencySlider from './LayerTransparencySlider';
 import CanopyDensityPicker from 'js/components/sharedComponents/CanopyDensityPicker';
 import TimeSlider from 'js/components/sharedComponents/TimeSlider';
 
-import { renderModal, renderInfoModal } from 'js/store/appState/actions';
+import { renderModal, setInfoModalLayerID } from 'js/store/appState/actions';
 
 import { RootState } from 'js/store';
 
@@ -39,10 +39,10 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
     }
   };
 
-  const setInfoModal = (): void => {
+  const openInfoModal = (): void => {
     if (layer) {
       dispatch(renderModal('InfoContent'));
-      dispatch(renderInfoModal(layer.id));
+      dispatch(setInfoModalLayerID(layer.id));
     }
 
     return;
@@ -58,7 +58,7 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
           parentID={props.parentID}
         />
         <span className="layer-label">{layer?.title}</span>
-        <div className="info-icon-container" onClick={() => setInfoModal()}>
+        <div className="info-icon-container" onClick={() => openInfoModal()}>
           <InfoIcon width={10} height={10} fill={'#fff'} />
         </div>
       </div>

--- a/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
+++ b/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 import LayerToggleSwitch from './LayerToggleSwitch';
 import LayerTransparencySlider from './LayerTransparencySlider';
 import CanopyDensityPicker from 'js/components/sharedComponents/CanopyDensityPicker';
 import TimeSlider from 'js/components/sharedComponents/TimeSlider';
+
+import { renderModal, renderInfoModal } from 'js/store/appState/actions';
 
 import { RootState } from 'js/store';
 
@@ -19,6 +21,7 @@ interface LayerControlProps {
 }
 
 const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
+  const dispatch = useDispatch();
   const { allAvailableLayers } = useSelector(
     (store: RootState) => store.mapviewState
   );
@@ -36,6 +39,14 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
     }
   };
 
+  const setInfoModal = (): void => {
+    if (!layer) {
+      return;
+    }
+    dispatch(renderModal('InfoContent'));
+    dispatch(renderInfoModal(layer.id));
+  };
+
   return (
     <>
       <div className="layers-control-checkbox">
@@ -46,7 +57,7 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
           parentID={props.parentID}
         />
         <span className="layer-label">{layer?.title}</span>
-        <div className="info-icon-container">
+        <div className="info-icon-container" onClick={() => setInfoModal()}>
           <InfoIcon width={10} height={10} fill={'#fff'} />
         </div>
       </div>

--- a/src/js/components/modal/modalCard.tsx
+++ b/src/js/components/modal/modalCard.tsx
@@ -9,6 +9,7 @@ import CoordinatesForm from 'js/components/mapWidgets/widgetContent/coordinatesF
 import MeasureContent from 'js/components/mapWidgets/widgetContent/measureContent';
 import CanopyDensityContent from 'js/components/mapWidgets/widgetContent/CanopyDensityContent';
 import SubscriptionContent from '../mapWidgets/widgetContent/SubscriptionContent';
+import InfoContent from 'js/components/sharedComponents/InfoContent';
 
 import { renderModal } from 'js/store/appState/actions';
 
@@ -47,6 +48,8 @@ const ModalCard: FunctionComponent<{}> = () => {
         return <MeasureContent />;
       case 'CanopyDensity':
         return <CanopyDensityContent />;
+      case 'InfoContent':
+        return <InfoContent />;
       default:
         break;
     }

--- a/src/js/components/modal/modalCard.tsx
+++ b/src/js/components/modal/modalCard.tsx
@@ -69,6 +69,8 @@ const ModalCard: FunctionComponent<{}> = () => {
         return 'print-widget';
       case 'ShareWidget':
         return 'share-widget';
+      case 'InfoContent':
+        return 'info-content';
       default:
         return '';
     }

--- a/src/js/components/sharedComponents/InfoContent.tsx
+++ b/src/js/components/sharedComponents/InfoContent.tsx
@@ -5,7 +5,7 @@ import { RootState } from 'js/store';
 
 const InfoContent: FunctionComponent<{}> = () => {
   const layerID = useSelector(
-    (store: RootState) => store.appState.renderInfoModal
+    (store: RootState) => store.appState.infoModalLayerID
   );
   const { allAvailableLayers } = useSelector(
     (store: RootState) => store.mapviewState

--- a/src/js/components/sharedComponents/InfoContent.tsx
+++ b/src/js/components/sharedComponents/InfoContent.tsx
@@ -28,50 +28,78 @@ const InfoContent: FunctionComponent<{}> = () => {
         cautions,
         license,
         overview,
-        citation
+        citation,
+        title,
+        subtitle
       } = metadata;
 
       return (
         <>
+          <div className="header">
+            <h2>{title}</h2>
+            <h3>{subtitle}</h3>
+          </div>
           <table>
             <tbody>
               <tr>
-                <td>Function</td>
-                <td dangerouslySetInnerHTML={{ __html: metadata.function }} />
-              </tr>
-              <tr>
-                <td>Resolution</td>
-                <td dangerouslySetInnerHTML={{ __html: resolution }} />
-              </tr>
-              <tr>
-                <td>Tags</td>
-                <td>{tags}</td>
-              </tr>
-              <tr>
-                <td>Geographic Coverage</td>
-                <td dangerouslySetInnerHTML={{ __html: geographic_coverage }} />
-              </tr>
-              <tr>
-                <td>Source</td>
-                <td dangerouslySetInnerHTML={{ __html: source }} />
-              </tr>
-              <tr>
-                <td>Frequency</td>
+                <td className="label">Function</td>
                 <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: metadata.function }}
+                />
+              </tr>
+              <tr>
+                <td className="label">Resolution</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: resolution }}
+                />
+              </tr>
+              <tr>
+                <td className="label">Tags</td>
+                <td className="label-info">{tags}</td>
+              </tr>
+              <tr>
+                <td className="label">Geographic Coverage</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: geographic_coverage }}
+                />
+              </tr>
+              <tr>
+                <td className="label">Source</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: source }}
+                />
+              </tr>
+              <tr>
+                <td className="label">Frequency</td>
+                <td
+                  className="label-info"
                   dangerouslySetInnerHTML={{ __html: frequency_of_updates }}
                 />
               </tr>
               <tr>
-                <td>Date of Content</td>
-                <td dangerouslySetInnerHTML={{ __html: date_of_content }} />
+                <td className="label">Date of Content</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: date_of_content }}
+                />
               </tr>
               <tr>
-                <td>Cautions</td>
-                <td dangerouslySetInnerHTML={{ __html: cautions }} />
+                <td className="label">Cautions</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: cautions }}
+                />
               </tr>
               <tr>
-                <td>License</td>
-                <td dangerouslySetInnerHTML={{ __html: license }} />
+                <td className="label">License</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: license }}
+                />
               </tr>
             </tbody>
           </table>
@@ -82,6 +110,14 @@ const InfoContent: FunctionComponent<{}> = () => {
           <div className="citation-container">
             <h4>Citation</h4>
             <div dangerouslySetInnerHTML={{ __html: citation }} />
+          </div>
+          <div className="button-container">
+            <button
+              className="orange-button"
+              onClick={(): void => console.log('download data!')}
+            >
+              Download Data
+            </button>
           </div>
         </>
       );
@@ -95,7 +131,7 @@ const InfoContent: FunctionComponent<{}> = () => {
   };
 
   return (
-    <div>
+    <div className="info-content-container">
       <RenderLayerContent />
     </div>
   );

--- a/src/js/components/sharedComponents/InfoContent.tsx
+++ b/src/js/components/sharedComponents/InfoContent.tsx
@@ -1,0 +1,94 @@
+import React, { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
+
+import { RootState } from 'js/store';
+
+const InfoContent: FunctionComponent<{}> = () => {
+  const layerID = useSelector(
+    (store: RootState) => store.appState.renderInfoModal
+  );
+  const { allAvailableLayers } = useSelector(
+    (store: RootState) => store.mapviewState
+  );
+
+  const layer = allAvailableLayers.filter(
+    (layer: any) => layer.id === layerID
+  )[0];
+
+  const RenderLayerContent = (): JSX.Element => {
+    const { metadata } = layer.metadata as any;
+    const {
+      resolution,
+      tags,
+      geographic_coverage,
+      source,
+      frequency_of_updates,
+      date_of_content,
+      cautions,
+      license,
+      overview,
+      citation
+    } = metadata;
+
+    return (
+      <>
+        <table>
+          <tr>
+            <td>Function</td>
+            <td dangerouslySetInnerHTML={{ __html: metadata.function }} />
+          </tr>
+          <tr>
+            <td>Resolution</td>
+            <td dangerouslySetInnerHTML={{ __html: resolution }} />
+          </tr>
+          <tr>
+            <td>Tags</td>
+            <td>{tags}</td>
+          </tr>
+          <tr>
+            <td>Geographic Coverage</td>
+            <td dangerouslySetInnerHTML={{ __html: geographic_coverage }} />
+          </tr>
+          <tr>
+            <td>Source</td>
+            <td dangerouslySetInnerHTML={{ __html: source }} />
+          </tr>
+          <tr>
+            <td>Frequency</td>
+            <td>
+              <td dangerouslySetInnerHTML={{ __html: frequency_of_updates }} />
+            </td>
+          </tr>
+          <tr>
+            <td>Date of Content</td>
+            <td dangerouslySetInnerHTML={{ __html: date_of_content }} />
+          </tr>
+          <tr>
+            <td>Cautions</td>
+            <td dangerouslySetInnerHTML={{ __html: cautions }} />
+          </tr>
+          <tr>
+            <td>License</td>
+            <td dangerouslySetInnerHTML={{ __html: license }} />
+          </tr>
+        </table>
+        <div className="overview-container">
+          <h3>Overview</h3>
+          <div dangerouslySetInnerHTML={{ __html: overview }} />
+        </div>
+        <div className="citation-container">
+          <h4>Citation</h4>
+          <div dangerouslySetInnerHTML={{ __html: citation }} />
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <div>
+      <RenderLayerContent />
+    </div>
+  );
+};
+
+export default InfoContent;

--- a/src/js/components/sharedComponents/InfoContent.tsx
+++ b/src/js/components/sharedComponents/InfoContent.tsx
@@ -16,80 +16,82 @@ const InfoContent: FunctionComponent<{}> = () => {
   )[0];
 
   const RenderLayerContent = (): JSX.Element => {
-    if (!layer.metadata) {
+    if (layer.metadata) {
+      const { metadata } = layer.metadata as any;
+      const {
+        resolution,
+        tags,
+        geographic_coverage,
+        source,
+        frequency_of_updates,
+        date_of_content,
+        cautions,
+        license,
+        overview,
+        citation
+      } = metadata;
+
+      return (
+        <>
+          <table>
+            <tbody>
+              <tr>
+                <td>Function</td>
+                <td dangerouslySetInnerHTML={{ __html: metadata.function }} />
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td dangerouslySetInnerHTML={{ __html: resolution }} />
+              </tr>
+              <tr>
+                <td>Tags</td>
+                <td>{tags}</td>
+              </tr>
+              <tr>
+                <td>Geographic Coverage</td>
+                <td dangerouslySetInnerHTML={{ __html: geographic_coverage }} />
+              </tr>
+              <tr>
+                <td>Source</td>
+                <td dangerouslySetInnerHTML={{ __html: source }} />
+              </tr>
+              <tr>
+                <td>Frequency</td>
+                <td
+                  dangerouslySetInnerHTML={{ __html: frequency_of_updates }}
+                />
+              </tr>
+              <tr>
+                <td>Date of Content</td>
+                <td dangerouslySetInnerHTML={{ __html: date_of_content }} />
+              </tr>
+              <tr>
+                <td>Cautions</td>
+                <td dangerouslySetInnerHTML={{ __html: cautions }} />
+              </tr>
+              <tr>
+                <td>License</td>
+                <td dangerouslySetInnerHTML={{ __html: license }} />
+              </tr>
+            </tbody>
+          </table>
+          <div className="overview-container">
+            <h3>Overview</h3>
+            <div dangerouslySetInnerHTML={{ __html: overview }} />
+          </div>
+          <div className="citation-container">
+            <h4>Citation</h4>
+            <div dangerouslySetInnerHTML={{ __html: citation }} />
+          </div>
+        </>
+      );
+    } else {
       console.log(
         "This layer doesn't have metadata to support this feature!",
         layer
       );
       return <></>;
     }
-
-    const { metadata } = layer.metadata as any;
-    const {
-      resolution,
-      tags,
-      geographic_coverage,
-      source,
-      frequency_of_updates,
-      date_of_content,
-      cautions,
-      license,
-      overview,
-      citation
-    } = metadata;
-
-    return (
-      <>
-        <table>
-          <tbody>
-            <tr>
-              <td>Function</td>
-              <td dangerouslySetInnerHTML={{ __html: metadata.function }} />
-            </tr>
-            <tr>
-              <td>Resolution</td>
-              <td dangerouslySetInnerHTML={{ __html: resolution }} />
-            </tr>
-            <tr>
-              <td>Tags</td>
-              <td>{tags}</td>
-            </tr>
-            <tr>
-              <td>Geographic Coverage</td>
-              <td dangerouslySetInnerHTML={{ __html: geographic_coverage }} />
-            </tr>
-            <tr>
-              <td>Source</td>
-              <td dangerouslySetInnerHTML={{ __html: source }} />
-            </tr>
-            <tr>
-              <td>Frequency</td>
-              <td dangerouslySetInnerHTML={{ __html: frequency_of_updates }} />
-            </tr>
-            <tr>
-              <td>Date of Content</td>
-              <td dangerouslySetInnerHTML={{ __html: date_of_content }} />
-            </tr>
-            <tr>
-              <td>Cautions</td>
-              <td dangerouslySetInnerHTML={{ __html: cautions }} />
-            </tr>
-            <tr>
-              <td>License</td>
-              <td dangerouslySetInnerHTML={{ __html: license }} />
-            </tr>
-          </tbody>
-        </table>
-        <div className="overview-container">
-          <h3>Overview</h3>
-          <div dangerouslySetInnerHTML={{ __html: overview }} />
-        </div>
-        <div className="citation-container">
-          <h4>Citation</h4>
-          <div dangerouslySetInnerHTML={{ __html: citation }} />
-        </div>
-      </>
-    );
   };
 
   return (

--- a/src/js/components/sharedComponents/InfoContent.tsx
+++ b/src/js/components/sharedComponents/InfoContent.tsx
@@ -16,6 +16,14 @@ const InfoContent: FunctionComponent<{}> = () => {
   )[0];
 
   const RenderLayerContent = (): JSX.Element => {
+    if (!layer.metadata) {
+      console.log(
+        "This layer doesn't have metadata to support this feature!",
+        layer
+      );
+      return <></>;
+    }
+
     const { metadata } = layer.metadata as any;
     const {
       resolution,
@@ -33,44 +41,44 @@ const InfoContent: FunctionComponent<{}> = () => {
     return (
       <>
         <table>
-          <tr>
-            <td>Function</td>
-            <td dangerouslySetInnerHTML={{ __html: metadata.function }} />
-          </tr>
-          <tr>
-            <td>Resolution</td>
-            <td dangerouslySetInnerHTML={{ __html: resolution }} />
-          </tr>
-          <tr>
-            <td>Tags</td>
-            <td>{tags}</td>
-          </tr>
-          <tr>
-            <td>Geographic Coverage</td>
-            <td dangerouslySetInnerHTML={{ __html: geographic_coverage }} />
-          </tr>
-          <tr>
-            <td>Source</td>
-            <td dangerouslySetInnerHTML={{ __html: source }} />
-          </tr>
-          <tr>
-            <td>Frequency</td>
-            <td>
+          <tbody>
+            <tr>
+              <td>Function</td>
+              <td dangerouslySetInnerHTML={{ __html: metadata.function }} />
+            </tr>
+            <tr>
+              <td>Resolution</td>
+              <td dangerouslySetInnerHTML={{ __html: resolution }} />
+            </tr>
+            <tr>
+              <td>Tags</td>
+              <td>{tags}</td>
+            </tr>
+            <tr>
+              <td>Geographic Coverage</td>
+              <td dangerouslySetInnerHTML={{ __html: geographic_coverage }} />
+            </tr>
+            <tr>
+              <td>Source</td>
+              <td dangerouslySetInnerHTML={{ __html: source }} />
+            </tr>
+            <tr>
+              <td>Frequency</td>
               <td dangerouslySetInnerHTML={{ __html: frequency_of_updates }} />
-            </td>
-          </tr>
-          <tr>
-            <td>Date of Content</td>
-            <td dangerouslySetInnerHTML={{ __html: date_of_content }} />
-          </tr>
-          <tr>
-            <td>Cautions</td>
-            <td dangerouslySetInnerHTML={{ __html: cautions }} />
-          </tr>
-          <tr>
-            <td>License</td>
-            <td dangerouslySetInnerHTML={{ __html: license }} />
-          </tr>
+            </tr>
+            <tr>
+              <td>Date of Content</td>
+              <td dangerouslySetInnerHTML={{ __html: date_of_content }} />
+            </tr>
+            <tr>
+              <td>Cautions</td>
+              <td dangerouslySetInnerHTML={{ __html: cautions }} />
+            </tr>
+            <tr>
+              <td>License</td>
+              <td dangerouslySetInnerHTML={{ __html: license }} />
+            </tr>
+          </tbody>
         </table>
         <div className="overview-container">
           <h3>Overview</h3>

--- a/src/js/store/appState/actions.ts
+++ b/src/js/store/appState/actions.ts
@@ -1,6 +1,7 @@
 import {
   TOGGLE_TABVIEW_PANEL,
   RENDER_MODAL,
+  RENDER_INFO_MODAL,
   SELECT_ACTIVE_TAB,
   SET_LANGUAGE,
   SET_OPEN_LAYER_GROUP,
@@ -30,6 +31,13 @@ export function setCanopyDensity(payload: LeftPanel['density']) {
 export function setHideWidget(payload: AppState['hideWidgetActive']) {
   return {
     type: SET_HIDE_WIDGET as typeof SET_HIDE_WIDGET,
+    payload: payload
+  };
+}
+
+export function renderInfoModal(payload: AppState['renderInfoModal']) {
+  return {
+    type: RENDER_INFO_MODAL as typeof RENDER_INFO_MODAL,
     payload: payload
   };
 }

--- a/src/js/store/appState/actions.ts
+++ b/src/js/store/appState/actions.ts
@@ -35,7 +35,7 @@ export function setHideWidget(payload: AppState['hideWidgetActive']) {
   };
 }
 
-export function renderInfoModal(payload: AppState['renderInfoModal']) {
+export function setInfoModalLayerID(payload: AppState['infoModalLayerID']) {
   return {
     type: RENDER_INFO_MODAL as typeof RENDER_INFO_MODAL,
     payload: payload

--- a/src/js/store/appState/reducers.ts
+++ b/src/js/store/appState/reducers.ts
@@ -5,6 +5,7 @@ import {
   SELECT_ACTIVE_TAB,
   SET_LANGUAGE,
   RENDER_MODAL,
+  RENDER_INFO_MODAL,
   SET_OPEN_LAYER_GROUP,
   SET_LOGGED_IN,
   SET_MEASURE_RESULTS,
@@ -16,6 +17,7 @@ import {
 const initialState: AppState = {
   selectedLanguage: 'en',
   renderModal: '',
+  renderInfoModal: '',
   hideWidgetActive: false,
   isLoggedIn: false,
   leftPanel: {
@@ -53,6 +55,8 @@ export function appStateReducer(
       };
     case RENDER_MODAL:
       return { ...state, renderModal: action.payload };
+    case RENDER_INFO_MODAL:
+      return { ...state, renderInfoModal: action.payload };
     case SELECT_ACTIVE_TAB:
       return {
         ...state,

--- a/src/js/store/appState/reducers.ts
+++ b/src/js/store/appState/reducers.ts
@@ -17,7 +17,7 @@ import {
 const initialState: AppState = {
   selectedLanguage: 'en',
   renderModal: '',
-  renderInfoModal: '',
+  infoModalLayerID: '',
   hideWidgetActive: false,
   isLoggedIn: false,
   leftPanel: {
@@ -56,7 +56,7 @@ export function appStateReducer(
     case RENDER_MODAL:
       return { ...state, renderModal: action.payload };
     case RENDER_INFO_MODAL:
-      return { ...state, renderInfoModal: action.payload };
+      return { ...state, infoModalLayerID: action.payload };
     case SELECT_ACTIVE_TAB:
       return {
         ...state,

--- a/src/js/store/appState/types.ts
+++ b/src/js/store/appState/types.ts
@@ -32,6 +32,7 @@ export interface MeasureContent {
 export interface AppState {
   leftPanel: LeftPanel;
   renderModal: string;
+  renderInfoModal: string;
   selectedLanguage: string;
   measureContent: MeasureContent;
   hideWidgetActive: boolean;
@@ -40,6 +41,7 @@ export interface AppState {
 
 //Action names available
 export const RENDER_MODAL = 'RENDER_MODAL';
+export const RENDER_INFO_MODAL = 'RENDER_INFO_MODAL';
 export const SELECT_ACTIVE_TAB = 'SELECT_ACTIVE_TAB';
 export const SET_LANGUAGE = 'SET_LANGUAGE';
 export const TOGGLE_TABVIEW_PANEL = 'TOGGLE_TABVIEW_PANEL';
@@ -75,6 +77,11 @@ interface RenderModalAction {
   payload: AppState['renderModal'];
 }
 
+interface RenderInfoModalAction {
+  type: typeof RENDER_INFO_MODAL;
+  payload: AppState['renderInfoModal'];
+}
+
 interface SetLoggedIn {
   type: typeof SET_LOGGED_IN;
   payload: AppState['isLoggedIn'];
@@ -103,6 +110,7 @@ interface SetActiveMeasureButton {
 export type AppStateTypes =
   | ToggleTabviewPanelAction
   | RenderModalAction
+  | RenderInfoModalAction
   | SelectActiveTab
   | SetLanguageAction
   | SetOpenLayerGroup

--- a/src/js/store/appState/types.ts
+++ b/src/js/store/appState/types.ts
@@ -32,7 +32,7 @@ export interface MeasureContent {
 export interface AppState {
   leftPanel: LeftPanel;
   renderModal: string;
-  renderInfoModal: string;
+  infoModalLayerID: string;
   selectedLanguage: string;
   measureContent: MeasureContent;
   hideWidgetActive: boolean;
@@ -79,7 +79,7 @@ interface RenderModalAction {
 
 interface RenderInfoModalAction {
   type: typeof RENDER_INFO_MODAL;
-  payload: AppState['renderInfoModal'];
+  payload: AppState['infoModalLayerID'];
 }
 
 interface SetLoggedIn {


### PR DESCRIPTION
This PR enables a user to select the 'i' button and see additional information

Fixes part of #716 

What it accomplishes;
- Renders info content in modalcard component
- leverages redux store to track what layerID info content should listen to
- New component, `InfoContent`, renders `metadata` content

What it does not accomplish;
- Doesn't provide a solution for `WEBMAP_GROUP`, which doesn't have a `metadata` property or alternative property we can use to populate `InfoContent`
- styling of any kind
