### PR TITLE
Swap vega link to CDN link to be ready for PROD

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
     />
     <meta name="mobile-web-app-capable" content="yes" />
     <title>GFW Mapbuilder</title>
-    <script src="https://vega.github.io/vega/vega.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/vega@5"></script>
   </head>
   <body>
     <noscript> JavaScript is required in order to use this app </noscript>

--- a/src/library.html
+++ b/src/library.html
@@ -8,7 +8,7 @@
     />
     <meta name="mobile-web-app-capable" content="yes" />
     <title>GFW Mapbuilder Library</title>
-    <script src="https://vega.github.io/vega/vega.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/vega@5"></script>
   </head>
   <body>
     <div id="lib-main"></div>


### PR DESCRIPTION
Swapping vega chart link to the one that is CDN. Based on their docs, that is what we should be using.

Partially related and addressing this: #963 