### PR TITLE
Ticket 931 - toggle bugfix

### DIFF
--- a/src/js/components/leftPanel/layersPanel/LayerToggleSwitch.tsx
+++ b/src/js/components/leftPanel/layersPanel/LayerToggleSwitch.tsx
@@ -11,6 +11,12 @@ interface LayerToggleProps {
 
 const LayerToggleSwitch = (props: LayerToggleProps): React.ReactElement => {
   const { layerIsVisible, layerID, sublayer, parentID } = props;
+
+  const toggleVisibility = (): void => {
+    mapController.toggleLayerVisibility(layerID, sublayer, parentID);
+    mapController.turnOffVIIRSorMODIS(layerID);
+  };
+
   return (
     <div className="layer-checkbox">
       <input
@@ -19,9 +25,7 @@ const LayerToggleSwitch = (props: LayerToggleProps): React.ReactElement => {
         className="styled-checkbox"
         id={`layer-checkbox-${layerID}`}
         checked={layerIsVisible}
-        onChange={(): void =>
-          mapController.toggleLayerVisibility(layerID, sublayer, parentID)
-        }
+        onChange={(): void => toggleVisibility()}
       />
       <label
         className="styled-checkboxlabel"

--- a/src/js/components/leftPanel/layersPanel/LayerToggleSwitch.tsx
+++ b/src/js/components/leftPanel/layersPanel/LayerToggleSwitch.tsx
@@ -13,8 +13,11 @@ const LayerToggleSwitch = (props: LayerToggleProps): React.ReactElement => {
   const { layerIsVisible, layerID, sublayer, parentID } = props;
 
   const toggleVisibility = (): void => {
-    mapController.toggleLayerVisibility(layerID, sublayer, parentID);
-    mapController.turnOffVIIRSorMODIS(layerID);
+    if (layerID === 'VIIRS_ACTIVE_FIRES' || layerID === 'MODIS_ACTIVE_FIRES') {
+      mapController.turnOffVIIRSorMODIS(layerID);
+    } else {
+      mapController.toggleLayerVisibility(layerID, sublayer, parentID);
+    }
   };
 
   return (

--- a/src/js/components/leftPanel/layersPanel/LayerToggleSwitch.tsx
+++ b/src/js/components/leftPanel/layersPanel/LayerToggleSwitch.tsx
@@ -14,7 +14,7 @@ const LayerToggleSwitch = (props: LayerToggleProps): React.ReactElement => {
 
   const toggleVisibility = (): void => {
     if (layerID === 'VIIRS_ACTIVE_FIRES' || layerID === 'MODIS_ACTIVE_FIRES') {
-      mapController.turnOffVIIRSorMODIS(layerID);
+      mapController.toggleVIIRSorMODIS(layerID);
     } else {
       mapController.toggleLayerVisibility(layerID, sublayer, parentID);
     }

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -1460,7 +1460,7 @@ export class MapController {
     }
   }
 
-  turnOffVIIRSorMODIS(layerID: string): void {
+  toggleVIIRSorMODIS(layerID: string): void {
     if (!this._map) {
       return;
     }

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -1473,6 +1473,8 @@ export class MapController {
       return;
     }
 
+    layer.visible = !layer.visible;
+
     const sublayer24 = layer.sublayers.items.filter(
       (sublayer: Sublayer) =>
         sublayer.title === 'Global Fires (VIIRS) 24 hrs' ||
@@ -1500,6 +1502,19 @@ export class MapController {
         }
       });
     }
+
+    const { mapviewState } = store.getState();
+    const newLayersArray = mapviewState.allAvailableLayers.map(l => {
+      if (l.id === layer.id) {
+        return {
+          ...l,
+          visible: layer.visible
+        };
+      } else {
+        return l;
+      }
+    });
+    store.dispatch(allAvailableLayers(newLayersArray));
   }
 
   updateMODISorVIIRSOpacity(layerID: string, opacity: number): void {

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -1480,7 +1480,9 @@ export class MapController {
         sublayer.title === 'Global Fires (MODIS) 24 hrs'
     )[0];
 
-    sublayer24.visible = true;
+    if (sublayer24) {
+      sublayer24.visible = true;
+    }
 
     if (layer.id === 'VIIRS_ACTIVE_FIRES') {
       VIIRSLayerIDs.forEach(({ layerID }) => {

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -623,7 +623,6 @@ export class MapController {
     parentID?: string
   ): void {
     let layer = null as any;
-    this.turnOffVIIRSorMODIS(layerID);
     if (sublayer && parentID) {
       layer = this._map
         ?.findLayerById(parentID)


### PR DESCRIPTION
This PR fixes errors we receive in the console when toggling a layer

Fixes part of #931 

What it accomplishes;
- Fixes toggle logic bug so layers are toggleable by conditionally firing `toggleVIIRSorMODIS()`

What it doesn't accomplish;
- Doesn't ID why there are certain layers that don't update on the map - I'm thinking this should go in a separate PR/ticket
    - Alertes SAD
    - Unités forestières d'exploitation
    - Assietes annuelles de coupe
    - Permis d'exploitation des carrières industrielles
    - Autorisation d'exploitation des carrières
    - Permis de recherches