### PR TITLE
Report crash bug fix - graphics layers

### DIFF
--- a/src/js/helpers/MapGraphics.ts
+++ b/src/js/helpers/MapGraphics.ts
@@ -12,10 +12,6 @@ import { getCustomSymbol, getPointSymbol } from 'js/helpers/generateSymbol';
 
 import { FeatureResult } from 'js/store/mapview/types';
 
-import store from 'js/store/index';
-
-import { setActiveFeatures } from 'js/store/mapview/actions';
-
 const setSymbol = (symbolType: string): any => {
   switch (symbolType) {
     case 'polygon':
@@ -81,6 +77,8 @@ export function setNewGraphic({
   allFeatures,
   isUploadFile
 }: GraphicConfig): void {
+  //TODO: this needs a refactor, we are handling file uploads and featues on the map with a single
+  //function, we likely need to either reuse multiple functions or split this up
   let graphicsLayer: any = map.findLayerById('active-feature-layer');
 
   if (graphicsLayer) {
@@ -91,74 +89,73 @@ export function setNewGraphic({
     });
   }
 
-  const setSymbol = (symbolType: string): any => {
-    switch (symbolType) {
-      case 'polygon':
-        return getCustomSymbol();
-      case 'point':
-        return getPointSymbol();
-      default:
-        console.warn('potential edge case in setSymbol()', symbolType);
-        return getCustomSymbol();
-    }
-  };
+  if (!isUploadFile) {
+    const isPolygon = allFeatures[0].geometry.type === 'polygon';
+    const symbol = isPolygon
+      ? setSymbol('polygon')
+      : setSymbol(allFeatures[0].geometry.type);
 
-  const setGeometry = (symbolType: string, geometry: __esri.Geometry): any => {
-    switch (symbolType) {
-      case 'polygon':
-        return new Polygon(geometry);
-      case 'point':
-        return new Point(geometry);
-      default:
-        console.warn('potential edge case in setGeometry()', symbolType);
-        return new Polygon(geometry);
-    }
-  };
+    const geometry = isPolygon
+      ? setGeometry('polygon', allFeatures[0].geometry)
+      : setGeometry(allFeatures[0].geometry.type, allFeatures[0].geometry);
 
-  projection.load().then(() => {
-    const allGraphics = allFeatures.map((feature: FeatureResult) => {
-      const isPolygon =
-        (feature.geometry as any).rings || feature.geometry.type === 'polygon';
-
-      /**
-       * * NOTE:
-       * * File uploads don't have a geometry.type,
-       * * so we have to check if it has geometry.rings
-       */
-
-      const symbol = isPolygon
-        ? setSymbol('polygon')
-        : setSymbol(feature.geometry.type);
-
-      const geometry = isPolygon
-        ? setGeometry('polygon', feature.geometry)
-        : setGeometry(feature.geometry.type, feature.geometry);
-
-      const featureGraphic = new Graphic({
-        geometry: geometry,
-        attributes: feature.attributes,
-        symbol: symbol
-      });
-
-      const transformation = projection.getTransformation(
-        featureGraphic.geometry.spatialReference,
-        mapController._mapview.spatialReference
-      );
-
-      featureGraphic.geometry = projection.project(
-        featureGraphic.geometry,
-        mapController._mapview.spatialReference,
-        transformation
-      ) as __esri.Geometry;
-
-      return featureGraphic;
+    const featureGraphic = new Graphic({
+      geometry: geometry,
+      attributes: allFeatures[0].attributes,
+      symbol: symbol
     });
 
-    graphicsLayer.graphics.push(...allGraphics);
-    mapController.initializeAndSetSketch(graphicsLayer.graphics);
+    graphicsLayer.graphics.add(featureGraphic);
+    map.add(graphicsLayer);
+    return;
+  }
 
-    if (isUploadFile) {
+  if (isUploadFile) {
+    projection.load().then(() => {
+      const allGraphics = allFeatures.map((feature: FeatureResult) => {
+        const isPolygon =
+          (feature.geometry as any).rings ||
+          feature.geometry.type === 'polygon';
+
+        /**
+         * * NOTE:
+         * * File uploads don't have a geometry.type,
+         * * so we have to check if it has geometry.rings
+         */
+
+        const symbol = isPolygon
+          ? setSymbol('polygon')
+          : setSymbol(feature.geometry.type);
+
+        const geometry = isPolygon
+          ? setGeometry('polygon', feature.geometry)
+          : setGeometry(feature.geometry.type, feature.geometry);
+
+        const featureGraphic = new Graphic({
+          geometry: geometry,
+          attributes: feature.attributes,
+          symbol: symbol
+        });
+
+        const transformation = projection.getTransformation(
+          featureGraphic.geometry.spatialReference,
+          mapController._mapview.spatialReference
+        );
+
+        featureGraphic.geometry = projection.project(
+          featureGraphic.geometry,
+          mapController._mapview.spatialReference,
+          transformation
+        ) as __esri.Geometry;
+
+        return featureGraphic;
+      });
+
+      graphicsLayer.graphics.push(...allGraphics);
+      mapController.initializeAndSetSketch(graphicsLayer.graphics);
+
       mapview.goTo(allGraphics);
-    }
-  });
+    });
+    return;
+  }
 }

--- a/src/js/helpers/generateSymbol.ts
+++ b/src/js/helpers/generateSymbol.ts
@@ -6,7 +6,6 @@ export const getCustomSymbol = (): SimpleFillSymbol => {
     style: 'solid',
     color: [210, 210, 210, 0.0],
     outline: {
-      // autocasts as new SimpleLineSymbol()
       color: [3, 188, 255],
       width: 3
     }
@@ -18,7 +17,6 @@ export const getImagerySymbol = (): SimpleFillSymbol => {
     style: 'solid',
     color: [210, 210, 210, 0.0],
     outline: {
-      // autocasts as new SimpleLineSymbol()
       color: [210, 210, 210, 0],
       width: 1
     }


### PR DESCRIPTION
Report was crashing due to graphics layers not being added correctly, this implements a quick fix, but our graphics addition util functions need refactor down the line.