### PR TITLE
Ticket 915 - DateRange.tsx style

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -46,3 +46,21 @@ button {
     margin-right: 0.5rem;
   }
 }
+
+.date-time-toggle {
+  position: relative;
+  background: transparent;
+  width: 6rem;
+  padding: 5px;
+  font-size: 16px;
+  line-height: 1;
+  height: 1.5rem;
+  border-radius: 16px;
+  -webkit-appearance: none;
+  margin-top: auto;
+  margin-bottom: auto;
+  border: 1px solid $base-yellow;
+  background-color: $white;
+  color: $dark-grey;
+  font-size: 11px;
+}

--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -248,6 +248,57 @@
       }
     }
   }
+
+  .daterange-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    justify-content: space-evenly;
+    font-family: $fira-sans;
+    width: auto;
+    height: 2rem;
+    margin-top: 1rem;
+
+    &.expanded-date-section {
+      height: 8rem;
+    }
+
+    select.date-time-toggle {
+      padding: 5px 5px 5px 10px;
+    }
+
+    .date-time-toggle {
+      &.input {
+        width: 7.5rem;
+        height: 1rem;
+      }
+    }
+
+    .calendar-wrapper {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      width: -webkit-fill-available;
+      padding: 1.5rem 1.5rem 0rem 1.5rem;
+
+      .date-section-wrapper {
+        display: flex;
+        width: -webkit-fill-available;
+        justify-content: space-evenly;
+
+        label {
+          margin-top: auto;
+          margin-bottom: auto;
+          font-size: 0.75rem;
+          color: $black;
+        }
+
+        input {
+          font-family: $fira-sans;
+        }
+      }
+    }
+  }
 }
 
 .transparency-slider {

--- a/src/js/components/leftPanel/layersPanel/DateRange.tsx
+++ b/src/js/components/leftPanel/layersPanel/DateRange.tsx
@@ -66,8 +66,13 @@ const DateRange = (props: DateRangeProps): JSX.Element => {
 
   return (
     <>
-      <div className="dropdown-wrapper">
+      <div
+        className={`daterange-wrapper ${
+          renderCustomRange ? 'expanded-date-section' : ''
+        } `}
+      >
         <select
+          className="date-time-toggle"
           onChange={(e): void => setDefinedDateRange(e)}
           value={definedRange.length ? definedRange : '24 hrs'}
         >
@@ -76,34 +81,39 @@ const DateRange = (props: DateRangeProps): JSX.Element => {
           <option value={'72 hrs'}>Past 72 hours</option>
           <option value={'7 days'}>Past week</option>
         </select>
+        <button
+          className="date-time-toggle"
+          onClick={(): void => setCustomRange()}
+        >
+          Custom Range
+        </button>
+        {renderCustomRange && (
+          <div className="calendar-wrapper">
+            <div className="date-section-wrapper">
+              <label htmlFor="start-date">Start:</label>
+              <input
+                className="date-time-toggle input"
+                type="date"
+                value={startDate}
+                min="2018-01-01"
+                max={returnDateToday()}
+                onChange={(e): void => updateStartDate(e)}
+              />
+            </div>
+            <div className="date-section-wrapper">
+              <label htmlFor="end-date">End:</label>
+              <input
+                className="date-time-toggle input"
+                type="date"
+                value={endDate}
+                min="2018-01-01"
+                max={returnDateToday()}
+                onChange={(e): void => updateEndDate(e)}
+              />
+            </div>
+          </div>
+        )}
       </div>
-      <button onClick={(): void => setCustomRange()}>Custom Range</button>
-      {renderCustomRange && (
-        <>
-          <div className="date-section-wrapper">
-            <label htmlFor="start-date">Start:</label>
-            <input
-              type="date"
-              id="start-date"
-              value={startDate}
-              min="2018-01-01"
-              max={returnDateToday()}
-              onChange={(e): void => updateStartDate(e)}
-            />
-          </div>
-          <div className="date-section-wrapper">
-            <label htmlFor="end-date">End:</label>
-            <input
-              type="date"
-              id="end-date"
-              value={endDate}
-              min="2018-01-01"
-              max={returnDateToday()}
-              onChange={(e): void => updateEndDate(e)}
-            />
-          </div>
-        </>
-      )}
     </>
   );
 };


### PR DESCRIPTION
This PR styles `DateRange.tsx` with flexbox

Fixes part of #915 

What it accomplishes;
- Styles date range component to match comps

What it doesn't accomplish;
- When 'Custom Date Range' is selected, there's additional spacing in the start/end dates. When the user hovers over, they can see additional options ('x', etc). This isn't aligned with the comps, but we're also preserving the accessibility of the feature