### PR TITLE
Analysis tab control - vega charts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
     'react-hooks/exhaustive-deps': 'warn', // Checks effect dependencies
     '@typescript-eslint/ban-ts-ignore': 0,
-    '@typescript-eslint/no-var-requires': 0
+    '@typescript-eslint/no-var-requires': 0,
+    'react/prop-types': 0
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5691,6 +5691,14 @@
       "dev": true,
       "requires": {
         "dojo": "1.14.2"
+      },
+      "dependencies": {
+        "dojo": {
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/dojo/-/dojo-1.14.2.tgz",
+          "integrity": "sha512-TI+Ytgfh/VfmHWERp45Jte6NFMdoJTPsvUP/uzJUvAXET8FP2h442LePWWJ/q/xZ4V0V8OtdJhx8It/GB+Zbxg==",
+          "dev": true
+        }
       }
     },
     "dir-glob": {
@@ -5754,6 +5762,14 @@
       "dev": true,
       "requires": {
         "dojo": "^1.9.0"
+      },
+      "dependencies": {
+        "dojo": {
+          "version": "1.16.2",
+          "resolved": "https://registry.npmjs.org/dojo/-/dojo-1.16.2.tgz",
+          "integrity": "sha512-cgiT6WFAmcc1p95X7HPPVq3pM+qD4eB+DRWI+z04IWlGh5v4h9wqOdz1s+2mG7x7UYz+EzoGyLB87GDgGUOtIQ==",
+          "dev": true
+        }
       }
     },
     "dojo-util": {
@@ -5822,6 +5838,12 @@
           "requires": {
             "dojo": "1.14.2"
           }
+        },
+        "dojo": {
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/dojo/-/dojo-1.14.2.tgz",
+          "integrity": "sha512-TI+Ytgfh/VfmHWERp45Jte6NFMdoJTPsvUP/uzJUvAXET8FP2h442LePWWJ/q/xZ4V0V8OtdJhx8It/GB+Zbxg==",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5812,6 +5812,17 @@
       "requires": {
         "dijit": "1.14.2",
         "dojo": "1.14.2"
+      },
+      "dependencies": {
+        "dijit": {
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/dijit/-/dijit-1.14.2.tgz",
+          "integrity": "sha512-T/jEhBVpGdU3ruw5K68S8qn8VCjn1Pv/2fC4g0QJjPD0VgxOV9BvXdjo8Fjpv5AQ69PEUdZijHrSTTcPwIo7bg==",
+          "dev": true,
+          "requires": {
+            "dojo": "1.14.2"
+          }
+        }
       }
     },
     "dom-align": {
@@ -14178,6 +14189,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "react-redux": "^7.1.3",
     "react-tooltip": "^3.11.2",
     "redux": "^4.0.5",
-    "redux-logger": "^3.0.6"
+    "redux-logger": "^3.0.6",
+    "reselect": "^4.0.0"
   },
   "devDependencies": {
     "@arcgis/webpack-plugin": "^4.14.0",

--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -204,8 +204,13 @@
     }
     .analysis-input {
       display: grid;
-      justify-content: center;
+      justify-items: center;
       margin-bottom: 20px;
+      .time-slider-container {
+        width: 90%;
+        padding-top: 10px;
+        padding-bottom: 10px;
+      }
       .calendar-wrapper {
         .date-section-wrapper {
           display: grid;

--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -202,6 +202,11 @@
       border-bottom: 1px solid rgba(0, 0, 0, 0.2);
       margin-bottom: 10px;
     }
+    .analysis-input {
+      display: grid;
+      justify-content: center;
+      margin-bottom: 20px;
+    }
     .ui-description {
       display: grid;
       grid-template-columns: auto 1fr;

--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -206,6 +206,20 @@
       display: grid;
       justify-content: center;
       margin-bottom: 20px;
+      .calendar-wrapper {
+        .date-section-wrapper {
+          display: grid;
+          grid-template-columns: 40px 1fr;
+          margin-bottom: 2px;
+          label {
+            margin-right: 5px;
+          }
+          input {
+            width: auto;
+            height: auto;
+          }
+        }
+      }
     }
     .ui-description {
       display: grid;

--- a/src/js/components/header/GFWLogin.tsx
+++ b/src/js/components/header/GFWLogin.tsx
@@ -14,8 +14,8 @@ interface LoginProps {
 
 const GFWLogin = (props: LoginProps): JSX.Element => {
   const dispatch = useDispatch();
-  const { renderGFWDropdown } = useSelector(
-    (state: RootState) => state.appState
+  const renderGFWDropdown = useSelector(
+    (state: RootState) => state.appState.renderGFWDropdown
   );
 
   return (

--- a/src/js/components/header/Header.tsx
+++ b/src/js/components/header/Header.tsx
@@ -8,8 +8,22 @@ import { RootState } from 'js/store/index';
 import { setRenderGFWDropdown } from 'js/store/appState/actions';
 
 import 'css/header.scss';
+import { createSelector } from 'reselect';
 
-// import config from '../../../../configs/resources';
+const appSettingsSelector = createSelector(
+  (state: RootState) => state.appSettings,
+  appSettings => ({
+    language: appSettings.language,
+    title: appSettings.title,
+    subtitle: appSettings.subtitle,
+    logoUrl: appSettings.logoUrl,
+    logoLinkUrl: appSettings.logoLinkUrl,
+    useAlternativeLanguage: appSettings.useAlternativeLanguage,
+    alternativeWebmap: appSettings.alternativeWebmap,
+    alternativeLanguage: appSettings.alternativeLanguage,
+    includeMyGFWLogin: appSettings.includeMyGFWLogin
+  })
+);
 
 const Header: FunctionComponent = () => {
   const dispatch = useDispatch();
@@ -23,10 +37,18 @@ const Header: FunctionComponent = () => {
     alternativeWebmap,
     alternativeLanguage,
     includeMyGFWLogin
-  } = useSelector((store: RootState) => store.appSettings);
+  } = useSelector(appSettingsSelector);
 
-  const { selectedLanguage, isLoggedIn, renderGFWDropdown } = useSelector(
-    (store: RootState) => store.appState
+  const selectedLanguage = useSelector(
+    (store: RootState) => store.appState.selectedLanguage
+  );
+
+  const isLoggedIn = useSelector(
+    (store: RootState) => store.appState.isLoggedIn
+  );
+
+  const renderGFWDropdown = useSelector(
+    (store: RootState) => store.appState.renderGFWDropdown
   );
 
   const closeGFWDropdown = () => {

--- a/src/js/components/leftPanel/LeftPanel.tsx
+++ b/src/js/components/leftPanel/LeftPanel.tsx
@@ -101,15 +101,20 @@ const Tabs = (props: TabsProps): React.ReactElement => {
 
 const LeftPanel = (): React.ReactElement => {
   const dispatch = useDispatch();
-  const { hideWidgetActive, renderGFWDropdown } = useSelector(
-    (store: RootState) => store.appState
+  const hideWidgetActive = useSelector(
+    (store: RootState) => store.appState.hideWidgetActive
+  );
+  const renderGFWDropdown = useSelector(
+    (store: RootState) => store.appState.renderGFWDropdown
   );
   const renderDocTab = useSelector(
     (store: RootState) => store.appSettings.includeDocumentsTab
   );
-
-  const { narrative, alternativeNarrative } = useSelector(
-    (store: RootState) => store.appSettings
+  const narrative = useSelector(
+    (store: RootState) => store.appSettings.narrative
+  );
+  const alternativeNarrative = useSelector(
+    (store: RootState) => store.appSettings.alternativeNarrative
   );
 
   const renderInfoTab =

--- a/src/js/components/leftPanel/analysisPanel/AnalysisTabView.tsx
+++ b/src/js/components/leftPanel/analysisPanel/AnalysisTabView.tsx
@@ -130,21 +130,6 @@ const AnalysisTabView = (props: TabProps): JSX.Element => {
     </div>
   );
 
-  // const TabViewContent = (): JSX.Element | null => {
-  //   console.log('tabview is re-rendering!');
-  //   if (tabViewIsVisible) {
-  //     //let's check for active features
-  //     if (activeFeaturesLength === 0) {
-  //       return <DefaultAnalysisContent />;
-  //     } else {
-  //       return <BaseAnalysis />;
-  //     }
-  //   } else {
-  //     return null;
-  //   }
-  // };
-
-  // return <TabViewContent />;
   return (
     <>
       {tabViewIsVisible && activeFeaturesLength !== 0 && <BaseAnalysis />}

--- a/src/js/components/leftPanel/analysisPanel/AnalysisTabView.tsx
+++ b/src/js/components/leftPanel/analysisPanel/AnalysisTabView.tsx
@@ -16,6 +16,13 @@ import { ReactComponent as PolygonIcon } from 'images/polygonIcon.svg';
 import { ReactComponent as PenIcon } from 'images/penIcon.svg';
 import { ReactComponent as PlusIcon } from 'images/plusIcon.svg';
 
+import { createSelector } from 'reselect';
+//Memo'd selectors
+const selectActiveFeaturesLength = createSelector(
+  (state: RootState) => state.mapviewState,
+  mapviewState => mapviewState.activeFeatures.length
+);
+
 interface TabProps {
   key: string;
   label: string;
@@ -23,10 +30,15 @@ interface TabProps {
 
 const AnalysisTabView = (props: TabProps): JSX.Element => {
   const dispatch = useDispatch();
-  const { selectedLanguage, leftPanel } = useSelector(
+  const activeTab = useSelector(
+    (store: RootState) => store.appState.leftPanel.activeTab
+  );
+  const tabViewVisible = useSelector(
+    (store: RootState) => store.appState.leftPanel.activeTab
+  );
+  const { selectedLanguage } = useSelector(
     (store: RootState) => store.appState
   );
-  const { activeTab, tabViewVisible } = leftPanel;
 
   const {
     analyzeExistingShapeTitle,
@@ -40,9 +52,7 @@ const AnalysisTabView = (props: TabProps): JSX.Element => {
     visitTitle
   } = analysisContent[selectedLanguage];
 
-  const { activeFeatures } = useSelector(
-    (store: RootState) => store.mapviewState
-  );
+  const activeFeaturesLength = useSelector(selectActiveFeaturesLength);
 
   const tabViewIsVisible = tabViewVisible && activeTab === props.label;
 
@@ -120,20 +130,29 @@ const AnalysisTabView = (props: TabProps): JSX.Element => {
     </div>
   );
 
-  const TabViewContent = (): JSX.Element | null => {
-    if (tabViewIsVisible) {
-      //let's check for active features
-      if (activeFeatures.length === 0) {
-        return <DefaultAnalysisContent />;
-      } else {
-        return <BaseAnalysis />;
-      }
-    } else {
-      return null;
-    }
-  };
+  // const TabViewContent = (): JSX.Element | null => {
+  //   console.log('tabview is re-rendering!');
+  //   if (tabViewIsVisible) {
+  //     //let's check for active features
+  //     if (activeFeaturesLength === 0) {
+  //       return <DefaultAnalysisContent />;
+  //     } else {
+  //       return <BaseAnalysis />;
+  //     }
+  //   } else {
+  //     return null;
+  //   }
+  // };
 
-  return <TabViewContent />;
+  // return <TabViewContent />;
+  return (
+    <>
+      {tabViewIsVisible && activeFeaturesLength !== 0 && <BaseAnalysis />}
+      {tabViewIsVisible && activeFeaturesLength == 0 && (
+        <DefaultAnalysisContent />
+      )}
+    </>
+  );
 };
 
 export default AnalysisTabView;

--- a/src/js/components/leftPanel/analysisPanel/AnalysisTabView.tsx
+++ b/src/js/components/leftPanel/analysisPanel/AnalysisTabView.tsx
@@ -36,8 +36,8 @@ const AnalysisTabView = (props: TabProps): JSX.Element => {
   const tabViewVisible = useSelector(
     (store: RootState) => store.appState.leftPanel.activeTab
   );
-  const { selectedLanguage } = useSelector(
-    (store: RootState) => store.appState
+  const selectedLanguage = useSelector(
+    (store: RootState) => store.appState.selectedLanguage
   );
 
   const {

--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -10,7 +10,7 @@ import { registerGeometry } from 'js/helpers/geometryRegistration';
 import VegaChart from './VegaChartContainer';
 import analysisTranslations from './analysisTranslations';
 import 'css/leftpanel.scss';
-import { RangeSlider, MemoDatePicker } from './InputComponents';
+import { MemoRangeSlider, MemoDatePicker } from './InputComponents';
 import CanopyDensityPicker from 'js/components/sharedComponents/CanopyDensityPicker';
 import { markValueMap } from 'js/components/mapWidgets/widgetContent/CanopyDensityContent';
 
@@ -26,6 +26,7 @@ export interface UIParams {
   maxDate: string; //YYYY-MM-DD
   defaultStartDate: string; //YYYY-MM-DD
   defaultEndDate: string; //YYYY-MM-DD
+  bounds?: number[];
 }
 
 //Memo'd selectors
@@ -147,11 +148,21 @@ const BaseAnalysis = (): JSX.Element => {
     }
   }
 
-  const renderInputComponent = (props: UIParams): JSX.Element | null => {
-    const { multi, minDate, maxDate, defaultStartDate, defaultEndDate } = props;
+  const renderInputComponent = (
+    props: UIParams
+  ): JSX.Element | null | undefined => {
+    const {
+      multi,
+      minDate,
+      maxDate,
+      defaultStartDate,
+      defaultEndDate,
+      bounds
+    } = props;
     switch (props.inputType) {
       case 'rangeSlider':
-        return <RangeSlider />;
+        if (bounds) return <MemoRangeSlider yearRange={bounds} />;
+        break;
       case 'tcd':
         return <CanopyDensityPicker label={false} />;
       case 'datepicker':

--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -12,6 +12,8 @@ import { registerGeometry } from 'js/helpers/geometryRegistration';
 import VegaChart from './VegaChartContainer';
 import analysisTranslations from './analysisTranslations';
 import 'css/leftpanel.scss';
+import { DatePicker, RangeSlider } from './InputComponents';
+import CanopyDensityPicker from 'js/components/sharedComponents/CanopyDensityPicker';
 
 const AnalysisSpinner = (): React.ReactElement => (
   <h4>Geometry is Registering...</h4>
@@ -79,6 +81,18 @@ const BaseAnalysis = (): JSX.Element => {
     }
   }
 
+  type InputTypes = 'rangeSlider' | 'tcd' | 'datepicker';
+  const renderInputComponent = (type: InputTypes): JSX.Element | null => {
+    switch (type) {
+      case 'rangeSlider':
+        return <RangeSlider />;
+      case 'tcd':
+        return <CanopyDensityPicker label={false} />;
+      case 'datepicker':
+        return <DatePicker />;
+    }
+  };
+
   const AnalysisInstructions = (): JSX.Element | null => {
     const currentAnalysis = analysisModules.find(
       module => module.analysisId === selectedAnalysis
@@ -118,7 +132,9 @@ const BaseAnalysis = (): JSX.Element => {
                       </div>
                       <p>{uiParam.label[selectedLanguage]}</p>
                     </div>
-                    <p>{uiParam.inputType}</p>
+                    <div className="analysis-input">
+                      {renderInputComponent(uiParam.inputType)}
+                    </div>
                   </div>
                 );
               })}

--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -3,9 +3,6 @@
 import * as React from 'react';
 import { useState, useEffect } from 'react';
 import { createSelector } from 'reselect';
-
-import { mapController } from 'js/controllers/mapController';
-
 import { RootState } from 'js/store';
 import { useSelector, useDispatch } from 'react-redux';
 import { setActiveFeatures } from 'js/store/mapview/actions';

--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -15,6 +15,7 @@ import analysisTranslations from './analysisTranslations';
 import 'css/leftpanel.scss';
 import { RangeSlider, MemoDatePicker } from './InputComponents';
 import CanopyDensityPicker from 'js/components/sharedComponents/CanopyDensityPicker';
+import { markValueMap } from 'js/components/mapWidgets/widgetContent/CanopyDensityContent';
 
 type InputTypes = 'rangeSlider' | 'tcd' | 'datepicker';
 export interface UIParams {
@@ -52,10 +53,9 @@ const BaseAnalysis = (): JSX.Element => {
   const selectedLanguage = useSelector(
     (store: RootState) => store.appState.selectedLanguage
   );
-
-  // const { analysisModules } = useSelector(
-  //   (store: RootState) => store.appSettings
-  // );
+  const canopyDensity = useSelector(
+    (store: RootState) => store.appState.leftPanel.density
+  );
   const analysisModules = useSelector(selectAnalysisModules);
 
   //Default to the first analysis
@@ -102,11 +102,11 @@ const BaseAnalysis = (): JSX.Element => {
   ): string {
     let baseURL = 'https://api.resourcewatch.org/v1/widget/';
     //Add Widget ID
-    baseURL = baseURL.concat(widgetID);
+    baseURL = baseURL.concat(`${widgetID}?`);
     //Figure out if we have Date Range, Date Picker or Canopy Density Params that need appending
     for (const param of uiParams) {
       if (param.inputType === 'datepicker') {
-        let datePickerString = `?${param.startParamName}=`;
+        let datePickerString = `${param.startParamName}=`;
         if (param.combineParams) {
           const start = analysisDateRange[0];
           const end = analysisDateRange[1];
@@ -117,12 +117,15 @@ const BaseAnalysis = (): JSX.Element => {
         }
       } else if (param.inputType === 'rangeSlider') {
         //
-      } else if (param.inputType === 'tcd') console.log(param);
+      } else if (param.inputType === 'tcd') {
+        const threshold = `&thresh=${markValueMap[canopyDensity]}`;
+        baseURL = baseURL.concat(threshold);
+        //&thresh=20
+      }
     }
 
     //Add Geostore ID
     baseURL = baseURL.concat(`&geostore=${geostoreID}`);
-    console.log(baseURL);
     return baseURL;
   }
 

--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -53,8 +53,8 @@ const BaseAnalysis = (): JSX.Element => {
   const [startDate, setStartDate] = useState(getTodayDate());
   const [endDate, setEndDate] = useState(getTodayDate());
 
-  const { selectedLanguage } = useSelector(
-    (store: RootState) => store.appState
+  const selectedLanguage = useSelector(
+    (store: RootState) => store.appState.selectedLanguage
   );
 
   // const { analysisModules } = useSelector(

--- a/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
+++ b/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
@@ -1,55 +1,43 @@
 import * as React from 'react';
-import { UIParams } from './BaseAnalysis';
+import { setAnalysisDateRange } from 'js/store/appState/actions';
+import { useDispatch } from 'react-redux';
+
 interface DatePickerProps {
-  startParamName: string;
-  combineParams: boolean;
-  endParamName?: string;
-  valueSeparator?: string;
   multi?: boolean;
   minDate: string; //YYYY-MM-DD
   maxDate: string; //YYYY-MM-DD
-  defaultStartDate: string; //YYYY-MM-DD
-  defaultEndDate: string; //YYYY-MM-DD
 }
-
-const getTodayDate = (): string => {
-  const getTodayDate = new Date().toISOString().split('T')[0];
-  return getTodayDate;
-};
 
 interface CallbackProp {
-  sendDate: (date: string, period: 'start' | 'end') => void;
+  sendDate?: (date: string, type: 'start' | 'end') => void;
 }
+const getTodayDate = new Date().toISOString().split('T')[0];
 
-export const DatePicker = (props: UIParams & CallbackProp): JSX.Element => {
-  console.log(props);
-  const {
-    startParamName,
-    combineParams,
-    endParamName,
-    valueSeparator,
-    multi,
-    minDate,
-    maxDate,
-    defaultStartDate,
-    defaultEndDate
-  } = props;
-  const [startDate, setStartDate] = React.useState(
-    defaultStartDate ? defaultStartDate : getTodayDate()
-  );
-  const [endDate, setEndDate] = React.useState(
-    defaultEndDate ? defaultEndDate : getTodayDate()
-  );
+const DatePicker = (props: DatePickerProps): JSX.Element => {
+  const dispatch = useDispatch();
+  const { multi, minDate, maxDate } = props;
+
+  const [startDate, setStartDate] = React.useState(getTodayDate);
+
+  const [endDate, setEndDate] = React.useState(getTodayDate);
   function handleStartDateChange(e: any): void {
     setStartDate(e.target.value);
-    props.sendDate(e.target.value, 'start');
-    console.log(e.target.value);
+    // dispatch(setAnalysisDateRange([startDate, endDate]));
+    // props.sendDate(startDate, endDate);
+    // props.sendDate(e.target.value, 'start');
   }
 
   function handleEndDateChange(e: any): void {
     setEndDate(e.target.value);
-    props.sendDate(e.target.value, 'end');
+    // dispatch(setAnalysisDateRange([startDate, endDate]));
+    // props.sendDate(startDate, endDate);
+    // props.sendDate(e.target.value, 'end');
   }
+
+  // React.useEffect(() => {
+  //   console.log('synccccccccccccc');
+  //   props.sendDate(startDate, endDate);
+  // }, [startDate, endDate]);
 
   return (
     <div className="calendar-wrapper">
@@ -58,8 +46,10 @@ export const DatePicker = (props: UIParams & CallbackProp): JSX.Element => {
         <input
           className="date-time-toggle input"
           type="date"
-          value={startDate}
+          defaultValue={startDate}
+          // value={props.startDate}
           min={minDate ? minDate : undefined}
+          // onChange={handleStartDateChange}
           onChange={handleStartDateChange}
         />
       </div>
@@ -78,6 +68,8 @@ export const DatePicker = (props: UIParams & CallbackProp): JSX.Element => {
     </div>
   );
 };
+
+export const MemoDatePicker = React.memo(DatePicker);
 
 export const RangeSlider = (): JSX.Element => {
   return <p>Range Slider</p>;

--- a/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
+++ b/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
@@ -6,38 +6,37 @@ interface DatePickerProps {
   multi?: boolean;
   minDate: string; //YYYY-MM-DD
   maxDate: string; //YYYY-MM-DD
-}
-
-interface CallbackProp {
-  sendDate?: (date: string, type: 'start' | 'end') => void;
+  defaultStartDate?: string;
+  defaultEndDate?: string;
 }
 const getTodayDate = new Date().toISOString().split('T')[0];
 
 const DatePicker = (props: DatePickerProps): JSX.Element => {
   const dispatch = useDispatch();
-  const { multi, minDate, maxDate } = props;
+  const { multi, minDate, maxDate, defaultEndDate, defaultStartDate } = props;
 
-  const [startDate, setStartDate] = React.useState(getTodayDate);
+  const [startDate, setStartDate] = React.useState(
+    defaultStartDate ? defaultStartDate : getTodayDate
+  );
 
-  const [endDate, setEndDate] = React.useState(getTodayDate);
+  const [endDate, setEndDate] = React.useState(
+    defaultEndDate ? defaultEndDate : getTodayDate
+  );
+
   function handleStartDateChange(e: any): void {
     setStartDate(e.target.value);
-    // dispatch(setAnalysisDateRange([startDate, endDate]));
-    // props.sendDate(startDate, endDate);
-    // props.sendDate(e.target.value, 'start');
+    dispatch(setAnalysisDateRange([startDate, endDate]));
   }
 
   function handleEndDateChange(e: any): void {
     setEndDate(e.target.value);
-    // dispatch(setAnalysisDateRange([startDate, endDate]));
-    // props.sendDate(startDate, endDate);
-    // props.sendDate(e.target.value, 'end');
+    dispatch(setAnalysisDateRange([startDate, endDate]));
   }
 
-  // React.useEffect(() => {
-  //   console.log('synccccccccccccc');
-  //   props.sendDate(startDate, endDate);
-  // }, [startDate, endDate]);
+  //Sync at the start too
+  React.useEffect(() => {
+    dispatch(setAnalysisDateRange([startDate, endDate]));
+  }, []);
 
   return (
     <div className="calendar-wrapper">
@@ -47,9 +46,7 @@ const DatePicker = (props: DatePickerProps): JSX.Element => {
           className="date-time-toggle input"
           type="date"
           defaultValue={startDate}
-          // value={props.startDate}
           min={minDate ? minDate : undefined}
-          // onChange={handleStartDateChange}
           onChange={handleStartDateChange}
         />
       </div>

--- a/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
+++ b/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { UIParams } from './BaseAnalysis';
+interface DatePickerProps {
+  startParamName: string;
+  combineParams: boolean;
+  endParamName?: string;
+  valueSeparator?: string;
+  multi?: boolean;
+  minDate: string; //YYYY-MM-DD
+  maxDate: string; //YYYY-MM-DD
+  defaultStartDate: string; //YYYY-MM-DD
+  defaultEndDate: string; //YYYY-MM-DD
+}
+
+const getTodayDate = (): string => {
+  const getTodayDate = new Date().toISOString().split('T')[0];
+  return getTodayDate;
+};
+
+interface CallbackProp {
+  sendDate: (date: string, period: 'start' | 'end') => void;
+}
+
+export const DatePicker = (props: UIParams & CallbackProp): JSX.Element => {
+  console.log(props);
+  const {
+    startParamName,
+    combineParams,
+    endParamName,
+    valueSeparator,
+    multi,
+    minDate,
+    maxDate,
+    defaultStartDate,
+    defaultEndDate
+  } = props;
+  const [startDate, setStartDate] = React.useState(
+    defaultStartDate ? defaultStartDate : getTodayDate()
+  );
+  const [endDate, setEndDate] = React.useState(
+    defaultEndDate ? defaultEndDate : getTodayDate()
+  );
+  function handleStartDateChange(e: any): void {
+    setStartDate(e.target.value);
+    props.sendDate(e.target.value, 'start');
+    console.log(e.target.value);
+  }
+
+  function handleEndDateChange(e: any): void {
+    setEndDate(e.target.value);
+    props.sendDate(e.target.value, 'end');
+  }
+
+  return (
+    <div className="calendar-wrapper">
+      <div className="date-section-wrapper">
+        <label htmlFor="start-date">Start:</label>
+        <input
+          className="date-time-toggle input"
+          type="date"
+          value={startDate}
+          min={minDate ? minDate : undefined}
+          onChange={handleStartDateChange}
+        />
+      </div>
+      {multi && (
+        <div className="date-section-wrapper">
+          <label htmlFor="end-date">End:</label>
+          <input
+            className="date-time-toggle input"
+            type="date"
+            value={endDate}
+            max={maxDate ? maxDate : undefined}
+            onChange={handleEndDateChange}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const RangeSlider = (): JSX.Element => {
+  return <p>Range Slider</p>;
+};

--- a/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
+++ b/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
-import { setAnalysisDateRange } from 'js/store/appState/actions';
+import {
+  setAnalysisDateRange,
+  setAnalysisYearRange
+} from 'js/store/appState/actions';
 import { useDispatch } from 'react-redux';
-import { createSliderWithTooltip, Range, Marks } from 'rc-slider';
+import { createSliderWithTooltip, Range } from 'rc-slider';
 const SliderWithTooltip = createSliderWithTooltip(Range);
 
 interface DatePickerProps {
@@ -74,7 +77,6 @@ function generateMarks(range: number[]): any[] | {} {
   const marksObject = {};
   for (let i = range[0]; i <= range[1]; i++) {
     if (i === range[0] || i === range[1]) {
-      console.log('truth');
       marksObject[i] = { label: String(i), style: {} };
     } else {
       marksObject[i] = { label: String(i), style: { display: 'none' } };
@@ -90,23 +92,22 @@ const RangeSlider = (props: RangeSliderProps): JSX.Element => {
   //Sync at the start too
   const dispatch = useDispatch();
 
-  const [yearRange, setYearRange] = React.useState<number[]>(props.yearRange);
   const [activeYearRange, setActiveYearRange] = React.useState<number[]>(
     props.yearRange
   );
 
-  // React.useEffect(() => {
-  //   dispatch(setAnalysisYearRange(activeYearRange));
-  // }, []);
+  React.useEffect(() => {
+    dispatch(setAnalysisYearRange(activeYearRange));
+  }, []);
 
   function handleSliderRange(val: number[]): void {
     setActiveYearRange(val);
-    console.log(val);
+    dispatch(setAnalysisYearRange(val));
   }
 
-  const marks: any = React.useCallback(() => {
-    return generateMarks(props.yearRange);
-  }, [props.yearRange]);
+  const marks: any = React.useMemo(() => generateMarks(props.yearRange), [
+    props.yearRange
+  ]);
 
   return (
     <div className="time-slider-container">

--- a/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
+++ b/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
@@ -68,6 +68,114 @@ const DatePicker = (props: DatePickerProps): JSX.Element => {
 
 export const MemoDatePicker = React.memo(DatePicker);
 
+import { createSliderWithTooltip, Range } from 'rc-slider';
+const SliderWithTooltip = createSliderWithTooltip(Range);
+
 export const RangeSlider = (): JSX.Element => {
-  return <p>Range Slider</p>;
+  const defaultMarks = {
+    '2000': {
+      label: '2000',
+      style: {}
+    },
+    '2001': {
+      label: '2001',
+      style: { display: 'none' }
+    },
+    '2002': {
+      label: '2002',
+      style: { display: 'none' }
+    },
+    '2003': {
+      label: '2003',
+      style: {}
+    },
+    '2004': {
+      label: '2004',
+      style: { display: 'none' }
+    },
+    '2005': {
+      label: '2005',
+      style: { display: 'none' }
+    },
+    '2006': {
+      label: '2006',
+      style: {}
+    },
+    '2007': {
+      label: '2007',
+      style: { display: 'none' }
+    },
+    '2008': {
+      label: '2008',
+      style: { display: 'none' }
+    },
+    '2009': {
+      label: '2009',
+      style: {}
+    },
+    '2010': {
+      label: '2010',
+      style: { display: 'none' }
+    },
+    '2011': {
+      label: '2011',
+      style: { display: 'none' }
+    },
+    '2012': {
+      label: '2012',
+      style: {}
+    },
+    '2013': {
+      label: '2013',
+      style: { display: 'none' }
+    },
+    '2014': {
+      label: '2014',
+      style: { display: 'none' }
+    },
+    '2015': {
+      label: '2015',
+      style: {}
+    },
+    '2016': {
+      label: '2016',
+      style: { display: 'none' }
+    },
+    '2017': {
+      label: '2017',
+      style: { display: 'none' }
+    },
+    '2018': {
+      label: '2018',
+      style: {}
+    }
+  };
+  const [range, setRange] = React.useState([2000, 2018]);
+
+  function handleSliderRange(val: any) {
+    console.log(val);
+  }
+
+  return (
+    <div className="time-slider-container">
+      <SliderWithTooltip
+        min={2000}
+        max={2018}
+        defaultValue={[2000, 2018]}
+        value={range}
+        allowCross={false}
+        tipFormatter={(val: number): number => val}
+        dots={true}
+        marks={defaultMarks}
+        railStyle={{ backgroundColor: 'rgb(233, 233, 233)' }}
+        handleStyle={[{ borderColor: 'rgb(240, 171, 0)' }]}
+        dotStyle={{ border: '1px solid #e9e9e9' }}
+        activeDotStyle={{
+          border: '1px solid #F0AB00'
+        }}
+        trackStyle={[{ backgroundColor: 'rgb(240, 171, 0)' }]}
+        onChange={(value: Array<number>): void => handleSliderRange(value)}
+      />
+    </div>
+  );
 };

--- a/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
+++ b/src/js/components/leftPanel/analysisPanel/InputComponents.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { setAnalysisDateRange } from 'js/store/appState/actions';
 import { useDispatch } from 'react-redux';
+import { createSliderWithTooltip, Range, Marks } from 'rc-slider';
+const SliderWithTooltip = createSliderWithTooltip(Range);
 
 interface DatePickerProps {
   multi?: boolean;
@@ -68,105 +70,55 @@ const DatePicker = (props: DatePickerProps): JSX.Element => {
 
 export const MemoDatePicker = React.memo(DatePicker);
 
-import { createSliderWithTooltip, Range } from 'rc-slider';
-const SliderWithTooltip = createSliderWithTooltip(Range);
-
-export const RangeSlider = (): JSX.Element => {
-  const defaultMarks = {
-    '2000': {
-      label: '2000',
-      style: {}
-    },
-    '2001': {
-      label: '2001',
-      style: { display: 'none' }
-    },
-    '2002': {
-      label: '2002',
-      style: { display: 'none' }
-    },
-    '2003': {
-      label: '2003',
-      style: {}
-    },
-    '2004': {
-      label: '2004',
-      style: { display: 'none' }
-    },
-    '2005': {
-      label: '2005',
-      style: { display: 'none' }
-    },
-    '2006': {
-      label: '2006',
-      style: {}
-    },
-    '2007': {
-      label: '2007',
-      style: { display: 'none' }
-    },
-    '2008': {
-      label: '2008',
-      style: { display: 'none' }
-    },
-    '2009': {
-      label: '2009',
-      style: {}
-    },
-    '2010': {
-      label: '2010',
-      style: { display: 'none' }
-    },
-    '2011': {
-      label: '2011',
-      style: { display: 'none' }
-    },
-    '2012': {
-      label: '2012',
-      style: {}
-    },
-    '2013': {
-      label: '2013',
-      style: { display: 'none' }
-    },
-    '2014': {
-      label: '2014',
-      style: { display: 'none' }
-    },
-    '2015': {
-      label: '2015',
-      style: {}
-    },
-    '2016': {
-      label: '2016',
-      style: { display: 'none' }
-    },
-    '2017': {
-      label: '2017',
-      style: { display: 'none' }
-    },
-    '2018': {
-      label: '2018',
-      style: {}
+function generateMarks(range: number[]): any[] | {} {
+  const marksObject = {};
+  for (let i = range[0]; i <= range[1]; i++) {
+    if (i === range[0] || i === range[1]) {
+      console.log('truth');
+      marksObject[i] = { label: String(i), style: {} };
+    } else {
+      marksObject[i] = { label: String(i), style: { display: 'none' } };
     }
-  };
-  const [range, setRange] = React.useState([2000, 2018]);
+  }
+  return marksObject;
+}
 
-  function handleSliderRange(val: any) {
+interface RangeSliderProps {
+  yearRange: number[];
+}
+const RangeSlider = (props: RangeSliderProps): JSX.Element => {
+  //Sync at the start too
+  const dispatch = useDispatch();
+
+  const [yearRange, setYearRange] = React.useState<number[]>(props.yearRange);
+  const [activeYearRange, setActiveYearRange] = React.useState<number[]>(
+    props.yearRange
+  );
+
+  // React.useEffect(() => {
+  //   dispatch(setAnalysisYearRange(activeYearRange));
+  // }, []);
+
+  function handleSliderRange(val: number[]): void {
+    setActiveYearRange(val);
     console.log(val);
   }
+
+  const marks: any = React.useCallback(() => {
+    return generateMarks(props.yearRange);
+  }, [props.yearRange]);
 
   return (
     <div className="time-slider-container">
       <SliderWithTooltip
-        min={2000}
-        max={2018}
-        defaultValue={[2000, 2018]}
-        value={range}
+        min={props.yearRange[0]}
+        max={props.yearRange[1]}
+        defaultValue={[props.yearRange[0], props.yearRange[1]]}
+        value={activeYearRange}
         allowCross={false}
         tipFormatter={(val: number): number => val}
         dots={true}
-        marks={defaultMarks}
+        marks={marks}
         railStyle={{ backgroundColor: 'rgb(233, 233, 233)' }}
         handleStyle={[{ borderColor: 'rgb(240, 171, 0)' }]}
         dotStyle={{ border: '1px solid #e9e9e9' }}
@@ -179,3 +131,5 @@ export const RangeSlider = (): JSX.Element => {
     </div>
   );
 };
+
+export const MemoRangeSlider = React.memo(RangeSlider);

--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -18,12 +18,17 @@ interface DataTabProps {
 }
 const DataTabView = (props: DataTabProps): JSX.Element => {
   const dispatch = useDispatch();
-  const { activeTab, tabViewVisible } = useSelector(
-    (store: RootState) => store.appState.leftPanel
+  const activeTab = useSelector(
+    (store: RootState) => store.appState.leftPanel.activeTab
   );
-
-  const { activeFeatures, activeFeatureIndex } = useSelector(
-    (store: RootState) => store.mapviewState
+  const tabViewVisible = useSelector(
+    (store: RootState) => store.appState.leftPanel.tabViewVisible
+  );
+  const activeFeatures = useSelector(
+    (store: RootState) => store.mapviewState.activeFeatures
+  );
+  const activeFeatureIndex = useSelector(
+    (store: RootState) => store.mapviewState.activeFeatureIndex
   );
 
   const FeatureDataView = (): JSX.Element => {

--- a/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
+++ b/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
@@ -104,7 +104,7 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
         </div>
       </div>
       {layer?.visible && returnTimeSlider(props.id)}
-      {layer?.visible && densityPicker && <CanopyDensityPicker />}
+      {layer?.visible && densityPicker && <CanopyDensityPicker label={true} />}
       {layer?.visible && (
         <LayerTransparencySlider
           layerID={props.id}

--- a/src/js/components/sharedComponents/CanopyDensityPicker.tsx
+++ b/src/js/components/sharedComponents/CanopyDensityPicker.tsx
@@ -6,7 +6,11 @@ import { markValueMap } from 'js/components/mapWidgets/widgetContent/CanopyDensi
 
 //TODO: Language awareness
 //
-const CanopyDensityPicker = (): JSX.Element => {
+interface CanopyDensityPickerProps {
+  label: boolean;
+}
+
+const CanopyDensityPicker = (props: CanopyDensityPickerProps): JSX.Element => {
   const dispatch = useDispatch();
   const { density } = useSelector(
     (store: RootState) => store.appState.leftPanel
@@ -19,7 +23,7 @@ const CanopyDensityPicker = (): JSX.Element => {
   return (
     <>
       <div>
-        <span>Change canopy density</span>
+        {props.label && <span>Change canopy density</span>}
         <button
           className="canopy-density-picker"
           onClick={handleDensityButtonClick}

--- a/src/js/store/appSettings/reducers.ts
+++ b/src/js/store/appSettings/reducers.ts
@@ -38,7 +38,8 @@ const initialState: AppSettings = {
       useGfwWidget: false,
       chartType: '',
       uiParams: [],
-      widgetId: ''
+      widgetId: '',
+      params: []
     }
   ]
 };

--- a/src/js/store/appSettings/types.ts
+++ b/src/js/store/appSettings/types.ts
@@ -42,6 +42,7 @@ interface AnalysisModule {
   useGfwWidget: boolean;
   widgetId: string;
   uiParams: any;
+  params: { name: string; value: string }[];
 }
 
 export interface LayerGroupInfo {

--- a/src/js/store/appState/actions.ts
+++ b/src/js/store/appState/actions.ts
@@ -13,7 +13,8 @@ import {
   SET_MEASURE_RESULTS,
   SET_ACTIVE_MEASURE_BUTTON,
   SET_CANOPY_DENSITY,
-  SET_ANALYSIS_DATE
+  SET_ANALYSIS_DATE,
+  SET_ANALYSIS_YEAR_RANGE
 } from './types';
 
 export function toggleTabviewPanel(payload: LeftPanel['tabViewVisible']) {
@@ -107,6 +108,15 @@ export function setAnalysisDateRange(
 ) {
   return {
     type: SET_ANALYSIS_DATE as typeof SET_ANALYSIS_DATE,
+    payload: payload
+  };
+}
+
+export function setAnalysisYearRange(
+  payload: AppState['leftPanel']['analysisYearRange']
+) {
+  return {
+    type: SET_ANALYSIS_YEAR_RANGE as typeof SET_ANALYSIS_YEAR_RANGE,
     payload: payload
   };
 }

--- a/src/js/store/appState/actions.ts
+++ b/src/js/store/appState/actions.ts
@@ -12,7 +12,8 @@ import {
   LeftPanel,
   SET_MEASURE_RESULTS,
   SET_ACTIVE_MEASURE_BUTTON,
-  SET_CANOPY_DENSITY
+  SET_CANOPY_DENSITY,
+  SET_ANALYSIS_DATE
 } from './types';
 
 export function toggleTabviewPanel(payload: LeftPanel['tabViewVisible']) {
@@ -97,6 +98,15 @@ export function setActiveMeasureButton(
 ) {
   return {
     type: SET_ACTIVE_MEASURE_BUTTON as typeof SET_ACTIVE_MEASURE_BUTTON,
+    payload: payload
+  };
+}
+
+export function setAnalysisDateRange(
+  payload: AppState['leftPanel']['analysisDateRange']
+) {
+  return {
+    type: SET_ANALYSIS_DATE as typeof SET_ANALYSIS_DATE,
     payload: payload
   };
 }

--- a/src/js/store/appState/reducers.ts
+++ b/src/js/store/appState/reducers.ts
@@ -13,7 +13,8 @@ import {
   SET_ACTIVE_MEASURE_BUTTON,
   SET_HIDE_WIDGET,
   SET_CANOPY_DENSITY,
-  SET_ANALYSIS_DATE
+  SET_ANALYSIS_DATE,
+  SET_ANALYSIS_YEAR_RANGE
 } from './types';
 
 const initialState: AppState = {
@@ -28,7 +29,8 @@ const initialState: AppState = {
     activeTab: 'layers',
     openLayerGroup: 'GROUP_WEBMAP',
     density: 5,
-    analysisDateRange: ['', '']
+    analysisDateRange: ['', ''],
+    analysisYearRange: [2001, 2018]
   },
   measureContent: {
     activeButton: '',
@@ -112,6 +114,14 @@ export function appStateReducer(
         leftPanel: {
           ...state.leftPanel,
           analysisDateRange: action.payload
+        }
+      };
+    case SET_ANALYSIS_YEAR_RANGE:
+      return {
+        ...state,
+        leftPanel: {
+          ...state.leftPanel,
+          analysisYearRange: action.payload
         }
       };
     default:

--- a/src/js/store/appState/reducers.ts
+++ b/src/js/store/appState/reducers.ts
@@ -12,7 +12,8 @@ import {
   SET_MEASURE_RESULTS,
   SET_ACTIVE_MEASURE_BUTTON,
   SET_HIDE_WIDGET,
-  SET_CANOPY_DENSITY
+  SET_CANOPY_DENSITY,
+  SET_ANALYSIS_DATE
 } from './types';
 
 const initialState: AppState = {
@@ -26,7 +27,8 @@ const initialState: AppState = {
     tabViewVisible: true,
     activeTab: 'layers',
     openLayerGroup: 'GROUP_WEBMAP',
-    density: 5
+    density: 5,
+    analysisDateRange: ['', '']
   },
   measureContent: {
     activeButton: '',
@@ -102,6 +104,14 @@ export function appStateReducer(
         ...state,
         measureContent: {
           ...action.payload
+        }
+      };
+    case SET_ANALYSIS_DATE:
+      return {
+        ...state,
+        leftPanel: {
+          ...state.leftPanel,
+          analysisDateRange: action.payload
         }
       };
     default:

--- a/src/js/store/appState/types.ts
+++ b/src/js/store/appState/types.ts
@@ -4,6 +4,7 @@ export interface LeftPanel {
   openLayerGroup: string;
   density: 1 | 2 | 3 | 4 | 5 | 6 | 7 | number; //careful about introducing any more density numbers, AG_BIOMASS layer depends on those to render and update
   analysisDateRange: string[];
+  analysisYearRange: number[];
 }
 
 interface SpecificAreaResults {
@@ -53,6 +54,7 @@ export const SET_ACTIVE_MEASURE_BUTTON = 'SET_ACTIVE_MEASURE_BUTTON';
 export const SET_HIDE_WIDGET = 'SET_HIDE_WIDGET';
 export const SET_CANOPY_DENSITY = 'SET_CANOPY_DENSITY';
 export const SET_ANALYSIS_DATE = 'SET_ANALYSIS_DATE';
+export const SET_ANALYSIS_YEAR_RANGE = 'SET_ANALYSIS_YEAR_RANGE';
 
 interface SetOpenLayerGroup {
   type: typeof SET_OPEN_LAYER_GROUP;
@@ -119,6 +121,11 @@ interface SetAnalysisDate {
   payload: AppState['leftPanel']['analysisDateRange'];
 }
 
+interface SetAnalysisYearRange {
+  type: typeof SET_ANALYSIS_YEAR_RANGE;
+  payload: AppState['leftPanel']['analysisYearRange'];
+}
+
 export type AppStateTypes =
   | ToggleTabviewPanelAction
   | RenderModalAction
@@ -132,4 +139,5 @@ export type AppStateTypes =
   | SetActiveMeasureButton
   | SetHideWidget
   | SetCanopyDensity
-  | SetAnalysisDate;
+  | SetAnalysisDate
+  | SetAnalysisYearRange;

--- a/src/js/store/appState/types.ts
+++ b/src/js/store/appState/types.ts
@@ -1,10 +1,9 @@
-// import Point from 'esri/geometry/Point';
-
 export interface LeftPanel {
   tabViewVisible: boolean;
   activeTab: string;
   openLayerGroup: string;
   density: 1 | 2 | 3 | 4 | 5 | 6 | 7 | number; //careful about introducing any more density numbers, AG_BIOMASS layer depends on those to render and update
+  analysisDateRange: string[];
 }
 
 interface SpecificAreaResults {
@@ -53,6 +52,7 @@ export const SET_MEASURE_RESULTS = 'SET_MEASURE_RESULTS';
 export const SET_ACTIVE_MEASURE_BUTTON = 'SET_ACTIVE_MEASURE_BUTTON';
 export const SET_HIDE_WIDGET = 'SET_HIDE_WIDGET';
 export const SET_CANOPY_DENSITY = 'SET_CANOPY_DENSITY';
+export const SET_ANALYSIS_DATE = 'SET_ANALYSIS_DATE';
 
 interface SetOpenLayerGroup {
   type: typeof SET_OPEN_LAYER_GROUP;
@@ -114,6 +114,11 @@ interface SetActiveMeasureButton {
   payload: AppState['measureContent']['activeButton'];
 }
 
+interface SetAnalysisDate {
+  type: typeof SET_ANALYSIS_DATE;
+  payload: AppState['leftPanel']['analysisDateRange'];
+}
+
 export type AppStateTypes =
   | ToggleTabviewPanelAction
   | RenderModalAction
@@ -126,4 +131,5 @@ export type AppStateTypes =
   | SetMeasureResults
   | SetActiveMeasureButton
   | SetHideWidget
-  | SetCanopyDensity;
+  | SetCanopyDensity
+  | SetAnalysisDate;


### PR DESCRIPTION
Partial Fix #863 

- Add `reselect` library to utilize memoization for complicated Redux selectors
- Refactor selectors to prevent re-rendering in Header, Leftpanel, Analysis, Data Tab components
- Add uiParams for Analysis Tab: Date Picker, Year Slider, Canopy Density
- Add logic to generate unique URL based on uiParams that we use to fetch vega chart information