### PR TITLE
Ticket 1024 - Subscribe to alerts flow styling

### DIFF
--- a/src/css/alertCarousel.scss
+++ b/src/css/alertCarousel.scss
@@ -34,8 +34,7 @@
     ul {
       display: grid;
       list-style: none;
-      grid-template-columns: 8rem 8rem;
-
+      grid-template-columns: 1.5fr 1.5fr;
       li {
         font-size: 0.875rem;
         font-weight: 400;
@@ -89,7 +88,6 @@
           appearance: none;
           padding: 0.75rem;
           padding-right: 2rem;
-          background-color: transparent;
           cursor: pointer;
           height: 2rem;
           width: auto;

--- a/src/css/alertCarousel.scss
+++ b/src/css/alertCarousel.scss
@@ -1,0 +1,5 @@
+@import './variables.scss';
+
+.alert-carousel-container {
+  display: flex;
+}

--- a/src/css/alertCarousel.scss
+++ b/src/css/alertCarousel.scss
@@ -2,4 +2,119 @@
 
 .alert-carousel-container {
   display: flex;
+
+  .orange-button {
+    &.custom {
+      width: 3rem;
+      font-weight: 400;
+    }
+
+    &.inactive {
+      opacity: 0.5;
+    }
+  }
+
+  .subscribe-to-content-container {
+    h2,
+    p,
+    ul {
+      padding: 0 1.5rem 0 1.5rem;
+    }
+
+    h2 {
+      font-size: 24px;
+      text-align: center;
+    }
+
+    p {
+      font-weight: 400;
+      line-height: 1.7;
+    }
+
+    ul {
+      display: grid;
+      list-style: none;
+      grid-template-columns: 8rem 8rem;
+
+      li {
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 1.7;
+        padding: 0.25rem;
+      }
+    }
+  }
+
+  .name-your-subscriptions-container {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
+    margin-top: 2rem;
+
+    h3 {
+      font-size: 24px;
+      color: #555;
+      text-align: center;
+      width: 10rem;
+    }
+
+    .form-wrapper {
+      display: grid;
+      grid-auto-rows: 5rem 5rem 2.5rem;
+      align-items: center;
+      margin: 0 auto;
+
+      .column {
+        display: flex;
+        flex-direction: column;
+
+        label {
+          font-size: 14px;
+          font-weight: 400;
+          line-height: 1.7;
+        }
+
+        input {
+          height: 2rem;
+          font-size: 14px;
+          padding-left: 5px;
+          width: auto;
+          margin-top: 0.25rem;
+          margin-bottom: 0.5rem;
+        }
+
+        select {
+          position: relative;
+          z-index: 1;
+          appearance: none;
+          padding: 0.75em;
+          padding-right: 2em;
+          border: 0.125em solid;
+          border-radius: 0.25em;
+          background-color: transparent;
+          cursor: pointer;
+          height: 2rem;
+          width: auto;
+        }
+      }
+    }
+
+    .buttons-wrapper {
+      display: flex;
+    }
+  }
+
+  .subscription-saved-container {
+    padding: 0.5rem;
+
+    h3 {
+      line-height: 1.7;
+    }
+
+    p {
+      font-size: 14px;
+      font-weight: 400;
+      line-height: 1.7;
+    }
+  }
 }

--- a/src/css/alertCarousel.scss
+++ b/src/css/alertCarousel.scss
@@ -22,7 +22,7 @@
     }
 
     h2 {
-      font-size: 24px;
+      font-size: 1.5rem;
       text-align: center;
     }
 
@@ -37,7 +37,7 @@
       grid-template-columns: 8rem 8rem;
 
       li {
-        font-size: 14px;
+        font-size: 0.875rem;
         font-weight: 400;
         line-height: 1.7;
         padding: 0.25rem;
@@ -52,7 +52,7 @@
     margin-top: 2rem;
 
     h3 {
-      font-size: 24px;
+      font-size: 1.5rem;
       color: #555;
       text-align: center;
       width: 10rem;
@@ -69,14 +69,14 @@
         flex-direction: column;
 
         label {
-          font-size: 14px;
+          font-size: 0.875rem;
           font-weight: 400;
           line-height: 1.7;
         }
 
         input {
           height: 2rem;
-          font-size: 14px;
+          font-size: 0.875rem;
           padding-left: 5px;
           width: auto;
           margin-top: 0.25rem;
@@ -87,14 +87,17 @@
           position: relative;
           z-index: 1;
           appearance: none;
-          padding: 0.75em;
-          padding-right: 2em;
-          border: 0.125em solid;
-          border-radius: 0.25em;
+          padding: 0.75rem;
+          padding-right: 2rem;
           background-color: transparent;
           cursor: pointer;
           height: 2rem;
           width: auto;
+
+          border: 1px solid rgb(166, 166, 166);
+          border-radius: 0.25rem;
+          border-style: solid;
+          background-color: rgb(247, 247, 247);
         }
       }
     }
@@ -112,7 +115,7 @@
     }
 
     p {
-      font-size: 14px;
+      font-size: 0.875rem;
       font-weight: 400;
       line-height: 1.7;
     }

