### PR TITLE
Ticket 870 - doc tab UI

### DIFF
--- a/configs/leftPanel.config.ts
+++ b/configs/leftPanel.config.ts
@@ -205,3 +205,54 @@ export const basemapLayersContent = {
     }
   ]
 };
+
+export const documentsContent = {
+  en: {
+    instructions:
+      'Select an area of interest to see if there are any related documents',
+    name: 'Name',
+    pdf: 'PDF',
+    size: 'Size'
+  },
+  ka: {
+    instructions:
+      'შეარჩიეთ საინტერესო ტერიტორია, და ნახეთ არის თუ არა მასთან დაკავშირებული დოკუმენტები',
+    name: 'სახელი',
+    pdf: 'PDF',
+    size: 'ზომა'
+  },
+  fr: {
+    instructions:
+      "Choisisez une région d'intérêt pour voir les documents associés",
+    name: 'Nom du fichier',
+    pdf: 'PDF',
+    size: 'Taille'
+  },
+  es: {
+    instructions:
+      'Seleccionar una área de interés para ver si haya algún documento relacionado',
+    name: 'Nombre',
+    pdf: 'PDF',
+    size: 'Size'
+  },
+  pt: {
+    instructions:
+      'Selecione área de interesse para verificar a existência de documentos relacionados',
+    name: 'Nome',
+    pdf: 'PDF',
+    size: 'Tamanho'
+  },
+  id: {
+    instructions:
+      'Select an area of interest to see if there are any related documents',
+    name: 'Nama',
+    pdf: 'PDF',
+    size: 'Size'
+  },
+  zh: {
+    instructions: '选择感兴趣区域来查看相关文件',
+    name: '姓名',
+    pdf: 'PDF',
+    size: 'Size'
+  }
+};

