### PR TITLE
Ticket 716 - conditionally returns subtitles

### DIFF
--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -209,6 +209,12 @@
       margin-left: 0.5rem;
     }
 
+    .layer-subtitle {
+      font-size: 0.8rem;
+      margin-left: 0.5rem;
+      color: $medium-dark-grey;
+    }
+
     .info-ifon-container,
     .layer-checkbox {
       flex-grow: 0;

--- a/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
+++ b/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
@@ -36,6 +36,23 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
     }
   };
 
+  const returnSubtitle = (): JSX.Element | undefined => {
+    let subTitle = '';
+    if (layer?.metadata?.metadata) {
+      subTitle = (layer?.metadata?.metadata as any).subtitle;
+      return (
+        <>
+          <br />
+          <span className="layer-subtitle">{subTitle}</span>
+        </>
+      );
+    } else {
+      console.log('layer does not have metadata to support subtitles!', layer);
+      return;
+    }
+    // return <span className="layer-subtitle">{subTitle}</span>;
+  };
+
   return (
     <>
       <div className="layers-control-checkbox">
@@ -45,7 +62,10 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
           sublayer={props.sublayer}
           parentID={props.parentID}
         />
-        <span className="layer-label">{layer?.title}</span>
+        <div className="title-wrapper">
+          <span className="layer-label">{layer?.title}</span>
+          {returnSubtitle()}
+        </div>
         <div className="info-icon-container">
           <InfoIcon width={10} height={10} fill={'#fff'} />
         </div>

--- a/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
+++ b/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
@@ -22,6 +22,9 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
   const { allAvailableLayers } = useSelector(
     (store: RootState) => store.mapviewState
   );
+  const { selectedLanguage } = useSelector(
+    (store: RootState) => store.appState
+  );
   const layer = allAvailableLayers.find(l => l.id === props.id);
 
   //Determine if we need density control on this layer
@@ -38,8 +41,9 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
 
   const returnSubtitle = (): JSX.Element | undefined => {
     let subTitle = '';
-    if (layer?.metadata?.metadata) {
-      subTitle = (layer?.metadata?.metadata as any).subtitle;
+    if (layer?.sublabel) {
+      subTitle = layer.sublabel[selectedLanguage];
+
       return (
         <>
           <br />
@@ -50,7 +54,6 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
       console.log('layer does not have metadata to support subtitles!', layer);
       return;
     }
-    // return <span className="layer-subtitle">{subTitle}</span>;
   };
 
   return (


### PR DESCRIPTION
This PR conditionally returns subtitles if they exist in the `layer` object

Fixes part of #716 

What it accomplishes;
- Conditionally returns the subtitle

What it does not accomplish;
- Does not style to be pixel-perfect
- Doesn't debug why `WEBMAP_GROUP` doesn't return metadata (is beyond the scope of this PR)