### PR TITLE
Adding a timeout logic for legend info

### DIFF
--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -234,12 +234,9 @@ export class MapController {
               //dealing with resouces (config file) layers
 
               //TODO: This fetches legend info from mapservice, but not all layers in the config may be that. we need to figure out other types too
-              let legendInfoObject;
-              try {
-                legendInfoObject = await fetchLegendInfo(remoteLayerObject.url);
-              } catch (e) {
-                console.error('Error fetching Legend Info', e);
-              }
+              const legendInfoObject = await fetchLegendInfo(
+                remoteLayerObject.url
+              );
               const layerLegendInfo =
                 legendInfoObject &&
                 legendInfoObject?.layers.filter((l: any) =>

--- a/src/js/helpers/legendInfo.ts
+++ b/src/js/helpers/legendInfo.ts
@@ -1,8 +1,16 @@
-//Helper that fetches legend information from mapserver
-export async function fetchLegendInfo(layerUrl: string): Promise<any> {
-  const legendRes = await fetch(`${layerUrl}/legend?f=pjson`)
-    .then(result => result.json())
-    .then(data => data)
-    .catch(e => console.log(e));
-  return legendRes;
+export function fetchLegendInfo(layerUrl: string): any {
+  const timeout = new Promise((resolve, reject) => {
+    setTimeout(reject, 500, 'Legend info request time out');
+  });
+
+  const fetchLegendInfo = new Promise((resolve, reject) => {
+    fetch(`${layerUrl}/legend?f=pjson`)
+      .then(result => result.json())
+      .then(data => resolve(data))
+      .catch(reject);
+  });
+
+  return Promise.race([timeout, fetchLegendInfo])
+    .then(legendInfoJSON => legendInfoJSON)
+    .catch(e => console.error(e));
 }


### PR DESCRIPTION
Fixing a bug where some layer services would timeout after a long time in order to fetch legend information slowing down the application. Adding timeouts to fetch legend helper.