--- a/src/css/modalCard.scss
+++ b/src/css/modalCard.scss
@@ -37,6 +37,11 @@
     width: 21rem;
   }
 
+  &.alert-carousel {
+    width: 320px;
+    height: 450px;
+  }
+
   &.info-content {
     width: 31.25rem;
     height: 25rem;

--- a/src/css/modalCard.scss
+++ b/src/css/modalCard.scss
@@ -40,6 +40,7 @@
   &.alert-carousel {
     width: 320px;
     height: 450px;
+    top: 35%;
   }
 
   &.info-content {

--- a/src/js/components/leftPanel/dataPanel/subscribeToAlerts/AlertCarousel.tsx
+++ b/src/js/components/leftPanel/dataPanel/subscribeToAlerts/AlertCarousel.tsx
@@ -13,6 +13,8 @@ import {
 } from 'js/store/mapview/actions';
 import { RootState } from 'js/store/index';
 
+import 'css/alertCarousel.scss';
+
 const AlertCarousel = (): JSX.Element => {
   const allSteps: ReadonlyArray<string> = [
     'SubscribeToAlerts',

--- a/src/js/components/leftPanel/dataPanel/subscribeToAlerts/NameYourSubscription.tsx
+++ b/src/js/components/leftPanel/dataPanel/subscribeToAlerts/NameYourSubscription.tsx
@@ -36,35 +36,42 @@ const NameYourSubscription = (
 
   return (
     <div className="name-your-subscriptions-container">
-      <h3>{title}</h3>
-      <label>{nameLabel}</label>
-      <input
-        type="text"
-        value={subscriptionName}
-        placeholder={'Area name'}
-        onChange={(e: any): void => setSubscriptionName(e.target.value)}
-      />
-
-      <label>{subscribeLabel}</label>
-      <select
-        onClick={(e: any): void => setSubscriptionLanguage(e.target.value)}
-      >
-        {languageOptions.map(({ label, field }, index: number) => (
-          <option key={index} value={field}>
-            {label}
-          </option>
-        ))}
-      </select>
-      <div>
-        <button
-          onClick={(): void => setPrevStep()}
-          className="esri-icon-left-arrow"
-        />
-        <button
-          onClick={(): void => setNextStep()}
-          disabled={subscriptionName.length ? false : true}
-          className="esri-icon-right-arrow"
-        />
+      <div className="form-wrapper">
+        <h3>{title}</h3>
+        <div className="column">
+          <label>{nameLabel}</label>
+          <input
+            type="text"
+            value={subscriptionName}
+            placeholder={'Area name'}
+            onChange={(e: any): void => setSubscriptionName(e.target.value)}
+          />
+        </div>
+        <div className="column">
+          <label>{subscribeLabel}</label>
+          <select
+            onClick={(e: any): void => setSubscriptionLanguage(e.target.value)}
+          >
+            {languageOptions.map(({ label, field }, index: number) => (
+              <option key={index} value={field}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="buttons-wrapper">
+          <button
+            onClick={(): void => setPrevStep()}
+            className="orange-button custom esri-icon-left-arrow"
+          />
+          <button
+            onClick={(): void => setNextStep()}
+            disabled={subscriptionName.length ? false : true}
+            className={`orange-button custom esri-icon-right-arrow ${
+              subscriptionName.length ? '' : 'inactive'
+            }`}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/js/components/leftPanel/dataPanel/subscribeToAlerts/NameYourSubscription.tsx
+++ b/src/js/components/leftPanel/dataPanel/subscribeToAlerts/NameYourSubscription.tsx
@@ -70,6 +70,7 @@ const NameYourSubscription = (
           <button
             onClick={(): void => setPrevStep()}
             className="orange-button custom esri-icon-left-arrow"
+            style={{ backgroundColor: customColorTheme }}
           />
           <button
             onClick={(): void => setNextStep()}
@@ -77,6 +78,7 @@ const NameYourSubscription = (
             className={`orange-button custom esri-icon-right-arrow ${
               subscriptionName.length ? '' : 'inactive'
             }`}
+            style={{ backgroundColor: customColorTheme }}
           />
         </div>
       </div>

--- a/src/js/components/leftPanel/dataPanel/subscribeToAlerts/NameYourSubscription.tsx
+++ b/src/js/components/leftPanel/dataPanel/subscribeToAlerts/NameYourSubscription.tsx
@@ -27,6 +27,9 @@ const NameYourSubscription = (
     setSubscriptionLanguage
   } = props;
 
+  const customColorTheme = useSelector(
+    (store: RootState) => store.appSettings.customColorTheme
+  );
   const selectedLanguage = useSelector(
     (state: RootState) => state.appState.selectedLanguage
   );
@@ -50,6 +53,10 @@ const NameYourSubscription = (
         <div className="column">
           <label>{subscribeLabel}</label>
           <select
+            style={{
+              border: `1px solid ${customColorTheme}`,
+              backgroundColor: customColorTheme
+            }}
             onClick={(e: any): void => setSubscriptionLanguage(e.target.value)}
           >
             {languageOptions.map(({ label, field }, index: number) => (
@@ -66,7 +73,7 @@ const NameYourSubscription = (
           />
           <button
             onClick={(): void => setNextStep()}
-            disabled={subscriptionName.length ? false : true}
+            disabled={subscriptionName.length === 0}
             className={`orange-button custom esri-icon-right-arrow ${
               subscriptionName.length ? '' : 'inactive'
             }`}

--- a/src/js/components/leftPanel/dataPanel/subscribeToAlerts/SubscribeToAlerts.tsx
+++ b/src/js/components/leftPanel/dataPanel/subscribeToAlerts/SubscribeToAlerts.tsx
@@ -13,6 +13,9 @@ interface Props {
 
 const SubscribeToAlerts = (props: Props): JSX.Element => {
   const { selectedAlerts, setSelectedAlerts, setNextStep } = props;
+  const customColorTheme = useSelector(
+    (store: RootState) => store.appSettings.customColorTheme
+  );
   const selectedLanguage = useSelector(
     (store: RootState) => store.appState.selectedLanguage
   );
@@ -155,6 +158,7 @@ const SubscribeToAlerts = (props: Props): JSX.Element => {
         className={`orange-button custom esri-icon-right-arrow ${
           selectedAlerts.length ? '' : 'inactive'
         }`}
+        style={{ backgroundColor: customColorTheme }}
       />
     </div>
   );

--- a/src/js/components/leftPanel/dataPanel/subscribeToAlerts/SubscribeToAlerts.tsx
+++ b/src/js/components/leftPanel/dataPanel/subscribeToAlerts/SubscribeToAlerts.tsx
@@ -54,96 +54,107 @@ const SubscribeToAlerts = (props: Props): JSX.Element => {
       <p>{subtitle}</p>
       <div className="options-container">
         <ul>
-          <li>
-            <input
-              type="checkbox"
-              name={VIIRSLabel}
-              value={VIIRSField}
-              checked={selectedAlerts.includes(VIIRSField)}
-              onChange={(e: ChangeEvent<HTMLInputElement>): void =>
-                setAlerts(e.target.value)
-              }
-            />
-            <label>{VIIRSLabel}</label>
-          </li>
-          <li>
-            <input
-              type="checkbox"
-              name={GLADLabel}
-              value={GLADField}
-              checked={selectedAlerts.includes(GLADField)}
-              onChange={(e: ChangeEvent<HTMLInputElement>): void =>
-                setAlerts(e.target.value)
-              }
-            />
-            <label>{GLADLabel}</label>
-          </li>
-          <li>
-            <input
-              type="checkbox"
-              name={FORMALabel}
-              value={FORMAField}
-              checked={selectedAlerts.includes(FORMAField)}
-              onChange={(e: ChangeEvent<HTMLInputElement>): void =>
-                setAlerts(e.target.value)
-              }
-            />
-            <label>{FORMALabel}</label>
-          </li>
-          <li>
-            <input
-              type="checkbox"
-              name={PRODESLabel}
-              value={PRODESField}
-              checked={selectedAlerts.includes(PRODESField)}
-              onChange={(e: ChangeEvent<HTMLInputElement>): void =>
-                setAlerts(e.target.value)
-              }
-            />
-            <label>{PRODESLabel}</label>
-          </li>
-          <li>
-            <input
-              type="checkbox"
-              name={treeCoverLossLabel}
-              value={treeCoverLossField}
-              checked={selectedAlerts.includes(treeCoverLossField)}
-              onChange={(e: ChangeEvent<HTMLInputElement>): void =>
-                setAlerts(e.target.value)
-              }
-            />
-            <label>{treeCoverLossLabel}</label>
-          </li>
-          <li>
-            <input
-              type="checkbox"
-              name={SADLabel}
-              value={SADField}
-              checked={selectedAlerts.includes(SADField)}
-              onChange={(e: ChangeEvent<HTMLInputElement>): void =>
-                setAlerts(e.target.value)
-              }
-            />
-            <label>{SADLabel}</label>
-          </li>
-          <li>
-            <input
-              type="checkbox"
-              name={TERRALabel}
-              value={TERRAField}
-              checked={selectedAlerts.includes(TERRAField)}
-              onChange={(e: ChangeEvent<HTMLInputElement>): void =>
-                setAlerts(e.target.value)
-              }
-            />
-            <label>{TERRALabel}</label>
-          </li>
+          <div className="column">
+            <li>
+              <input
+                type="checkbox"
+                name={VIIRSLabel}
+                value={VIIRSField}
+                checked={selectedAlerts.includes(VIIRSField)}
+                onChange={(e: ChangeEvent<HTMLInputElement>): void =>
+                  setAlerts(e.target.value)
+                }
+              />
+              <label>{VIIRSLabel}</label>
+            </li>
+            <li>
+              <input
+                type="checkbox"
+                name={GLADLabel}
+                value={GLADField}
+                checked={selectedAlerts.includes(GLADField)}
+                onChange={(e: ChangeEvent<HTMLInputElement>): void =>
+                  setAlerts(e.target.value)
+                }
+              />
+              <label>{GLADLabel}</label>
+            </li>
+          </div>
+          <div className="column">
+            <li>
+              <input
+                type="checkbox"
+                name={FORMALabel}
+                value={FORMAField}
+                checked={selectedAlerts.includes(FORMAField)}
+                onChange={(e: ChangeEvent<HTMLInputElement>): void =>
+                  setAlerts(e.target.value)
+                }
+              />
+              <label>{FORMALabel}</label>
+            </li>
+            <li>
+              <input
+                type="checkbox"
+                name={PRODESLabel}
+                value={PRODESField}
+                checked={selectedAlerts.includes(PRODESField)}
+                onChange={(e: ChangeEvent<HTMLInputElement>): void =>
+                  setAlerts(e.target.value)
+                }
+              />
+              <label>{PRODESLabel}</label>
+            </li>
+          </div>
+          <div className="column">
+            <li>
+              <input
+                type="checkbox"
+                name={treeCoverLossLabel}
+                value={treeCoverLossField}
+                checked={selectedAlerts.includes(treeCoverLossField)}
+                onChange={(e: ChangeEvent<HTMLInputElement>): void =>
+                  setAlerts(e.target.value)
+                }
+              />
+              <label>{treeCoverLossLabel}</label>
+            </li>
+            <li>
+              <input
+                type="checkbox"
+                name={SADLabel}
+                value={SADField}
+                checked={selectedAlerts.includes(SADField)}
+                onChange={(e: ChangeEvent<HTMLInputElement>): void =>
+                  setAlerts(e.target.value)
+                }
+              />
+              <label>{SADLabel}</label>
+            </li>
+          </div>
+          <div className="column">
+            <li>
+              <input
+                type="checkbox"
+                name={TERRALabel}
+                value={TERRAField}
+                checked={selectedAlerts.includes(TERRAField)}
+                onChange={(e: ChangeEvent<HTMLInputElement>): void =>
+                  setAlerts(e.target.value)
+                }
+              />
+              <label>{TERRALabel}</label>
+            </li>
+          </div>
         </ul>
       </div>
+
       <button
         onClick={(): void => setNextStep()}
         disabled={selectedAlerts.length ? false : true}
-        className="esri-icon-right-arrow"
+        className={`orange-button custom esri-icon-right-arrow ${
+          selectedAlerts.length ? '' : 'inactive'
+        }`}
       />
     </div>
   );

--- a/src/js/components/leftPanel/dataPanel/subscribeToAlerts/SubscriptionSaved.tsx
+++ b/src/js/components/leftPanel/dataPanel/subscribeToAlerts/SubscriptionSaved.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { renderModal } from 'js/store/appState/actions';
 
+import { RootState } from 'js/store/index';
+
 const SubscriptionSaved = (): JSX.Element => {
   const dispatch = useDispatch();
+
+  const customColorTheme = useSelector(
+    (store: RootState) => store.appSettings.customColorTheme
+  );
 
   return (
     <div className="subscription-saved-container">
@@ -28,6 +34,7 @@ const SubscriptionSaved = (): JSX.Element => {
       <button
         onClick={(): any => dispatch(renderModal('SubscriptionWidget'))}
         className="orange-button custom"
+        style={{ backgroundColor: customColorTheme }}
       >
         OK
       </button>

--- a/src/js/components/leftPanel/dataPanel/subscribeToAlerts/SubscriptionSaved.tsx
+++ b/src/js/components/leftPanel/dataPanel/subscribeToAlerts/SubscriptionSaved.tsx
@@ -10,18 +10,25 @@ const SubscriptionSaved = (): JSX.Element => {
     <div className="subscription-saved-container">
       <h3>Subscription saved!</h3>
       <p>
-        This subscription has been added to your profile. Please check your
-        email and click on the link to confirm your subscription. Visit your
+        This subscription has been added to your profile.{' '}
+        <strong>
+          Please check your email and click on the link to confirm your
+          subscription
+        </strong>
+        . Visit your
         <a
           href="https://www.globalforestwatch.org/my-gfw"
           rel="noopener noreferrer"
           target="_blank"
         >
-          saved subscriptions
+          <strong> saved subscriptions </strong>
         </a>
         to manage them.
       </p>
-      <button onClick={(): any => dispatch(renderModal('SubscriptionWidget'))}>
+      <button
+        onClick={(): any => dispatch(renderModal('SubscriptionWidget'))}
+        className="orange-button custom"
+      >
         OK
       </button>
     </div>

--- a/src/js/components/modal/modalCard.tsx
+++ b/src/js/components/modal/modalCard.tsx
@@ -76,6 +76,8 @@ const ModalCard: FunctionComponent<{}> = () => {
         return 'info-content';
       case 'SubscriptionWidget':
         return 'subscription-widget';
+      case 'AlertCarousel':
+        return 'alert-carousel';
       default:
         return '';
     }


### PR DESCRIPTION
This PR styles the subscribe to alerts feature. Fixes #1024 

What it accomplishes;
- matches comps
- improved UI/UX - back/forward buttons, form validation

What it doesn't accomplish;
- pixel perfection (but it's close) - I noticed this feature leans on `display: block` on `PROD` so I implemented flex grid instead. Styled to align with comps closely