### PR TITLE
Add MASK layer config loading

### DIFF
--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -323,19 +323,7 @@ export class MapController {
             }
           });
 
-          // Adding MASK Layer, which dims the area that is not the country ISO code based on Config ,separate from the flow as it comes in the config as 'extraLayers' array element, not following previous layer object specs
-          const { layerPanel } = appSettings;
-          const maskLayer = layerPanel['extraLayers'].find(
-            (l: any) => l.id === 'MASK'
-          );
-          if (maskLayer) {
-            maskLayer.type = 'MASK';
-            const esriMaskLayer = LayerFactory(this._mapview, maskLayer);
-            if (esriMaskLayer && this._map) {
-              this._map.add(esriMaskLayer);
-            }
-          }
-
+          this.addMaskLayer();
           this.initializeAndSetSketch();
         },
         (error: Error) => {
@@ -507,18 +495,7 @@ export class MapController {
         this._map
       );
 
-      // Adding MASK Layer, which dims the area that is not the country ISO code based on Config ,separate from the flow as it comes in the config as 'extraLayers' array element, not following previous layer object specs
-      const { layerPanel } = appSettings;
-      const maskLayer = layerPanel['extraLayers'].find(
-        (l: any) => l.id === 'MASK'
-      );
-      if (maskLayer) {
-        maskLayer.type = 'MASK';
-        const esriMaskLayer = LayerFactory(this._mapview, maskLayer);
-        if (esriMaskLayer && this._map) {
-          this._map.add(esriMaskLayer);
-        }
-      }
+      this.addMaskLayer();
 
       //Reorder layers on the map!
       this._map?.layers.forEach((layer: any) => {
@@ -532,6 +509,22 @@ export class MapController {
 
   log(): void {
     console.log(this._map?.basemap);
+  }
+
+  // Adding MASK Layer, which dims the area that is not the country ISO code based on Config ,separate from the flow as it comes in the config as 'extraLayers' array element, not following previous layer object specs
+  addMaskLayer(): void {
+    const appSettings = store.getState().appSettings;
+    const { layerPanel } = appSettings;
+    const maskLayer = layerPanel['extraLayers'].find(
+      (l: any) => l.id === 'MASK'
+    );
+    if (maskLayer) {
+      maskLayer.type = 'MASK';
+      const esriMaskLayer = LayerFactory(this._mapview, maskLayer);
+      if (esriMaskLayer && this._map) {
+        this._map.add(esriMaskLayer);
+      }
+    }
   }
 
   zoomInOrOut({ zoomIn }: ZoomParams): void {

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -323,6 +323,19 @@ export class MapController {
             }
           });
 
+          // Adding MASK Layer, which dims the area that is not the country ISO code based on Config ,separate from the flow as it comes in the config as 'extraLayers' array element, not following previous layer object specs
+          const { layerPanel } = appSettings;
+          const maskLayer = layerPanel['extraLayers'].find(
+            (l: any) => l.id === 'MASK'
+          );
+          if (maskLayer) {
+            maskLayer.type = 'MASK';
+            const esriMaskLayer = LayerFactory(this._mapview, maskLayer);
+            if (esriMaskLayer && this._map) {
+              this._map.add(esriMaskLayer);
+            }
+          }
+
           this.initializeAndSetSketch();
         },
         (error: Error) => {
@@ -493,6 +506,20 @@ export class MapController {
         allLayerObjects,
         this._map
       );
+
+      // Adding MASK Layer, which dims the area that is not the country ISO code based on Config ,separate from the flow as it comes in the config as 'extraLayers' array element, not following previous layer object specs
+      const { layerPanel } = appSettings;
+      const maskLayer = layerPanel['extraLayers'].find(
+        (l: any) => l.id === 'MASK'
+      );
+      if (maskLayer) {
+        maskLayer.type = 'MASK';
+        const esriMaskLayer = LayerFactory(this._mapview, maskLayer);
+        if (esriMaskLayer && this._map) {
+          this._map.add(esriMaskLayer);
+        }
+      }
+
       //Reorder layers on the map!
       this._map?.layers.forEach((layer: any) => {
         const layerIndex = mapLayerIDs?.findIndex(i => i === layer.id);

--- a/src/js/helpers/LayerFactory.ts
+++ b/src/js/helpers/LayerFactory.ts
@@ -20,6 +20,8 @@ interface LayerOptions {
   visible: boolean;
   url: string;
   sublayers?: { id: number; visible: boolean }[];
+  opacity?: number;
+  definitionExpression?: string;
 }
 
 export function LayerFactory(mapView: any, layerConfig: LayerProps): Layer {
@@ -119,6 +121,23 @@ export function LayerFactory(mapView: any, layerConfig: LayerProps): Layer {
         urlTemplate: layerConfig.url,
         view: mapView
       });
+      break;
+    case 'MASK':
+      const { appSettings } = store.getState();
+      const countryISOCode = appSettings?.iso;
+      const maskDefExp = `code_iso3 <> '${countryISOCode}'`;
+      const maskLayerOptions: LayerOptions = {
+        id: layerConfig.id,
+        visible: true,
+        url: layerConfig.url,
+        opacity: layerConfig.opacity
+      };
+      if (layerConfig.layerIds) {
+        maskLayerOptions.sublayers = layerConfig.layerIds.map(id => {
+          return { id: id, visible: true, definitionExpression: maskDefExp };
+        });
+      }
+      esriLayer = new MapImageLayer(maskLayerOptions);
       break;
     default:
       console.error('No error type!');

--- a/src/js/helpers/dataPanel/DataPanel.ts
+++ b/src/js/helpers/dataPanel/DataPanel.ts
@@ -180,7 +180,8 @@ export async function queryLayersForFeatures(
         l.visible &&
         l.type !== 'graphics' &&
         l.type !== 'base-tile' &&
-        l.type !== 'imagery'
+        l.type !== 'imagery' &&
+        l.id !== 'MASK'
     )
     .filter((l: any) => layerIsInScale(l, mapview.scale))
     .toArray();

--- a/src/js/store/appSettings/reducers.ts
+++ b/src/js/store/appSettings/reducers.ts
@@ -13,6 +13,7 @@ const initialState: AppSettings = {
   printServiceUrl:
     'https://gis.forest-atlas.org/server/rest/services/print/ExportWebMap/GPServer/Export%20Web%20Map',
   language: 'en',
+  iso: '',
   layerPanel: {
     GROUP_WEBMAP: {},
     GROUP_BASEMAP: {},

--- a/src/js/store/appSettings/types.ts
+++ b/src/js/store/appSettings/types.ts
@@ -16,6 +16,7 @@ export interface AppSettings {
   alternativeNarrative: string;
   analysisModules: AnalysisModule[];
   alternativeLanguageTitle: string;
+  iso: string;
 }
 
 type LayerGroupKey =


### PR DESCRIPTION
Partial for #956

Adding ISO reading from config and mask layer reading. Users must define mask layers in 'extraLayers' group with the id of 'MASK' for this to work.