--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -14,11 +14,28 @@
 
   .documents-container {
     display: flex;
+    flex-wrap: wrap;
     padding: 1rem;
     font-family: $fira-sans;
+    color: #6f6f6f;
+    font-weight: normal;
+
+    .feature-collection-title {
+      flex-wrap: wrap;
+      border-bottom: 1px solid #aaa;
+      width: 100%;
+      font-size: 1.1rem;
+      font-weight: normal;
+      padding-bottom: 0.5rem;
+    }
+
+    .no-documents {
+      font-size: 0.85rem;
+      text-align: center;
+    }
 
     table {
-      width: 100%;
+      width: 15rem;
 
       .file-name {
         max-width: 1rem;
@@ -29,17 +46,26 @@
 
       th,
       td {
-        text-align: left;
         padding: 0.25em;
+        text-align: center;
+      }
+
+      th {
+        font-size: 0.85rem;
+        font-weight: 700;
       }
 
       tr {
         border-bottom: 1px solid #ddd;
+        font-size: 0.85rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .custom-horizontal-rule {
         padding: 0.25rem 0;
-        border-bottom: 1px solid black;
+        border-bottom: 0.5px solid $black;
       }
     }
   }

--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -22,7 +22,7 @@
 
     .feature-collection-title {
       flex-wrap: wrap;
-      border-bottom: 1px solid #aaa;
+      border-bottom: 1px solid $medium-dark-grey;
       width: 100%;
       font-size: 1.1rem;
       font-weight: normal;
@@ -56,7 +56,7 @@
       }
 
       tr {
-        border-bottom: 1px solid #ddd;
+        border-bottom: 1px solid $dropdown-border;
         font-size: 0.85rem;
         white-space: nowrap;
         overflow: hidden;

--- a/src/js/components/leftPanel/DocumentsTabView.tsx
+++ b/src/js/components/leftPanel/DocumentsTabView.tsx
@@ -4,8 +4,9 @@ import { useSelector } from 'react-redux';
 import { getDocuments } from 'js/helpers/mapController/Documents';
 
 import { RootState } from 'js/store';
-
 import { AttachmentWithURLProps } from 'js/interfaces/Attachment';
+
+import { documentsContent } from 'configs/leftPanel.config';
 
 import { ReactComponent as DocIcon } from 'src/images/documentIcon.svg';
 
@@ -22,6 +23,11 @@ const DocumentsTabView = (props: Props): JSX.Element => {
   const { activeFeatures, activeFeatureIndex } = useSelector(
     (store: RootState) => store.mapviewState
   );
+  const { selectedLanguage } = useSelector(
+    (state: RootState) => state.appState
+  );
+
+  const { instructions, name, pdf, size } = documentsContent[selectedLanguage];
   const tabViewIsVisible = tabViewVisible && activeTab === props.label;
 
   const [featureCollectionIndex] = activeFeatureIndex;
@@ -102,9 +108,9 @@ const DocumentsTabView = (props: Props): JSX.Element => {
               <table className="documents-table">
                 <thead className="table-headers">
                   <tr>
-                    <th>Name</th>
-                    <th>Size</th>
-                    <th>PDF</th>
+                    <th>{name}</th>
+                    <th>{size}</th>
+                    <th>{pdf}</th>
                   </tr>
                 </thead>
                 <tbody>{returnDocuments()}</tbody>
@@ -112,10 +118,7 @@ const DocumentsTabView = (props: Props): JSX.Element => {
             </>
           ) : (
             <>
-              <p className="no-documents">
-                Select an area of interest to see if there are any related
-                documents.
-              </p>
+              <p className="no-documents">{instructions}</p>
             </>
           )}
         </>

--- a/src/js/components/leftPanel/DocumentsTabView.tsx
+++ b/src/js/components/leftPanel/DocumentsTabView.tsx
@@ -65,7 +65,7 @@ const DocumentsTabView = (props: Props): JSX.Element => {
     }
   }, [tabViewIsVisible]);
 
-  const returnDocuments = (): Array<JSX.Element> | JSX.Element => {
+  const returnDocuments = (): Array<JSX.Element> | undefined => {
     if (allAttachments && allAttachments.length) {
       return allAttachments.map(
         (attachment: AttachmentWithURLProps, key: number) => {
@@ -74,21 +74,19 @@ const DocumentsTabView = (props: Props): JSX.Element => {
             <Fragment key={key}>
               <tr>
                 <td title={name} className="file-name">
-                  <a href={url} target="_blank" rel="noopener noreferrer">
-                    {name}
-                  </a>
+                  {name}
                 </td>
                 <td>{Math.round(size / 1000)} KB</td>
                 <td>
-                  <DocIcon height={20} width={20} fill={'#555'} />
+                  <a href={url} target="_blank" rel="noopener noreferrer">
+                    <DocIcon height={20} width={20} fill={'#F0AB00'} />
+                  </a>
                 </td>
               </tr>
             </Fragment>
           );
         }
       );
-    } else {
-      return <>There are no attachments at this time.</>;
     }
   };
 
@@ -96,22 +94,32 @@ const DocumentsTabView = (props: Props): JSX.Element => {
     <div className="documents-container">
       {tabViewIsVisible && (
         <>
-          <table className="documents-table">
-            <thead className="feature-collection-title">
+          {allAttachments && allAttachments.length ? (
+            <h3 className="feature-collection-title">
               {featureCollectionTitle}
-            </thead>
-            <div className="custom-horizontal-rule" />
-            {allAttachments && allAttachments.length ? (
-              <thead className="table-headers">
-                <tr>
-                  <th>Name</th>
-                  <th>Size</th>
-                  <th>PDF</th>
-                </tr>
-              </thead>
-            ) : null}
-            <tbody>{returnDocuments()}</tbody>
-          </table>
+            </h3>
+          ) : null}
+          {allAttachments && allAttachments.length ? (
+            <>
+              <table className="documents-table">
+                <thead className="table-headers">
+                  <tr>
+                    <th>Name</th>
+                    <th>Size</th>
+                    <th>PDF</th>
+                  </tr>
+                </thead>
+                <tbody>{returnDocuments()}</tbody>
+              </table>
+            </>
+          ) : (
+            <>
+              <p className="no-documents">
+                Select an area of interest to see if there are any related
+                documents.
+              </p>
+            </>
+          )}
         </>
       )}
     </div>

--- a/src/js/components/leftPanel/DocumentsTabView.tsx
+++ b/src/js/components/leftPanel/DocumentsTabView.tsx
@@ -66,28 +66,26 @@ const DocumentsTabView = (props: Props): JSX.Element => {
   }, [tabViewIsVisible]);
 
   const returnDocuments = (): Array<JSX.Element> | undefined => {
-    if (allAttachments && allAttachments.length) {
-      return allAttachments.map(
-        (attachment: AttachmentWithURLProps, key: number) => {
-          const { url, size, name } = attachment;
-          return (
-            <Fragment key={key}>
-              <tr>
-                <td title={name} className="file-name">
-                  {name}
-                </td>
-                <td>{Math.round(size / 1000)} KB</td>
-                <td>
-                  <a href={url} target="_blank" rel="noopener noreferrer">
-                    <DocIcon height={20} width={20} fill={'#F0AB00'} />
-                  </a>
-                </td>
-              </tr>
-            </Fragment>
-          );
-        }
-      );
-    }
+    return allAttachments.map(
+      (attachment: AttachmentWithURLProps, key: number) => {
+        const { url, size, name } = attachment;
+        return (
+          <Fragment key={key}>
+            <tr>
+              <td title={name} className="file-name">
+                {name}
+              </td>
+              <td>{Math.round(size / 1000)} KB</td>
+              <td>
+                <a href={url} target="_blank" rel="noopener noreferrer">
+                  <DocIcon height={20} width={20} fill={'#F0AB00'} />
+                </a>
+              </td>
+            </tr>
+          </Fragment>
+        );
+      }
+    );
   };
 
   return (


### PR DESCRIPTION
This ticket implements desktop styling for the doc tab

Fixes part of #870 

What it accomplishes;
- Matches comps
- Increases spacing for better UI/readability - @vaidotasp let me know what you think about this

What it doesn't accomplish;
- iPad/mobile responsiveness

before;
![Screen Shot 2020-04-02 at 3 48 25 PM](https://user-images.githubusercontent.com/9040867/78295029-68135e80-74f9-11ea-9945-01cf6486f656.png)


after;
<img width="317" alt="Screen Shot 2020-04-02 at 3 46 30 PM" src="https://user-images.githubusercontent.com/9040867/78294898-21bdff80-74f9-11ea-93db-b4cafc06cdf1.png">
