### PR TITLE
Ticket 716 - 'i' button styling

### DIFF
--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -207,6 +207,7 @@
     .layer-label {
       font-size: 0.8rem;
       margin-left: 0.5rem;
+      max-width: 12rem;
     }
 
     .info-ifon-container,

--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -256,6 +256,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .hidden {

--- a/src/css/modalCard.scss
+++ b/src/css/modalCard.scss
@@ -34,7 +34,9 @@
 
   &.info-content {
     width: 31.25rem;
+    height: 25rem;
     margin-left: -15.625rem;
+    margin-top: -15.625rem;
     font-family: $fira-sans;
     padding: 1rem;
 

--- a/src/css/modalCard.scss
+++ b/src/css/modalCard.scss
@@ -33,8 +33,95 @@
   }
 
   &.info-content {
-    width: 30rem;
-    margin-left: -15rem;
+    width: 31.25rem;
+    margin-left: -15.625rem;
+    font-family: $fira-sans;
+    padding: 1rem;
+
+    .info-content-container {
+      padding: 1rem;
+
+      .header {
+        h2 {
+          text-transform: uppercase;
+          line-height: 1rem;
+          font-weight: 500;
+          font-size: 1rem;
+          display: block;
+          color: $dark-grey;
+        }
+
+        h3 {
+          font-weight: normal;
+          color: #aaa;
+          line-height: 1rem;
+          font-size: 0.8rem;
+          margin-top: 0.75rem;
+          color: $medium-dark-grey;
+        }
+      }
+      .button-container {
+        border-top: 1px solid #e5e5df;
+
+        .orange-button {
+          width: 7.75rem;
+          font-size: 0.85rem;
+        }
+      }
+
+      table,
+      .overview-container,
+      .citation-container {
+        padding-top: 1rem;
+      }
+
+      .citation-container {
+        padding-top: 1rem;
+        color: #aaa;
+        font-size: 0.75rem;
+      }
+
+      table {
+        border-collapse: collapse;
+        font-size: 0.7rem;
+
+        tr:nth-child(even) {
+          background-color: rgb(242, 242, 243);
+        }
+
+        tr {
+          td.label {
+            line-height: 1rem;
+            text-transform: uppercase;
+            font-weight: 500;
+            font-size: 0.7rem;
+            width: 120px; // * pixels are required
+            border-right: 1px solid #e5e5df;
+            border-bottom: 1px solid #e5e5df;
+            padding: 0.65rem;
+          }
+
+          td.label-info {
+            line-height: 1rem;
+            border-bottom: 1px solid #e5e5df;
+            padding-left: 0.85rem;
+          }
+        }
+      }
+    }
+
+    .overview-container {
+      font-size: 0.8rem;
+      h3 {
+        font-weight: 500;
+        font-size: 1rem;
+      }
+
+      div > p {
+        line-height: 1.25rem;
+        margin-top: 0.75rem;
+      }
+    }
   }
 
   &.pen-widget {

--- a/src/js/components/sharedComponents/InfoContent.tsx
+++ b/src/js/components/sharedComponents/InfoContent.tsx
@@ -28,50 +28,78 @@ const InfoContent: FunctionComponent<{}> = () => {
         cautions,
         license,
         overview,
-        citation
+        citation,
+        title,
+        subtitle
       } = metadata;
 
       return (
         <>
+          <div className="header">
+            <h2>{title}</h2>
+            <h3>{subtitle}</h3>
+          </div>
           <table>
             <tbody>
               <tr>
-                <td>Function</td>
-                <td dangerouslySetInnerHTML={{ __html: metadata.function }} />
-              </tr>
-              <tr>
-                <td>Resolution</td>
-                <td dangerouslySetInnerHTML={{ __html: resolution }} />
-              </tr>
-              <tr>
-                <td>Tags</td>
-                <td>{tags}</td>
-              </tr>
-              <tr>
-                <td>Geographic Coverage</td>
-                <td dangerouslySetInnerHTML={{ __html: geographic_coverage }} />
-              </tr>
-              <tr>
-                <td>Source</td>
-                <td dangerouslySetInnerHTML={{ __html: source }} />
-              </tr>
-              <tr>
-                <td>Frequency</td>
+                <td className="label">Function</td>
                 <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: metadata.function }}
+                />
+              </tr>
+              <tr>
+                <td className="label">Resolution</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: resolution }}
+                />
+              </tr>
+              <tr>
+                <td className="label">Tags</td>
+                <td className="label-info">{tags}</td>
+              </tr>
+              <tr>
+                <td className="label">Geographic Coverage</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: geographic_coverage }}
+                />
+              </tr>
+              <tr>
+                <td className="label">Source</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: source }}
+                />
+              </tr>
+              <tr>
+                <td className="label">Frequency</td>
+                <td
+                  className="label-info"
                   dangerouslySetInnerHTML={{ __html: frequency_of_updates }}
                 />
               </tr>
               <tr>
-                <td>Date of Content</td>
-                <td dangerouslySetInnerHTML={{ __html: date_of_content }} />
+                <td className="label">Date of Content</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: date_of_content }}
+                />
               </tr>
               <tr>
-                <td>Cautions</td>
-                <td dangerouslySetInnerHTML={{ __html: cautions }} />
+                <td className="label">Cautions</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: cautions }}
+                />
               </tr>
               <tr>
-                <td>License</td>
-                <td dangerouslySetInnerHTML={{ __html: license }} />
+                <td className="label">License</td>
+                <td
+                  className="label-info"
+                  dangerouslySetInnerHTML={{ __html: license }}
+                />
               </tr>
             </tbody>
           </table>
@@ -82,6 +110,14 @@ const InfoContent: FunctionComponent<{}> = () => {
           <div className="citation-container">
             <h4>Citation</h4>
             <div dangerouslySetInnerHTML={{ __html: citation }} />
+          </div>
+          <div className="button-container">
+            <button
+              className="orange-button"
+              onClick={(): void => console.log('download data!')}
+            >
+              Download Data
+            </button>
           </div>
         </>
       );
@@ -95,7 +131,7 @@ const InfoContent: FunctionComponent<{}> = () => {
   };
 
   return (
-    <div>
+    <div className="info-content-container">
       <RenderLayerContent />
     </div>
   );


### PR DESCRIPTION
This PR styles the `InfoContent.tsx`

Fixes part of #716 

What it accomplishes;
- Styles `InfoContent` to be desktop/ipad friendly
- Adds header section to `InfoContent.tsx`
- matches comps _pixel-by-pixel_! 🎆 

What it does not accomplish;
- Does not implement desktop styling (PROD doesn't have mobile styling either, but it would be a nice bonus since the left panel is mobile-responsive!)
- 'Download data' button isn't yet fixed to prioritize tickets in light of the upcoming sprint deadline
<img width="479" alt="Screen Shot 2020-03-25 at 4 00 36 PM" src="https://user-images.githubusercontent.com/9040867/77580122-d3ce4980-6eb1-11ea-8a4e-c26a59304c67.png">