### PR TITLE
MODIS and VIIRS Fires alerts improvements

### DIFF
--- a/configs/modis-viirs.ts
+++ b/configs/modis-viirs.ts
@@ -1,35 +1,61 @@
 export const VIIRSLayerIDs = [
   {
-    layerID: 'VIIRS48',
+    id: 'VIIRS48',
+    layerIds: [21],
+    type: 'dynamic',
     url:
-      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_VIIRS_48hrs/MapServer/21'
+      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_VIIRS_48hrs/MapServer/'
   },
   {
-    layerID: 'VIIRS72',
+    id: 'VIIRS72',
+    layerIds: [21],
+    type: 'dynamic',
     url:
-      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_VIIRS_7d/MapServer/21'
+      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_VIIRS_7d/MapServer/'
   },
   {
-    layerID: 'VIIRS7D',
+    id: 'VIIRS7D',
+    layerIds: [21],
+    type: 'dynamic',
     url:
-      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_VIIRS_7d/MapServer/21'
+      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_VIIRS_7d/MapServer/'
+  },
+  {
+    id: 'VIIRS1Y',
+    layerIds: [0],
+    type: 'dynamic',
+    url:
+      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_VIIRS_1yr/MapServer/'
   }
 ];
 
 export const MODISLayerIDs = [
   {
-    layerID: 'MODIS48',
+    id: 'MODIS48',
+    layerIds: [21],
+    type: 'dynamic',
     url:
-      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_48hrs/MapServer/21'
+      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_48hrs/MapServer/'
   },
   {
-    layerID: 'MODIS72',
+    id: 'MODIS72',
+    layerIds: [21],
+    type: 'dynamic',
     url:
-      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_7d/MapServer/21'
+      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_7d/MapServer/'
   },
   {
-    layerID: 'MODIS7D',
+    id: 'MODIS7D',
+    layerIds: [21],
+    type: 'dynamic',
     url:
-      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_7d/MapServer/21'
+      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_7d/MapServer/'
+  },
+  {
+    id: 'MODIS1Y',
+    layerIds: [21],
+    type: 'dynamic',
+    url:
+      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_1yr/MapServer'
   }
 ];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Template for the WRI Forest Atlas that will be available through ArcGIS Online.",
   "main": "index.html",
   "scripts": {
-    "start": "webpack-dev-server --open --config webpack.development.js",
+    "start": "webpack-dev-server --config webpack.development.js",
     "build": "webpack --config webpack.production.js --display-origins --display-provided-exports --display-reasons",
     "lib": "webpack --config webpack.lib-production.js --display-origins --display-provided-exports --display-reasons",
     "clean": "rm -rf node_modules; rm package-lock.json",

--- a/src/js/components/leftPanel/layersPanel/DateRangeModisViirs.tsx
+++ b/src/js/components/leftPanel/layersPanel/DateRangeModisViirs.tsx
@@ -1,41 +1,39 @@
 import React, { useState, ChangeEvent } from 'react';
 
 import { mapController } from 'js/controllers/mapController';
-
+import { RootState } from 'js/store/index';
+import { useSelector } from 'react-redux';
 import { LayerProps } from 'js/store/mapview/types';
+import { format } from 'date-fns';
 
 interface DateRangeProps {
   layer: LayerProps;
+  id: string;
 }
-
-const returnDateToday = (): string => {
-  const dateToday = new Date().toLocaleDateString();
-  const [monthToday, dayToday, yearToday] = dateToday.split('/');
-  const dayTodayFormatted = dayToday.length === 1 ? `0${dayToday}` : dayToday;
-  const monthTodayFormatted =
-    monthToday.length === 1 ? `0${monthToday}` : monthToday;
-  const dateTodayFormatted = `${yearToday}-${monthTodayFormatted}-${dayTodayFormatted}`;
-  return dateTodayFormatted;
-};
-
-const returnOneYearAgoToday = (): any => {
-  const dateToday = new Date().toLocaleDateString();
-  const [monthToday, dayToday, yearToday] = dateToday.split('/');
-  const lastYear = String(Number(yearToday) - 1);
-  const dayTodayFormatted = dayToday.length === 1 ? `0${dayToday}` : dayToday;
-  const monthTodayFormatted =
-    monthToday.length === 1 ? `0${monthToday}` : monthToday;
-
-  const dateTodayFormatted = `${lastYear}-${monthTodayFormatted}-${dayTodayFormatted}`;
-
-  return dateTodayFormatted;
-};
+const getTodayDate = format(new Date(Date.now()), 'yyyy-MM-dd');
 
 const DateRange = (props: DateRangeProps): JSX.Element => {
+  const modisStart = useSelector(
+    (store: RootState) => store.appState.leftPanel.modisStart
+  );
+  const modisEnd = useSelector(
+    (store: RootState) => store.appState.leftPanel.modisEnd
+  );
+  const viirsStart = useSelector(
+    (store: RootState) => store.appState.leftPanel.viirsStart
+  );
+  const viirsEnd = useSelector(
+    (store: RootState) => store.appState.leftPanel.viirsEnd
+  );
+
   const { layer } = props;
 
-  const [startDate, setStartDate] = useState(returnOneYearAgoToday());
-  const [endDate, setEndDate] = useState(returnDateToday());
+  const [startDate, setStartDate] = useState<string>(
+    props.id === 'VIIRS_ACTIVE_FIRES' ? viirsStart : modisStart
+  );
+  const [endDate, setEndDate] = useState(
+    props.id === 'VIIRS_ACTIVE_FIRES' ? viirsEnd : modisEnd
+  );
   const [renderCustomRange, setRenderCustomRange] = useState(false);
   const [definedRange, setDefinedRange] = useState('');
 
@@ -96,7 +94,7 @@ const DateRange = (props: DateRangeProps): JSX.Element => {
                 type="date"
                 value={startDate}
                 min="2018-01-01"
-                max={returnDateToday()}
+                max={getTodayDate}
                 onChange={(e): void => updateStartDate(e)}
               />
             </div>
@@ -107,7 +105,7 @@ const DateRange = (props: DateRangeProps): JSX.Element => {
                 type="date"
                 value={endDate}
                 min="2018-01-01"
-                max={returnDateToday()}
+                max={getTodayDate}
                 onChange={(e): void => updateEndDate(e)}
               />
             </div>

--- a/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
+++ b/src/js/components/leftPanel/layersPanel/GenericLayerControl.tsx
@@ -6,7 +6,7 @@ import LayerTransparencySlider from './LayerTransparencySlider';
 import LayerRadioButton from './LayerRadioButton';
 import CanopyDensityPicker from 'js/components/sharedComponents/CanopyDensityPicker';
 import TimeSlider from 'js/components/sharedComponents/TimeSlider';
-import DateRange from './DateRange';
+import DateRange from './DateRangeModisViirs';
 import { esriQuery } from 'js/helpers/dataPanel/esriQuery';
 import {
   renderModal,
@@ -464,18 +464,11 @@ const GenericLayerControl = (props: LayerControlProps): React.ReactElement => {
     layerConfig: any,
     selectedLanguage: string
   ): JSX.Element | undefined => {
-    if (!layer) {
-      return;
-    }
-    /**
-     * TODO
-     * [ ] glad alerts
-     * [ ] terra-I alerts
-     */
+    if (!layer) return;
     switch (id) {
       case 'VIIRS_ACTIVE_FIRES':
       case 'MODIS_ACTIVE_FIRES':
-        return <DateRange layer={layer} />;
+        return <DateRange layer={layer} id={id} />;
       case 'TERRA_I_ALERTS':
         return (
           <TerraControls

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -1471,9 +1471,6 @@ export class MapController {
   }
 
   initializeAndSetVIIRSLayers(): any {
-    //TODO: check for state here and apply def expression
-    // const { viirsStart, viirsEnd } = store.getState().appState.leftPanel;
-    // const defExpression = `ACQ_DATE > date '${viirsStart}' AND ACQ_DATE < date '${viirsEnd}'`;
     const viirsLayers = VIIRSLayerIDs.map(({ id, url, layerIds }) => {
       return new MapImageLayer({
         id: id,
@@ -1491,9 +1488,6 @@ export class MapController {
   }
 
   initializeAndSetMODISLayers(): any {
-    //TODO: check for state here and apply def expression
-    // const { modisStart, modisEnd } = store.getState().appState.leftPanel;
-    // const defExpression = `ACQ_DATE > date '${modisStart}' AND ACQ_DATE < date '${modisEnd}'`;
     const modisLayers = MODISLayerIDs.map(({ id, url, layerIds }) => {
       return new MapImageLayer({
         id: id,

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -1515,10 +1515,10 @@ export class MapController {
         {
           MODIS24.visible = true;
           MODISLayerIDs.forEach(({ id }) => {
-            const fireLayer = this._map?.findLayerById(id);
+            const modisLayer = this._map?.findLayerById(id);
 
-            if (fireLayer) {
-              fireLayer.visible = false;
+            if (modisLayer) {
+              modisLayer.visible = false;
             }
           });
         }
@@ -1527,12 +1527,12 @@ export class MapController {
         {
           MODIS24.visible = false;
           MODISLayerIDs.forEach(({ id }) => {
-            const fireLayer = this._map?.findLayerById(id);
-            if (fireLayer) {
-              if (fireLayer.id === 'MODIS48') {
-                fireLayer.visible = true;
+            const modisLayer = this._map?.findLayerById(id);
+            if (modisLayer) {
+              if (modisLayer.id === 'MODIS48') {
+                modisLayer.visible = true;
               } else {
-                fireLayer.visible = false;
+                modisLayer.visible = false;
               }
             }
           });
@@ -1542,12 +1542,12 @@ export class MapController {
         {
           MODIS24.visible = false;
           MODISLayerIDs.forEach(({ id }) => {
-            const fireLayer = this._map?.findLayerById(id);
-            if (fireLayer) {
-              if (fireLayer.id === 'MODIS72') {
-                fireLayer.visible = true;
+            const modisLayer = this._map?.findLayerById(id);
+            if (modisLayer) {
+              if (modisLayer.id === 'MODIS72') {
+                modisLayer.visible = true;
               } else {
-                fireLayer.visible = false;
+                modisLayer.visible = false;
               }
             }
           });
@@ -1557,12 +1557,12 @@ export class MapController {
         {
           MODIS24.visible = false;
           MODISLayerIDs.forEach(({ id }) => {
-            const fireLayer = this._map?.findLayerById(id);
-            if (fireLayer) {
-              if (fireLayer.id === 'MODIS7D') {
-                fireLayer.visible = true;
+            const modisLayer = this._map?.findLayerById(id);
+            if (modisLayer) {
+              if (modisLayer.id === 'MODIS7D') {
+                modisLayer.visible = true;
               } else {
-                fireLayer.visible = false;
+                modisLayer.visible = false;
               }
             }
           });
@@ -1584,9 +1584,9 @@ export class MapController {
         {
           VIIRS24.visible = true;
           VIIRSLayerIDs.forEach(({ id }) => {
-            const fireLayer = this._map?.findLayerById(id);
-            if (fireLayer) {
-              fireLayer.visible = false;
+            const viirsLayer = this._map?.findLayerById(id);
+            if (viirsLayer) {
+              viirsLayer.visible = false;
             }
           });
         }
@@ -1595,12 +1595,12 @@ export class MapController {
         {
           VIIRS24.visible = false;
           VIIRSLayerIDs.forEach(({ id }) => {
-            const fireLayer = this._map?.findLayerById(id);
-            if (fireLayer) {
-              if (fireLayer.id === 'VIIRS48') {
-                fireLayer.visible = true;
+            const viirsLayer = this._map?.findLayerById(id);
+            if (viirsLayer) {
+              if (viirsLayer.id === 'VIIRS48') {
+                viirsLayer.visible = true;
               } else {
-                fireLayer.visible = false;
+                viirsLayer.visible = false;
               }
             }
           });
@@ -1610,12 +1610,12 @@ export class MapController {
         {
           VIIRS24.visible = false;
           VIIRSLayerIDs.forEach(({ id }) => {
-            const fireLayer = this._map?.findLayerById(id);
-            if (fireLayer) {
-              if (fireLayer.id === 'VIIRS72') {
-                fireLayer.visible = true;
+            const viirsLayer = this._map?.findLayerById(id);
+            if (viirsLayer) {
+              if (viirsLayer.id === 'VIIRS72') {
+                viirsLayer.visible = true;
               } else {
-                fireLayer.visible = false;
+                viirsLayer.visible = false;
               }
             }
           });
@@ -1625,12 +1625,12 @@ export class MapController {
         {
           VIIRS24.visible = false;
           VIIRSLayerIDs.forEach(({ id }) => {
-            const fireLayer = this._map?.findLayerById(id);
-            if (fireLayer) {
-              if (fireLayer.id === 'VIIRS7D') {
-                fireLayer.visible = true;
+            const viirsLayer = this._map?.findLayerById(id);
+            if (viirsLayer) {
+              if (viirsLayer.id === 'VIIRS7D') {
+                viirsLayer.visible = true;
               } else {
-                fireLayer.visible = false;
+                viirsLayer.visible = false;
               }
             }
           });

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -18,6 +18,7 @@ import Basemap from 'esri/Basemap';
 import Sublayer from 'esri/layers/support/Sublayer';
 import RasterFunction from 'esri/layers/support/RasterFunction';
 import FeatureLayer from 'esri/layers/FeatureLayer';
+import MapImageLayer from 'esri/layers/MapImageLayer';
 import { debounce } from 'lodash-es';
 import { landsatBaselayerURL } from '../../../configs/layer-config';
 import { RefObject } from 'react';
@@ -46,7 +47,11 @@ import {
   setMeasureResults,
   setLanguage,
   setRenderGFWDropdown,
-  setSelectedSearchWidgetLayer
+  setSelectedSearchWidgetLayer,
+  setModisStart,
+  setModisEnd,
+  setViirsStart,
+  setViirsEnd
 } from 'js/store/appState/actions';
 import {
   LayerProps,
@@ -301,7 +306,6 @@ export class MapController {
           //Get VIIRS and MODIS layers
           const viirsLayers = this.initializeAndSetVIIRSLayers();
           const modisLayers = this.initializeAndSetMODISLayers();
-
           const allLayers = [
             ...viirsLayers,
             ...modisLayers,
@@ -1433,82 +1437,94 @@ export class MapController {
     startDate: string | Date,
     endDate: string | Date
   ): void {
-    const { mapviewState } = store.getState();
-
-    if (!this._map) {
-      return;
-    }
-
-    const layer = (this._map.allLayers as any).items.filter(
-      (layer: FeatureLayer) => layer.id === layerID
-    )[0];
-
-    if (layer.sublayers) {
-      const defExpression = `ACQ_DATE > date '${startDate}' AND ACQ_DATE < date '${endDate}'`;
-      const twentyFourHourSublayer = layer.sublayers.items.filter(
-        (sublayer: Sublayer) =>
-          sublayer.title === 'Global Fires (MODIS) 24 hrs' ||
-          sublayer.title === 'Global Fires (VIIRS) 24 hrs'
-      )[0];
-
-      twentyFourHourSublayer.definitionExpression = defExpression;
-
-      const newLayersArray = mapviewState.allAvailableLayers.map(
-        (layer: LayerProps) => {
-          if (layer.id === layerID) {
-            layer.definitionExpression = defExpression;
-          }
-
-          return layer;
+    //Custom date range is always set on the 1 year layer, all other layers must be turned off first
+    //and definition expression will be applied to that 1 year layer
+    const defExpression = `ACQ_DATE > date '${startDate}' AND ACQ_DATE < date '${endDate}'`;
+    if (layerID === 'MODIS_ACTIVE_FIRES') {
+      const modis24H = this._map!.findLayerById('MODIS_ACTIVE_FIRES');
+      modis24H.visible = false;
+      const modis1Y = this._map!.findLayerById('MODIS1Y') as any;
+      modis1Y.sublayers.items[0].definitionExpression = defExpression;
+      const modisIds = MODISLayerIDs.map(l => l.id);
+      this._map!.layers.forEach(l => {
+        if (modisIds.includes(l.id)) {
+          l.visible = l.id === 'MODIS1Y';
         }
-      );
-
-      store.dispatch(allAvailableLayers(newLayersArray));
+      });
+      store.dispatch(setModisStart(String(startDate)));
+      store.dispatch(setModisEnd(String(endDate)));
+    } else if (layerID === 'VIIRS_ACTIVE_FIRES') {
+      const viirs24H = this._map!.findLayerById('VIIRS_ACTIVE_FIRES');
+      viirs24H.visible = false;
+      const viirs1Y = this._map!.findLayerById('VIIRS1Y') as any;
+      viirs1Y.sublayers.items[0].definitionExpression = defExpression;
+      const viirsIds = VIIRSLayerIDs.map(l => l.id);
+      this._map!.layers.forEach(l => {
+        if (viirsIds.includes(l.id)) {
+          l.visible = l.id === 'VIIRS1Y';
+        }
+      });
+      //sync the new date with redux
+      store.dispatch(setViirsStart(String(startDate)));
+      store.dispatch(setViirsEnd(String(endDate)));
     }
-
-    return;
   }
 
   initializeAndSetVIIRSLayers(): any {
-    const viirsLayers = VIIRSLayerIDs.map(({ layerID, url }) => {
-      return new FeatureLayer({
-        id: layerID,
+    //TODO: check for state here and apply def expression
+    // const { viirsStart, viirsEnd } = store.getState().appState.leftPanel;
+    // const defExpression = `ACQ_DATE > date '${viirsStart}' AND ACQ_DATE < date '${viirsEnd}'`;
+    const viirsLayers = VIIRSLayerIDs.map(({ id, url, layerIds }) => {
+      return new MapImageLayer({
+        id: id,
         url,
-        visible: false
+        visible: false,
+        sublayers: [
+          {
+            id: layerIds[0],
+            visible: true
+          }
+        ]
       });
     });
     return viirsLayers;
   }
 
   initializeAndSetMODISLayers(): any {
-    const modisLayers = MODISLayerIDs.map(({ layerID, url }) => {
-      return new FeatureLayer({
-        id: layerID,
+    //TODO: check for state here and apply def expression
+    // const { modisStart, modisEnd } = store.getState().appState.leftPanel;
+    // const defExpression = `ACQ_DATE > date '${modisStart}' AND ACQ_DATE < date '${modisEnd}'`;
+    const modisLayers = MODISLayerIDs.map(({ id, url, layerIds }) => {
+      return new MapImageLayer({
+        id: id,
         url,
-        visible: false
+        visible: false,
+        sublayers: [
+          {
+            id: layerIds[0],
+            visible: true
+          }
+        ]
       });
     });
     return modisLayers;
   }
 
-  setMODISDefinedRange(layer: any, sublayerType: string): void {
-    if (!this._map) {
-      return;
-    }
-
-    const MODIS24 = layer.sublayers.items.filter(
-      (sublayer: Sublayer) => sublayer.title === 'Global Fires (MODIS) 24 hrs'
-    );
+  setMODISDefinedRange(sublayerType: string): void {
+    //Turn off 1Y layer as it does not apply for defined range controls
+    const MODIS1Y = this._map?.findLayerById('MODIS1Y');
+    MODIS1Y!.visible = false;
+    const MODIS24 = this._map!.findLayerById('MODIS_ACTIVE_FIRES');
 
     switch (sublayerType) {
       case '24 hrs':
         {
           MODIS24.visible = true;
-          MODISLayerIDs.forEach(({ layerID }) => {
-            const specificLayer = this._map?.findLayerById(layerID);
+          MODISLayerIDs.forEach(({ id }) => {
+            const fireLayer = this._map?.findLayerById(id);
 
-            if (specificLayer) {
-              specificLayer.visible = false;
+            if (fireLayer) {
+              fireLayer.visible = false;
             }
           });
         }
@@ -1516,13 +1532,13 @@ export class MapController {
       case '48 hrs':
         {
           MODIS24.visible = false;
-          MODISLayerIDs.forEach(({ layerID }) => {
-            const specificLayer = this._map?.findLayerById(layerID);
-            if (specificLayer) {
-              if (specificLayer.id === 'MODIS48') {
-                specificLayer.visible = true;
+          MODISLayerIDs.forEach(({ id }) => {
+            const fireLayer = this._map?.findLayerById(id);
+            if (fireLayer) {
+              if (fireLayer.id === 'MODIS48') {
+                fireLayer.visible = true;
               } else {
-                specificLayer.visible = false;
+                fireLayer.visible = false;
               }
             }
           });
@@ -1531,13 +1547,13 @@ export class MapController {
       case '72 hrs':
         {
           MODIS24.visible = false;
-          MODISLayerIDs.forEach(({ layerID }) => {
-            const specificLayer = this._map?.findLayerById(layerID);
-            if (specificLayer) {
-              if (specificLayer.id === 'MODIS72') {
-                specificLayer.visible = true;
+          MODISLayerIDs.forEach(({ id }) => {
+            const fireLayer = this._map?.findLayerById(id);
+            if (fireLayer) {
+              if (fireLayer.id === 'MODIS72') {
+                fireLayer.visible = true;
               } else {
-                specificLayer.visible = false;
+                fireLayer.visible = false;
               }
             }
           });
@@ -1546,13 +1562,13 @@ export class MapController {
       case '7 days':
         {
           MODIS24.visible = false;
-          MODISLayerIDs.forEach(({ layerID }) => {
-            const specificLayer = this._map?.findLayerById(layerID);
-            if (specificLayer) {
-              if (specificLayer.id === 'MODIS7D') {
-                specificLayer.visible = true;
+          MODISLayerIDs.forEach(({ id }) => {
+            const fireLayer = this._map?.findLayerById(id);
+            if (fireLayer) {
+              if (fireLayer.id === 'MODIS7D') {
+                fireLayer.visible = true;
               } else {
-                specificLayer.visible = false;
+                fireLayer.visible = false;
               }
             }
           });
@@ -1563,23 +1579,20 @@ export class MapController {
     }
   }
 
-  setVIIRSDefinedRange(layer: any, sublayerType: string): void {
-    if (!this._map) {
-      return;
-    }
-    const VIIRS24 = layer.sublayers.items.filter(
-      (sublayer: Sublayer) => sublayer.title === 'Global Fires (VIIRS) 24 hrs'
-    );
+  setVIIRSDefinedRange(sublayerType: string): void {
+    //Turn off 1Y layer as it does not apply for defined range controls
+    const VIIRS1Y = this._map?.findLayerById('VIIRS1Y');
+    VIIRS1Y!.visible = false;
+    const VIIRS24 = this._map!.findLayerById('VIIRS_ACTIVE_FIRES');
 
     switch (sublayerType) {
       case '24 hrs':
         {
           VIIRS24.visible = true;
-          VIIRSLayerIDs.forEach(({ layerID }) => {
-            const specificLayer = this._map?.findLayerById(layerID);
-
-            if (specificLayer) {
-              specificLayer.visible = false;
+          VIIRSLayerIDs.forEach(({ id }) => {
+            const fireLayer = this._map?.findLayerById(id);
+            if (fireLayer) {
+              fireLayer.visible = false;
             }
           });
         }
@@ -1587,13 +1600,13 @@ export class MapController {
       case '48 hrs':
         {
           VIIRS24.visible = false;
-          VIIRSLayerIDs.forEach(({ layerID }) => {
-            const specificLayer = this._map?.findLayerById(layerID);
-            if (specificLayer) {
-              if (specificLayer.id === 'VIIRS48') {
-                specificLayer.visible = true;
+          VIIRSLayerIDs.forEach(({ id }) => {
+            const fireLayer = this._map?.findLayerById(id);
+            if (fireLayer) {
+              if (fireLayer.id === 'VIIRS48') {
+                fireLayer.visible = true;
               } else {
-                specificLayer.visible = false;
+                fireLayer.visible = false;
               }
             }
           });
@@ -1602,13 +1615,13 @@ export class MapController {
       case '72 hrs':
         {
           VIIRS24.visible = false;
-          VIIRSLayerIDs.forEach(({ layerID }) => {
-            const specificLayer = this._map?.findLayerById(layerID);
-            if (specificLayer) {
-              if (specificLayer.id === 'VIIRS72') {
-                specificLayer.visible = true;
+          VIIRSLayerIDs.forEach(({ id }) => {
+            const fireLayer = this._map?.findLayerById(id);
+            if (fireLayer) {
+              if (fireLayer.id === 'VIIRS72') {
+                fireLayer.visible = true;
               } else {
-                specificLayer.visible = false;
+                fireLayer.visible = false;
               }
             }
           });
@@ -1617,13 +1630,13 @@ export class MapController {
       case '7 days':
         {
           VIIRS24.visible = false;
-          VIIRSLayerIDs.forEach(({ layerID }) => {
-            const specificLayer = this._map?.findLayerById(layerID);
-            if (specificLayer) {
-              if (specificLayer.id === 'VIIRS7D') {
-                specificLayer.visible = true;
+          VIIRSLayerIDs.forEach(({ id }) => {
+            const fireLayer = this._map?.findLayerById(id);
+            if (fireLayer) {
+              if (fireLayer.id === 'VIIRS7D') {
+                fireLayer.visible = true;
               } else {
-                specificLayer.visible = false;
+                fireLayer.visible = false;
               }
             }
           });
@@ -1660,16 +1673,16 @@ export class MapController {
     }
 
     if (layer.id === 'VIIRS_ACTIVE_FIRES') {
-      VIIRSLayerIDs.forEach(({ layerID }) => {
-        const specificLayer = this._map?.findLayerById(layerID);
+      VIIRSLayerIDs.forEach(({ id }) => {
+        const specificLayer = this._map?.findLayerById(id);
 
         if (specificLayer) {
           specificLayer.visible = false;
         }
       });
     } else if (layer.id === 'MODIS_ACTIVE_FIRES') {
-      MODISLayerIDs.forEach(({ layerID }) => {
-        const specificLayer = this._map?.findLayerById(layerID);
+      MODISLayerIDs.forEach(({ id }) => {
+        const specificLayer = this._map?.findLayerById(id);
 
         if (specificLayer) {
           specificLayer.visible = false;
@@ -1727,16 +1740,16 @@ export class MapController {
     sublayer24.opacity = opacity;
 
     if (layerID === 'VIIRS_ACTIVE_FIRES') {
-      VIIRSLayerIDs.forEach(({ layerID }) => {
-        const specificLayer = this._map?.findLayerById(layerID);
+      VIIRSLayerIDs.forEach(({ id }) => {
+        const specificLayer = this._map?.findLayerById(id);
 
         if (specificLayer) {
           specificLayer.opacity = opacity;
         }
       });
     } else if (layerID === 'MODIS_ACTIVE_FIRES') {
-      MODISLayerIDs.forEach(({ layerID }) => {
-        const specificLayer = this._map?.findLayerById(layerID);
+      MODISLayerIDs.forEach(({ id }) => {
+        const specificLayer = this._map?.findLayerById(id);
 
         if (specificLayer) {
           specificLayer.opacity = opacity;
@@ -1759,20 +1772,11 @@ export class MapController {
   }
 
   setDefinedDateRange(layerID: string, sublayerType: string): void {
-    if (!this._map) {
-      return;
-    }
-
-    const layer = (this._map.allLayers as any).items.filter(
-      (layer: LayerProps) => layer.id === layerID
-    )[0];
-
     if (layerID === 'MODIS_ACTIVE_FIRES') {
-      this.setMODISDefinedRange(layer, sublayerType);
+      this.setMODISDefinedRange(sublayerType);
     }
-
     if (layerID === 'VIIRS_ACTIVE_FIRES') {
-      this.setVIIRSDefinedRange(layer, sublayerType);
+      this.setVIIRSDefinedRange(sublayerType);
     }
   }
 

--- a/src/js/helpers/shareFunctionality.ts
+++ b/src/js/helpers/shareFunctionality.ts
@@ -7,7 +7,11 @@ import {
   setGladStart,
   setGladEnd,
   setTerraStart,
-  setTerraEnd
+  setTerraEnd,
+  setModisStart,
+  setModisEnd,
+  setViirsStart,
+  setViirsEnd
 } from 'js/store/appState/actions';
 import { LayerFeatureResult } from 'js/store/mapview/types';
 import { registerGeometry } from 'js/helpers/geometryRegistration';
@@ -134,6 +138,16 @@ export async function getShareableURL(props: ShareURLProps): Promise<string> {
     urlParams.push(`te=${leftPanel.terraEnd}`);
   }
 
+  const viirsLayer = mapController._map?.findLayerById('VIIRS_ACTIVE_FIRES');
+  if (viirsLayer) {
+    urlParams.push(`vs=${leftPanel.viirsStart}`);
+    urlParams.push(`ve=${leftPanel.viirsEnd}`);
+  }
+  const modisLayer = mapController._map?.findLayerById('MODIS_ACTIVE_FIRES');
+  if (modisLayer) {
+    urlParams.push(`ms=${leftPanel.modisStart}`);
+    urlParams.push(`me=${leftPanel.modisEnd}`);
+  }
   return urlParams.join('&');
 }
 
@@ -208,6 +222,18 @@ export function parseURLandApplyChanges(): void {
           break;
         case 'te':
           store.dispatch(setTerraEnd(urlParamValue));
+          break;
+        case 'vs':
+          store.dispatch(setViirsStart(urlParamValue));
+          break;
+        case 've':
+          store.dispatch(setViirsEnd(urlParamValue));
+          break;
+        case 'ms':
+          store.dispatch(setModisStart(urlParamValue));
+          break;
+        case 'me':
+          store.dispatch(setModisEnd(urlParamValue));
           break;
         default:
           break;

--- a/src/js/store/appState/actions.ts
+++ b/src/js/store/appState/actions.ts
@@ -20,7 +20,11 @@ import {
   SET_GLAD_START,
   SET_GLAD_END,
   SET_TERRA_START,
-  SET_TERRA_END
+  SET_TERRA_END,
+  SET_VIIRS_START,
+  SET_VIIRS_END,
+  SET_MODIS_START,
+  SET_MODIS_END
 } from './types';
 
 export function setSelectedSearchWidgetLayer(
@@ -169,6 +173,34 @@ export function setTerraStart(payload: AppState['leftPanel']['terraStart']) {
 export function setTerraEnd(payload: AppState['leftPanel']['terraEnd']) {
   return {
     type: SET_TERRA_END as typeof SET_TERRA_END,
+    payload: payload
+  };
+}
+
+export function setModisStart(payload: AppState['leftPanel']['modisStart']) {
+  return {
+    type: SET_MODIS_START as typeof SET_MODIS_START,
+    payload: payload
+  };
+}
+
+export function setModisEnd(payload: AppState['leftPanel']['modisEnd']) {
+  return {
+    type: SET_MODIS_END as typeof SET_MODIS_END,
+    payload: payload
+  };
+}
+
+export function setViirsStart(payload: AppState['leftPanel']['viirsStart']) {
+  return {
+    type: SET_VIIRS_START as typeof SET_VIIRS_START,
+    payload: payload
+  };
+}
+
+export function setViirsEnd(payload: AppState['leftPanel']['viirsEnd']) {
+  return {
+    type: SET_VIIRS_END as typeof SET_VIIRS_END,
     payload: payload
   };
 }

--- a/src/js/store/appState/reducers.ts
+++ b/src/js/store/appState/reducers.ts
@@ -1,3 +1,5 @@
+import { format, subYears } from 'date-fns';
+
 import {
   AppState,
   AppStateTypes,
@@ -20,7 +22,11 @@ import {
   SET_GLAD_START,
   SET_GLAD_END,
   SET_TERRA_START,
-  SET_TERRA_END
+  SET_TERRA_END,
+  SET_MODIS_START,
+  SET_MODIS_END,
+  SET_VIIRS_START,
+  SET_VIIRS_END
 } from './types';
 
 const initialState: AppState = {
@@ -43,9 +49,13 @@ const initialState: AppState = {
     analysisYearRange: [2001, 2018],
     gladConfirmed: false,
     gladStart: '2015-01-01',
-    gladEnd: new Date().toISOString().split('T')[0],
+    gladEnd: format(new Date(Date.now()), 'yyyy-MM-dd'),
     terraStart: '2004-01-01',
-    terraEnd: new Date().toISOString().split('T')[0]
+    terraEnd: format(new Date(Date.now()), 'yyyy-MM-dd'),
+    modisEnd: format(new Date(Date.now()), 'yyyy-MM-dd'),
+    modisStart: format(subYears(new Date(Date.now()), 1), 'yyyy-MM-dd'),
+    viirsEnd: format(new Date(Date.now()), 'yyyy-MM-dd'),
+    viirsStart: format(subYears(new Date(Date.now()), 1), 'yyyy-MM-dd')
   },
   measureContent: {
     activeButton: '',
@@ -182,6 +192,38 @@ export function appStateReducer(
         leftPanel: {
           ...state.leftPanel,
           terraEnd: action.payload
+        }
+      };
+    case SET_MODIS_START:
+      return {
+        ...state,
+        leftPanel: {
+          ...state.leftPanel,
+          modisStart: action.payload
+        }
+      };
+    case SET_MODIS_END:
+      return {
+        ...state,
+        leftPanel: {
+          ...state.leftPanel,
+          modisEnd: action.payload
+        }
+      };
+    case SET_VIIRS_START:
+      return {
+        ...state,
+        leftPanel: {
+          ...state.leftPanel,
+          viirsStart: action.payload
+        }
+      };
+    case SET_VIIRS_END:
+      return {
+        ...state,
+        leftPanel: {
+          ...state.leftPanel,
+          viirsEnd: action.payload
         }
       };
     default:

--- a/src/js/store/appState/types.ts
+++ b/src/js/store/appState/types.ts
@@ -10,6 +10,10 @@ export interface LeftPanel {
   gladEnd: string;
   terraStart: string;
   terraEnd: string;
+  modisStart: string;
+  modisEnd: string;
+  viirsStart: string;
+  viirsEnd: string;
 }
 
 interface SpecificAreaResults {
@@ -73,6 +77,10 @@ export const SET_GLAD_START = 'SET_GLAD_START';
 export const SET_GLAD_END = 'SET_GLAD_END';
 export const SET_TERRA_START = 'SET_TERRA_START';
 export const SET_TERRA_END = 'SET_TERRA_END';
+export const SET_VIIRS_START = 'SET_VIIRS_START';
+export const SET_VIIRS_END = 'SET_VIIRS_END';
+export const SET_MODIS_START = 'SET_MODIS_START';
+export const SET_MODIS_END = 'SET_MODIS_END';
 
 interface SetSelectedSearchWidgetLayer {
   type: typeof SET_SELECTED_SEARCH_WIDGET_LAYER;
@@ -174,6 +182,26 @@ interface SetTerraEnd {
   payload: AppState['leftPanel']['terraEnd'];
 }
 
+interface SetModisStart {
+  type: typeof SET_MODIS_START;
+  payload: AppState['leftPanel']['modisStart'];
+}
+
+interface SetModisEnd {
+  type: typeof SET_MODIS_END;
+  payload: AppState['leftPanel']['modisEnd'];
+}
+
+interface SetViirsStart {
+  type: typeof SET_VIIRS_START;
+  payload: AppState['leftPanel']['viirsStart'];
+}
+
+interface SetViirsEnd {
+  type: typeof SET_VIIRS_END;
+  payload: AppState['leftPanel']['viirsEnd'];
+}
+
 export type AppStateTypes =
   | ToggleTabviewPanelAction
   | RenderModalAction
@@ -194,4 +222,8 @@ export type AppStateTypes =
   | SetGladStart
   | SetGladEnd
   | SetTerraStart
-  | SetTerraEnd;
+  | SetTerraEnd
+  | SetModisStart
+  | SetModisEnd
+  | SetViirsStart
+  | SetViirsEnd;

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -8,6 +8,7 @@ module.exports = merge(common, {
   devtool: 'inline-source-map',
   devServer: {
     contentBase: './dist',
-    stats: 'minimal'
+    stats: 'minimal',
+    open: false
   }
 });


### PR DESCRIPTION
Partial for #818

This PR does the following:
1. Refactors how we create and interact with all MODIS and FIIRES layers. Previously we created them as FeatureLayers by directly accessing URL within MapImageServer. That introduced performance issues and very non-optimal queries, 1Year layer did not work at all. With this change all layers are created as MapImageLayers with their consecutive sublayer ids.
2. Redux tracking for date ranges related to these layer groups
3. Users can share date range for both layers with the usual share flow.