### PR TITLE
adding webtiled layers to layer factory

### DIFF
--- a/configs/layer-config.ts
+++ b/configs/layer-config.ts
@@ -1,4 +1,11 @@
-export const allowedLayers = ['feature', 'dynamic', 'loss', 'gain', 'image']; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
+export const allowedLayers = [
+  'feature',
+  'dynamic',
+  'loss',
+  'gain',
+  'image',
+  'webtiled'
+]; //To be: tiled, webtiled, image, dynamic, feature, graphic, and custom (loss, gain, glad, etc)
 
 //Layer controls (IDS)
 export const densityEnabledLayers = [

--- a/src/js/helpers/LayerFactory.ts
+++ b/src/js/helpers/LayerFactory.ts
@@ -2,6 +2,7 @@ import Layer from 'esri/layers/Layer';
 import ImageryLayer from 'esri/layers/ImageryLayer';
 import FeatureLayer from 'esri/layers/FeatureLayer';
 import MapImageLayer from 'esri/layers/MapImageLayer';
+import WebTileLayer from 'esri/layers/WebTileLayer';
 import MosaicRule from 'esri/layers/support/MosaicRule';
 import { TreeCoverLossLayer } from 'js/layers/TreeCoverLossLayer';
 import { TreeCoverGainLayer } from 'js/layers/TreeCoverGainLayer';
@@ -61,6 +62,15 @@ export function LayerFactory(
         visible: layerConfig.visible,
         urlTemplate: layerConfig.url,
         view: mapView
+      });
+      break;
+    case 'webtiled':
+      esriLayer = new WebTileLayer({
+        id: layerConfig.id,
+        title: layerConfig.title,
+        visible: layerConfig.visible,
+        urlTemplate: layerConfig.url,
+        opacity: layerConfig.opacity
       });
       break;
     default:


### PR DESCRIPTION
Partial Fix #817
This PR adds support for WebTileLayers. Testing with CMR config layer name `Couverture terrestre`

Layer loads okay and user is able to toggle it and change visibility. However seeing a lot of Tile errors in the console which may cause problems down below. Added as a discussion item with Christina. 
![image](https://user-images.githubusercontent.com/12076555/77693977-a64fd180-6f7f-11ea-9b7a-5509b76139de.png)
