### PR TITLE
Ticket 927 - Search quick UI

### DIFF
--- a/src/js/components/mapWidgets/widgetContent/searchContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/searchContent.tsx
@@ -18,9 +18,13 @@ const SearchContent: FunctionComponent = () => {
   const [formError, setFormError] = useState(false);
   const [latitudeInput, setLatitude] = useState('');
   const [longitudeInput, setLongitude] = useState('');
-  const selectedLanguage = useSelector(
-    (state: RootState) => state.appState.selectedLanguage
+  const { selectedLanguage, selectedSearchWidgetLayer } = useSelector(
+    (state: RootState) => state.appState
   );
+  const [selectedLayerInfo, setSelectedLayerInfo] = useState({
+    displayField: '',
+    layerTitle: ''
+  });
   const { title, buttonTitle, latitude, longitude } = searchContent[
     selectedLanguage
   ];
@@ -28,6 +32,10 @@ const SearchContent: FunctionComponent = () => {
   useEffect(() => {
     mapController.initializeSearchWidget(searchRef);
   }, []);
+
+  useEffect(() => {
+    setSelectedLayerInfo(selectedSearchWidgetLayer);
+  }, [selectedSearchWidgetLayer]);
 
   const setSearch = (): void => {
     if (latitudeInput === '' || latitudeInput === '') {
@@ -87,6 +95,13 @@ const SearchContent: FunctionComponent = () => {
       <div className="search-widget-wrapper">
         <p>{title}</p>
         <div ref={searchRef}></div>
+        {selectedLayerInfo.displayField.length &&
+        selectedLayerInfo.layerTitle.length ? (
+          <p>
+            Search <em>{selectedLayerInfo.layerTitle}</em> by{' '}
+            {selectedLayerInfo.displayField}
+          </p>
+        ) : null}
       </div>
     </div>
   );

--- a/src/js/components/mapWidgets/widgetContent/searchContent.tsx
+++ b/src/js/components/mapWidgets/widgetContent/searchContent.tsx
@@ -18,13 +18,13 @@ const SearchContent: FunctionComponent = () => {
   const [formError, setFormError] = useState(false);
   const [latitudeInput, setLatitude] = useState('');
   const [longitudeInput, setLongitude] = useState('');
-  const { selectedLanguage, selectedSearchWidgetLayer } = useSelector(
-    (state: RootState) => state.appState
+  const selectedLanguage = useSelector(
+    (state: RootState) => state.appState.selectedLanguage
   );
-  const [selectedLayerInfo, setSelectedLayerInfo] = useState({
-    displayField: '',
-    layerTitle: ''
-  });
+  const selectedSearchWidgetLayer = useSelector(
+    (state: RootState) => state.appState.selectedSearchWidgetLayer
+  );
+
   const { title, buttonTitle, latitude, longitude } = searchContent[
     selectedLanguage
   ];
@@ -32,10 +32,6 @@ const SearchContent: FunctionComponent = () => {
   useEffect(() => {
     mapController.initializeSearchWidget(searchRef);
   }, []);
-
-  useEffect(() => {
-    setSelectedLayerInfo(selectedSearchWidgetLayer);
-  }, [selectedSearchWidgetLayer]);
 
   const setSearch = (): void => {
     if (latitudeInput === '' || latitudeInput === '') {
@@ -95,11 +91,11 @@ const SearchContent: FunctionComponent = () => {
       <div className="search-widget-wrapper">
         <p>{title}</p>
         <div ref={searchRef}></div>
-        {selectedLayerInfo.displayField.length &&
-        selectedLayerInfo.layerTitle.length ? (
+        {selectedSearchWidgetLayer.displayField.length &&
+        selectedSearchWidgetLayer.layerTitle.length ? (
           <p>
-            Search <em>{selectedLayerInfo.layerTitle}</em> by{' '}
-            {selectedLayerInfo.displayField}
+            Search <em>{selectedSearchWidgetLayer.layerTitle}</em> by{' '}
+            {selectedSearchWidgetLayer.displayField}
           </p>
         ) : null}
       </div>

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -42,7 +42,8 @@ import {
   selectActiveTab,
   setMeasureResults,
   setLanguage,
-  setRenderGFWDropdown
+  setRenderGFWDropdown,
+  setSelectedSearchWidgetLayer
 } from 'js/store/appState/actions';
 import {
   LayerProps,
@@ -956,10 +957,18 @@ export class MapController {
   async initializeSearchWidget(searchRef: RefObject<any>): Promise<void> {
     const allSources = await setLayerSearchSource();
 
-    new Search({
+    const searchWidget = new Search({
       view: this._mapview,
       container: searchRef.current,
       sources: allSources
+    });
+
+    searchWidget.on('search-focus', (e: any) => {
+      const selectedLayer = {
+        displayField: e.target.activeSource.displayField,
+        layerTitle: e.target.activeSource.layer.title
+      };
+      store.dispatch(setSelectedSearchWidgetLayer(selectedLayer));
     });
   }
 

--- a/src/js/helpers/mapController/searchSources.ts
+++ b/src/js/helpers/mapController/searchSources.ts
@@ -18,9 +18,7 @@ const returnLayerSearchSources = (
       placeholder: layer.title,
       searchFields: [layer.displayField],
       displayField: layer.displayField,
-      suggestionTemplate: `${layer.displayField.toUpperCase()} {${
-        layer.displayField
-      }}`,
+      suggestionTemplate: `{${layer.displayField}}`,
       exactMatch: false,
       outFields: ['*'],
       maxResults: 6,
@@ -33,7 +31,25 @@ const returnLayerSearchSources = (
 
 const setFeatureLayerSources = (): ArrayOfLayerSources => {
   const allFeatureLayers = (mapController._map?.allLayers as any).items.filter(
-    (layer: Layer) => layer.type === 'feature'
+    (layer: Layer) => {
+      const isVIIRSLayer =
+        layer.id === 'VIIRS48' ||
+        layer.id === 'VIIRS72' ||
+        layer.id === 'VIIRS7D';
+
+      const isMODISLayer =
+        layer.id === 'MODIS48' ||
+        layer.id === 'MODIS72' ||
+        layer.id === 'MODIS7D';
+
+      if (isVIIRSLayer || isMODISLayer) {
+        return;
+      }
+
+      if (layer.type === 'feature') {
+        return layer;
+      }
+    }
   );
 
   return returnLayerSearchSources(allFeatureLayers);
@@ -68,8 +84,8 @@ const setMapImageLayerSources = async (): Promise<ArrayOfLayerSources> => {
 export const setLayerSearchSource = async (): Promise<ArrayOfLayerSources> => {
   const featureLayerSources = setFeatureLayerSources() as any;
 
-  const mapImageLayerSources = (await setMapImageLayerSources()) as any;
+  // const mapImageLayerSources = (await setMapImageLayerSources()) as any;
   // * NOTE: mapImageLayerSources returns console errors RE FeatureLayer
 
-  return [...featureLayerSources, ...mapImageLayerSources];
+  return featureLayerSources;
 };

--- a/src/js/store/appState/actions.ts
+++ b/src/js/store/appState/actions.ts
@@ -12,8 +12,18 @@ import {
   LeftPanel,
   SET_MEASURE_RESULTS,
   SET_ACTIVE_MEASURE_BUTTON,
-  SET_CANOPY_DENSITY
+  SET_CANOPY_DENSITY,
+  SET_SELECTED_SEARCH_WIDGET_LAYER
 } from './types';
+
+export function setSelectedSearchWidgetLayer(
+  payload: AppState['selectedSearchWidgetLayer']
+) {
+  return {
+    type: SET_SELECTED_SEARCH_WIDGET_LAYER as typeof SET_SELECTED_SEARCH_WIDGET_LAYER,
+    payload: payload
+  };
+}
 
 export function toggleTabviewPanel(payload: LeftPanel['tabViewVisible']) {
   return {

--- a/src/js/store/appState/reducers.ts
+++ b/src/js/store/appState/reducers.ts
@@ -12,7 +12,8 @@ import {
   SET_MEASURE_RESULTS,
   SET_ACTIVE_MEASURE_BUTTON,
   SET_HIDE_WIDGET,
-  SET_CANOPY_DENSITY
+  SET_CANOPY_DENSITY,
+  SET_SELECTED_SEARCH_WIDGET_LAYER
 } from './types';
 
 const initialState: AppState = {
@@ -22,6 +23,10 @@ const initialState: AppState = {
   infoModalLayerID: '',
   hideWidgetActive: false,
   isLoggedIn: false,
+  selectedSearchWidgetLayer: {
+    displayField: '',
+    layerTitle: ''
+  },
   leftPanel: {
     tabViewVisible: true,
     activeTab: 'layers',
@@ -42,6 +47,11 @@ export function appStateReducer(
   action: AppStateTypes
 ): AppState {
   switch (action.type) {
+    case SET_SELECTED_SEARCH_WIDGET_LAYER:
+      return {
+        ...state,
+        selectedSearchWidgetLayer: action.payload
+      };
     case TOGGLE_TABVIEW_PANEL:
       return {
         ...state,

--- a/src/js/store/appState/types.ts
+++ b/src/js/store/appState/types.ts
@@ -29,6 +29,11 @@ export interface MeasureContent {
   coordinatePointerMoveResults?: any; // ClickResults | undefined | Point;
 }
 
+interface SelectedSearchWidgetLayer {
+  displayField: string;
+  layerTitle: string;
+}
+
 export interface AppState {
   leftPanel: LeftPanel;
   renderModal: string;
@@ -38,6 +43,7 @@ export interface AppState {
   measureContent: MeasureContent;
   hideWidgetActive: boolean;
   isLoggedIn: boolean;
+  selectedSearchWidgetLayer: SelectedSearchWidgetLayer;
 }
 
 //Action names available
@@ -53,6 +59,13 @@ export const SET_MEASURE_RESULTS = 'SET_MEASURE_RESULTS';
 export const SET_ACTIVE_MEASURE_BUTTON = 'SET_ACTIVE_MEASURE_BUTTON';
 export const SET_HIDE_WIDGET = 'SET_HIDE_WIDGET';
 export const SET_CANOPY_DENSITY = 'SET_CANOPY_DENSITY';
+export const SET_SELECTED_SEARCH_WIDGET_LAYER =
+  'SET_SELECTED_SEARCH_WIDGET_LAYER';
+
+interface SetSelectedSearchWidgetLayer {
+  type: typeof SET_SELECTED_SEARCH_WIDGET_LAYER;
+  payload: AppState['selectedSearchWidgetLayer'];
+}
 
 interface SetOpenLayerGroup {
   type: typeof SET_OPEN_LAYER_GROUP;
@@ -126,4 +139,5 @@ export type AppStateTypes =
   | SetMeasureResults
   | SetActiveMeasureButton
   | SetHideWidget
-  | SetCanopyDensity;
+  | SetCanopyDensity
+  | SetSelectedSearchWidgetLayer;


### PR DESCRIPTION
This PR renders what property the user can use to query a selected layer

PR fixes #927 

What it accomplishes;
- Search widget listens to user's layer selection and updates store
- `searchContent.tsx` listens to store and updates with UI content as needed

What it doesn't accomplish;
- translation logic (since this is a new, simple feature)