### PR TITLE
Ticket 1029 - google analytics integration

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,9 +22,6 @@
         'https://www.google-analytics.com/analytics.js',
         'ga'
       );
-
-      ga('create', 'UA-62288390-15', 'auto');
-      ga('send', 'pageview');
     </script>
     <!-- End Google Analytics -->
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,32 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <!-- Google Analytics -->
+    <script>
+      (function(i, s, o, g, r, a, m) {
+        i['GoogleAnalyticsObject'] = r;
+        (i[r] =
+          i[r] ||
+          function() {
+            (i[r].q = i[r].q || []).push(arguments);
+          }),
+          (i[r].l = 1 * new Date());
+        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
+      })(
+        window,
+        document,
+        'script',
+        'https://www.google-analytics.com/analytics.js',
+        'ga'
+      );
+
+      ga('create', 'UA-62288390-15', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <!-- End Google Analytics -->
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta
       name="viewport"

--- a/src/js/components/App.tsx
+++ b/src/js/components/App.tsx
@@ -35,6 +35,9 @@ const App = (props: AppSettings | any): JSX.Element => {
   const sharinghost = useSelector(
     (store: RootState) => store.appSettings.sharinghost
   );
+  const analyticsCode = useSelector(
+    (store: RootState) => store.appSettings.analyticsCode
+  );
   //INIT with global spinner set to true
   const [showGlobalSpinner, setShowGlobalSpinner] = useState(true);
   const dispatch = useDispatch();
@@ -105,6 +108,11 @@ const App = (props: AppSettings | any): JSX.Element => {
       setShowGlobalSpinner(false);
     }
   }, [dispatch, props]); //dispatch should never update and this useEffect should fire only once, adding per eslint rule warning
+
+  useEffect(() => {
+    window['ga']('create', analyticsCode, 'auto');
+    window['ga']('send', 'pageview');
+  }, [analyticsCode]);
 
   const modalType = useSelector(
     (store: RootState) => store.appState.renderModal

--- a/src/js/store/appSettings/reducers.ts
+++ b/src/js/store/appSettings/reducers.ts
@@ -7,6 +7,7 @@ const initialState: AppSettings = {
   logoUrl: 'https://my.gfw-mapbuilder.org/img/gfw-logo.png',
   logoLinkUrl: 'https://developers.globalforestwatch.org/map-builder/',
   useAlternativeLanguage: false,
+  analyticsCode: 'UA-62288390-15',
   alternativeWebmap: '',
   alternativeLanguage: 'fr',
   includeMyGFWLogin: true,

--- a/src/js/store/appSettings/types.ts
+++ b/src/js/store/appSettings/types.ts
@@ -6,6 +6,7 @@ export interface AppSettings {
   subtitle?: string;
   logoUrl?: string;
   logoLinkUrl?: string;
+  analyticsCode: string;
   language: string;
   includeDocumentsTab?: boolean;
   layerPanel: LayerGroup;


### PR DESCRIPTION
This PR integrates google analytics and ensures the uniqueID is maintained by config. 
Fixes part of #1029 

What it accomplishes;
- default `analyticsCode` is the code used in PROD
- default is overwritten dynamically by config

What it doesn't accomplish;
- doesn't yet send events to a GA dashboard (coming soon!)