### PR TITLE
Tree Cover Imagery Layer and Raster Function control

### DIFF
--- a/src/js/components/mapWidgets/widgetContent/CanopyDensityContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/CanopyDensityContent.tsx
@@ -53,6 +53,7 @@ const CanopyDensityContent = (): JSX.Element => {
     //send % value to modify the layer
     mapController.updateDensityValue(markValueMap[value]);
     mapController.updateBiodensityValue(value);
+    mapController.updateTreeCoverValue(markValueMap[value]);
   }
 
   return (

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -1117,6 +1117,7 @@ export class MapController {
       remapRF.functionArguments = {
         InputRanges: [value, treeCoverLayerInfo.metadata.inputRange[1]],
         OutputValues: treeCoverLayerInfo.metadata.outputRange,
+        AllowUnmatched: false,
         Raster: '$$' // Apply remap to the image service
       };
       remapRF.outputPixelType = 'u8';

--- a/src/js/helpers/LayerFactory.ts
+++ b/src/js/helpers/LayerFactory.ts
@@ -6,6 +6,7 @@ import MosaicRule from 'esri/layers/support/MosaicRule';
 import RasterFunction from 'esri/layers/support/RasterFunction';
 import { TreeCoverLossLayer } from 'js/layers/TreeCoverLossLayer';
 import { TreeCoverGainLayer } from 'js/layers/TreeCoverGainLayer';
+import { markValueMap } from 'js/components/mapWidgets/widgetContent/CanopyDensityContent';
 import store from 'js/store/index';
 
 import { LayerFactoryObject } from 'js/interfaces/mapping';
@@ -29,21 +30,22 @@ export function LayerFactory(
       esriLayer = new ImageryLayer({
         id: layerConfig.id,
         visible: layerConfig.visible,
-        url: layerConfig.url
+        url: layerConfig.url,
+        opacity: layerConfig.opacity
       });
       if (layerConfig.metadata.colormap) {
         const remapRF = new RasterFunction();
         remapRF.functionName = 'Remap';
         remapRF.functionArguments = {
           InputRanges: [
-            appState.leftPanel.density,
+            markValueMap[appState.leftPanel.density],
             layerConfig.metadata.inputRange[1]
           ],
           OutputValues: layerConfig.metadata.outputRange,
-          Raster: '$$' // Apply remap to the image service
+          AllowUnmatched: false,
+          Raster: '$$'
         };
         remapRF.outputPixelType = 'u8';
-        //apply custom colormap that's coming from metadata
         const colorRF = new RasterFunction();
         colorRF.functionName = 'Colormap';
         colorRF.functionArguments = {

--- a/src/js/interfaces/mapping.ts
+++ b/src/js/interfaces/mapping.ts
@@ -6,4 +6,5 @@ export interface LayerFactoryObject {
   definitionExpression: string | undefined;
   url: string;
   type: string;
+  metadata: any;
 }


### PR DESCRIPTION
Implements the following:

- Imagery layers get created with correct color ramps and pixel filtering (see LayerFactory)
- Added control to update density for TREE_COVER layer which required going through RasterFunction creation
- Fixed the bug with layer ordering function that cause 0'th layer in the queue to be ignored due to falsy logic