### PR TITLE
Ticket 880 - draw message

### DIFF
--- a/src/css/popup.scss
+++ b/src/css/popup.scss
@@ -1,0 +1,34 @@
+@import './variables.scss';
+
+.user-point-popup-wrapper {
+  position: absolute;
+  background-color: rgb(255, 254, 229);
+  top: 50%;
+  left: 40%;
+  transform: translateX(-50%) translateY(-50%);
+  overflow: scroll;
+  padding: 1rem;
+  font-family: 'Fira Sans', sans-serif;
+  height: 6.25rem;
+  width: 6.25rem;
+  font-size: 12px;
+
+  button {
+    border: none;
+    background-color: rgb(255, 254, 229);
+    position: absolute;
+    right: 0;
+    font-size: 1rem;
+    top: 0;
+  }
+
+  .content-wrapper {
+    .header {
+      font-weight: bold;
+    }
+
+    p {
+      margin: 0.25rem 0;
+    }
+  }
+}

--- a/src/css/popup.scss
+++ b/src/css/popup.scss
@@ -6,7 +6,6 @@
   top: 50%;
   left: 40%;
   transform: translateX(-50%) translateY(-50%);
-  overflow: scroll;
   padding: 1rem;
   font-family: 'Fira Sans', sans-serif;
   height: 6.25rem;

--- a/src/js/components/MapContent.tsx
+++ b/src/js/components/MapContent.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+
 import Mapview from '../components/mapview/Mapview';
 import MapWidgets from './mapWidgets/mapWidgets';
 import Legend from './legend/Legend';
 import LeftPanel from './leftPanel/LeftPanel';
 import Footer from './Footer';
 import Report from './Report';
+import UserPointPopup from './mapWidgets/userPointPopup';
+
 import { RootState } from 'js/store';
 
 interface MapContentProps {
@@ -25,6 +28,7 @@ function determineMapContent(
         <MapWidgets />
         <Mapview />
         <Legend />
+        <UserPointPopup />
         {!hideFooter && <Footer />}
       </>
     );

--- a/src/js/components/MapContent.tsx
+++ b/src/js/components/MapContent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-
 import Mapview from '../components/mapview/Mapview';
 import MapWidgets from './mapWidgets/mapWidgets';
 import Legend from './legend/Legend';

--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -6,7 +6,10 @@ import { useSelector, useDispatch } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import { RootState } from 'js/store';
-import { setActiveFeatures } from 'js/store/mapview/actions';
+import {
+  setActiveFeatures,
+  setUserCoordinates
+} from 'js/store/mapview/actions';
 import { setRenderPopup } from 'js/store/appState/actions';
 
 import { registerGeometry } from 'js/helpers/geometryRegistration';
@@ -331,13 +334,14 @@ const BaseAnalysis = (): JSX.Element => {
   };
 
   const setSaveSketch = (): void => {
+    dispatch(setRenderPopup(false));
     mapController.removeUserPointListener();
     mapController.completeSketchVM();
     setRenderEditButton(true);
-    dispatch(setRenderPopup(false));
   };
 
   const setEditSketch = (): void => {
+    dispatch(setUserCoordinates(undefined));
     setRenderEditButton(false);
     mapController.updateSketchVM();
     mapController.getUserCoordinates();

--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -333,6 +333,9 @@ const BaseAnalysis = (): JSX.Element => {
   const setEditSketch = (): void => {
     setRenderEditButton(false);
     mapController.updateSketchVM();
+    mapController.getSketchVMCenter();
+    // ? can I grab the polygon's computer coordinates
+    // ? and use to render a popup?
   };
 
   const setDelete = (): void => {

--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 /* eslint-disable no-prototype-builtins */
 import * as React from 'react';
 import { useState, useEffect } from 'react';
@@ -19,7 +18,6 @@ import analysisTranslations from './analysisTranslations';
 import { MemoRangeSlider, MemoDatePicker } from './InputComponents';
 import CanopyDensityPicker from 'js/components/sharedComponents/CanopyDensityPicker';
 import { markValueMap } from 'js/components/mapWidgets/widgetContent/CanopyDensityContent';
-import { PrintReportButton } from 'js/components/sharedComponents/PrintReportButton';
 import { ReactComponent as DownloadIcon } from '../../../../images/downloadIcon.svg';
 import { DownloadOptions } from 'js/components/sharedComponents/DownloadOptions';
 import Loader from 'js/components/sharedComponents/Loader';
@@ -334,17 +332,16 @@ const BaseAnalysis = (): JSX.Element => {
   };
 
   const setSaveSketch = (): void => {
-    dispatch(setRenderPopup(false));
-    mapController.removeUserPointListener();
     mapController.completeSketchVM();
     setRenderEditButton(true);
+    mapController.detachMouseLocationTracking();
+    dispatch(setRenderPopup(false));
   };
 
   const setEditSketch = (): void => {
-    dispatch(setUserCoordinates(undefined));
     setRenderEditButton(false);
     mapController.updateSketchVM();
-    mapController.getUserCoordinates();
+    mapController.attachMouseLocationTracking();
     dispatch(setRenderPopup(true));
   };
 

--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -2,11 +2,15 @@
 /* eslint-disable no-prototype-builtins */
 import * as React from 'react';
 import { useState, useEffect } from 'react';
-import { createSelector } from 'reselect';
-import { RootState } from 'js/store';
 import { useSelector, useDispatch } from 'react-redux';
+import { createSelector } from 'reselect';
+
+import { RootState } from 'js/store';
 import { setActiveFeatures } from 'js/store/mapview/actions';
+import { setRenderPopup } from 'js/store/appState/actions';
+
 import { registerGeometry } from 'js/helpers/geometryRegistration';
+
 import VegaChart from './VegaChartContainer';
 import analysisTranslations from './analysisTranslations';
 import { MemoRangeSlider, MemoDatePicker } from './InputComponents';
@@ -58,6 +62,7 @@ const BaseAnalysis = (): JSX.Element => {
   const [base64ChartURL, setBase64ChartURL] = useState('');
   const [downloadOptionsVisible, setDownloadOptionsVisible] = useState(false);
   const [renderEditButton, setRenderEditButton] = useState(true);
+
   //This is used for date picker analysis module
 
   const selectedLanguage = useSelector(
@@ -326,16 +331,17 @@ const BaseAnalysis = (): JSX.Element => {
   };
 
   const setSaveSketch = (): void => {
+    mapController.removeUserPointListener();
     mapController.completeSketchVM();
     setRenderEditButton(true);
+    dispatch(setRenderPopup(false));
   };
 
   const setEditSketch = (): void => {
     setRenderEditButton(false);
     mapController.updateSketchVM();
-    mapController.getSketchVMCenter();
-    // ? can I grab the polygon's computer coordinates
-    // ? and use to render a popup?
+    mapController.getUserCoordinates();
+    dispatch(setRenderPopup(true));
   };
 
   const setDelete = (): void => {

--- a/src/js/components/mapWidgets/userPointPopup.tsx
+++ b/src/js/components/mapWidgets/userPointPopup.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import { setRenderPopup } from 'js/store/appState/actions';
+
+import { RootState } from 'js/store';
+
+const UserPointPopup = (): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const [coordinates, setCoordinates] = useState<__esri.Point | null>(null);
+
+  const userCoordinates = useSelector(
+    (state: RootState) => state.mapviewState.userCoordinates
+  );
+  const renderPopup = useSelector(
+    (state: RootState) => state.appState.renderPopup
+  );
+
+  useEffect(() => {
+    if (userCoordinates) {
+      setCoordinates(userCoordinates);
+    } else {
+      setCoordinates(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userCoordinates]);
+
+  console.log('userCoordinates', userCoordinates);
+
+  return renderPopup ? (
+    <div
+      className="user-point-popup-wrapper"
+      style={{
+        position: 'absolute',
+        float: 'left',
+        width: '15rem',
+        height: '10rem',
+        backgroundColor: 'rgb(255,254,229)',
+        top: '50%',
+        left: '35%',
+        transform: 'translateX(-50%) translateY(-50%)'
+      }}
+    >
+      <button onClick={(): any => dispatch(setRenderPopup(!renderPopup))}>
+        X
+      </button>
+      <p>Coordinate Values</p>
+      <p>Decimal degrees</p>
+      {coordinates && coordinates.latitude && (
+        <p>Latitude: {coordinates.latitude}</p>
+      )}
+      {coordinates && coordinates.longitude && (
+        <p>Longitude: {coordinates.longitude}</p>
+      )}
+    </div>
+  ) : null;
+};
+
+export default UserPointPopup;

--- a/src/js/components/mapWidgets/userPointPopup.tsx
+++ b/src/js/components/mapWidgets/userPointPopup.tsx
@@ -5,9 +5,11 @@ import { setRenderPopup } from 'js/store/appState/actions';
 
 import { RootState } from 'js/store';
 
+import 'css/popup.scss';
+
 const UserPointPopup = (): JSX.Element | null => {
   const dispatch = useDispatch();
-  const [coordinates, setCoordinates] = useState<__esri.Point | null>(null);
+  const [coordinates, setCoordinates] = useState<any | null>(null);
 
   const userCoordinates = useSelector(
     (state: RootState) => state.mapviewState.userCoordinates
@@ -17,41 +19,39 @@ const UserPointPopup = (): JSX.Element | null => {
   );
 
   useEffect(() => {
-    if (userCoordinates) {
-      setCoordinates(userCoordinates);
+    if (renderPopup && userCoordinates) {
+      const latitude = (userCoordinates as any).latitude
+        .toString()
+        .match(/^-?\d+(?:\.\d{0,2})?/)[0];
+
+      const longitude = (userCoordinates as any).longitude
+        .toString()
+        .match(/^-?\d+(?:\.\d{0,2})?/)[0];
+      setCoordinates({
+        latitude,
+        longitude
+      });
     } else {
       setCoordinates(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userCoordinates]);
-
-  console.log('userCoordinates', userCoordinates);
+  }, [renderPopup, userCoordinates]);
 
   return renderPopup ? (
-    <div
-      className="user-point-popup-wrapper"
-      style={{
-        position: 'absolute',
-        float: 'left',
-        width: '15rem',
-        height: '10rem',
-        backgroundColor: 'rgb(255,254,229)',
-        top: '50%',
-        left: '35%',
-        transform: 'translateX(-50%) translateY(-50%)'
-      }}
-    >
+    <div className="user-point-popup-wrapper">
       <button onClick={(): any => dispatch(setRenderPopup(!renderPopup))}>
         X
       </button>
-      <p>Coordinate Values</p>
-      <p>Decimal degrees</p>
-      {coordinates && coordinates.latitude && (
-        <p>Latitude: {coordinates.latitude}</p>
-      )}
-      {coordinates && coordinates.longitude && (
-        <p>Longitude: {coordinates.longitude}</p>
-      )}
+      <div className="content-wrapper">
+        <p className="header">Coordinate Values</p>
+        <p>(Decimal degrees)</p>
+        {coordinates && coordinates.latitude && (
+          <p>Latitude: {coordinates.latitude}</p>
+        )}
+        {coordinates && coordinates.longitude && (
+          <p>Longitude: {coordinates.longitude}</p>
+        )}
+      </div>
     </div>
   ) : null;
 };

--- a/src/js/components/mapWidgets/userPointPopup.tsx
+++ b/src/js/components/mapWidgets/userPointPopup.tsx
@@ -7,9 +7,14 @@ import { RootState } from 'js/store';
 
 import 'css/popup.scss';
 
+interface Coordinates {
+  latitude: string;
+  longitude: string;
+}
+
 const UserPointPopup = (): JSX.Element | null => {
   const dispatch = useDispatch();
-  const [coordinates, setCoordinates] = useState<any | null>(null);
+  const [coordinates, setCoordinates] = useState<Coordinates | null>(null);
 
   const userCoordinates = useSelector(
     (state: RootState) => state.mapviewState.userCoordinates
@@ -20,13 +25,9 @@ const UserPointPopup = (): JSX.Element | null => {
 
   useEffect(() => {
     if (renderPopup && userCoordinates) {
-      const latitude = (userCoordinates as any).latitude
-        .toString()
-        .match(/^-?\d+(?:\.\d{0,2})?/)[0];
+      const latitude = userCoordinates.latitude.toFixed(2);
+      const longitude = userCoordinates.longitude.toFixed(2);
 
-      const longitude = (userCoordinates as any).longitude
-        .toString()
-        .match(/^-?\d+(?:\.\d{0,2})?/)[0];
       setCoordinates({
         latitude,
         longitude

--- a/src/js/components/mapWidgets/userPointPopup.tsx
+++ b/src/js/components/mapWidgets/userPointPopup.tsx
@@ -1,42 +1,23 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-
 import { setRenderPopup } from 'js/store/appState/actions';
-
 import { RootState } from 'js/store';
 
 import 'css/popup.scss';
 
-interface Coordinates {
-  latitude: string;
-  longitude: string;
-}
-
 const UserPointPopup = (): JSX.Element | null => {
   const dispatch = useDispatch();
-  const [coordinates, setCoordinates] = useState<Coordinates | null>(null);
 
   const userCoordinates = useSelector(
     (state: RootState) => state.mapviewState.userCoordinates
   );
+
+  const latitude = userCoordinates?.latitude.toFixed(2);
+  const longitude = userCoordinates?.longitude.toFixed(2);
+
   const renderPopup = useSelector(
     (state: RootState) => state.appState.renderPopup
   );
-
-  useEffect(() => {
-    if (renderPopup && userCoordinates) {
-      const latitude = userCoordinates.latitude.toFixed(2);
-      const longitude = userCoordinates.longitude.toFixed(2);
-
-      setCoordinates({
-        latitude,
-        longitude
-      });
-    } else {
-      setCoordinates(null);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [renderPopup, userCoordinates]);
 
   return renderPopup ? (
     <div className="user-point-popup-wrapper">
@@ -46,12 +27,8 @@ const UserPointPopup = (): JSX.Element | null => {
       <div className="content-wrapper">
         <p className="header">Coordinate Values</p>
         <p>(Decimal degrees)</p>
-        {coordinates && coordinates.latitude && (
-          <p>Latitude: {coordinates.latitude}</p>
-        )}
-        {coordinates && coordinates.longitude && (
-          <p>Longitude: {coordinates.longitude}</p>
-        )}
+        {latitude && <p>Latitude: {latitude}</p>}
+        {longitude && <p>Longitude: {longitude}</p>}
       </div>
     </div>
   ) : null;

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -857,7 +857,9 @@ export class MapController {
         const userPoint = this._mapview.toMap({ x: event.x, y: event.y });
 
         const userHovering = allGeometries.map((geometry: Geometry) => {
-          return geometryEngine.contains(geometry, userPoint);
+          const intersects = geometryEngine.intersects(geometry, userPoint);
+          const contains = geometryEngine.contains(geometry, userPoint);
+          return intersects || contains;
         });
 
         if (userHovering.includes(true)) {

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -2,8 +2,11 @@ import Map from 'esri/Map';
 import Layer from 'esri/layers/Layer';
 import MapView from 'esri/views/MapView';
 import WebMap from 'esri/WebMap';
+import geometryEngine from 'esri/geometry/geometryEngine';
+import Geometry from 'esri/geometry/Geometry';
 import Graphic from 'esri/Graphic';
 import GraphicsLayer from 'esri/layers/GraphicsLayer';
+import Extent from 'esri/geometry/Extent';
 import SketchViewModel from 'esri/widgets/Sketch/SketchViewModel';
 import DistanceMeasurement2D from 'esri/widgets/DistanceMeasurement2D';
 import CoordinateConversion from 'esri/widgets/CoordinateConversion';
@@ -834,6 +837,45 @@ export class MapController {
 
   deleteSketchVM(): void {
     this._sketchVM?.emit('delete');
+  }
+
+  getSketchVMCenter(): any {
+    let allRings: Array<Array<number>> = [];
+
+    if (this._sketchVMGraphicsLayer) {
+      this._sketchVMGraphicsLayer.graphics['items'].forEach(
+        (item: any) => (allRings = allRings.concat(...item.geometry.rings))
+      );
+
+      // console.log('allRings', allRings);
+    }
+
+    if (allRings.length) {
+      this._mapview.on('pointer-move', event => {
+        const point = this._mapview.toMap({ x: event.x, y: event.y });
+        // console.log('pointttt', point);
+        // console.log('allRingssss', allRings);
+        // ? Can I use geometryEngine
+        // ? to determine if the sketchVM contains the constant point?
+
+        const userHovering = allRings.map((ring: any) => {
+          const [ringLat, ringLong] = ring;
+
+          return (
+            Math.round(ringLat) === Math.round(point.x) &&
+            Math.round(ringLong) === Math.round(point.y)
+          );
+        });
+
+        // console.log('userHovering', userHovering);
+
+        if (userHovering.includes(true)) {
+          console.log('USER IS HOVERINGGG!!!');
+          console.log('allRings', allRings);
+          console.log('pointer-move', event);
+        }
+      });
+    }
   }
 
   updateSketchVM(): any {

--- a/src/js/store/appState/actions.ts
+++ b/src/js/store/appState/actions.ts
@@ -24,7 +24,8 @@ import {
   SET_VIIRS_START,
   SET_VIIRS_END,
   SET_MODIS_START,
-  SET_MODIS_END
+  SET_MODIS_END,
+  SET_RENDER_POPUP
 } from './types';
 
 export function setSelectedSearchWidgetLayer(
@@ -201,6 +202,13 @@ export function setViirsStart(payload: AppState['leftPanel']['viirsStart']) {
 export function setViirsEnd(payload: AppState['leftPanel']['viirsEnd']) {
   return {
     type: SET_VIIRS_END as typeof SET_VIIRS_END,
+    payload: payload
+  };
+}
+
+export function setRenderPopup(payload: AppState['renderPopup']) {
+  return {
+    type: SET_RENDER_POPUP as typeof SET_RENDER_POPUP,
     payload: payload
   };
 }

--- a/src/js/store/appState/reducers.ts
+++ b/src/js/store/appState/reducers.ts
@@ -26,7 +26,8 @@ import {
   SET_MODIS_START,
   SET_MODIS_END,
   SET_VIIRS_START,
-  SET_VIIRS_END
+  SET_VIIRS_END,
+  SET_RENDER_POPUP
 } from './types';
 
 const initialState: AppState = {
@@ -63,7 +64,8 @@ const initialState: AppState = {
     distanceResults: {},
     coordinateMouseClickResults: {},
     coordinatePointerMoveResults: {}
-  }
+  },
+  renderPopup: false
 };
 
 export function appStateReducer(
@@ -225,6 +227,11 @@ export function appStateReducer(
           ...state.leftPanel,
           viirsEnd: action.payload
         }
+      };
+    case SET_RENDER_POPUP:
+      return {
+        ...state,
+        renderPopup: action.payload
       };
     default:
       return state;

--- a/src/js/store/appState/types.ts
+++ b/src/js/store/appState/types.ts
@@ -53,6 +53,7 @@ export interface AppState {
   hideWidgetActive: boolean;
   isLoggedIn: boolean;
   selectedSearchWidgetLayer: SelectedSearchWidgetLayer;
+  renderPopup: boolean;
 }
 
 //Action names available
@@ -81,6 +82,7 @@ export const SET_VIIRS_START = 'SET_VIIRS_START';
 export const SET_VIIRS_END = 'SET_VIIRS_END';
 export const SET_MODIS_START = 'SET_MODIS_START';
 export const SET_MODIS_END = 'SET_MODIS_END';
+export const SET_RENDER_POPUP = 'SET_RENDER_POPUP';
 
 interface SetSelectedSearchWidgetLayer {
   type: typeof SET_SELECTED_SEARCH_WIDGET_LAYER;
@@ -202,6 +204,11 @@ interface SetViirsEnd {
   payload: AppState['leftPanel']['viirsEnd'];
 }
 
+interface SetRenderPopup {
+  type: typeof SET_RENDER_POPUP;
+  payload: AppState['renderPopup'];
+}
+
 export type AppStateTypes =
   | ToggleTabviewPanelAction
   | RenderModalAction
@@ -226,4 +233,5 @@ export type AppStateTypes =
   | SetModisStart
   | SetModisEnd
   | SetViirsStart
-  | SetViirsEnd;
+  | SetViirsEnd
+  | SetRenderPopup;

--- a/src/js/store/mapview/actions.ts
+++ b/src/js/store/mapview/actions.ts
@@ -10,6 +10,7 @@ import {
   CHANGE_MAP_SCALE,
   CHANGE_MAP_CENTER_COORDINATES,
   SET_LAYERS_LOADING,
+  SET_USER_COORDINATES,
   MapviewState
 } from './types';
 
@@ -97,5 +98,12 @@ export function setLayersLoading(
   return {
     type: SET_LAYERS_LOADING as typeof SET_LAYERS_LOADING,
     payload: mapCenterCoordinates
+  };
+}
+
+export function setUserCoordinates(payload: MapviewState['userCoordinates']) {
+  return {
+    type: SET_USER_COORDINATES as typeof SET_USER_COORDINATES,
+    payload
   };
 }

--- a/src/js/store/mapview/reducers.ts
+++ b/src/js/store/mapview/reducers.ts
@@ -11,7 +11,8 @@ import {
   SET_TIME_SLIDER,
   CHANGE_MAP_SCALE,
   CHANGE_MAP_CENTER_COORDINATES,
-  SET_LAYERS_LOADING
+  SET_LAYERS_LOADING,
+  SET_USER_COORDINATES
 } from './types';
 
 const initialState: MapviewState = {
@@ -25,7 +26,8 @@ const initialState: MapviewState = {
   timeSlider: [2000, 2018],
   scale: 0,
   mapCenterCoordinates: { latitude: 0, longitude: 0 },
-  layersLoading: true
+  layersLoading: true,
+  userCoordinates: undefined
 };
 
 export function mapviewReducer(
@@ -55,6 +57,8 @@ export function mapviewReducer(
       return { ...state, mapCenterCoordinates: action.payload };
     case SET_LAYERS_LOADING:
       return { ...state, layersLoading: action.payload };
+    case SET_USER_COORDINATES:
+      return { ...state, userCoordinates: action.payload };
     default:
       return state;
   }

--- a/src/js/store/mapview/types.ts
+++ b/src/js/store/mapview/types.ts
@@ -61,6 +61,7 @@ export interface MapviewState {
   scale: number;
   mapCenterCoordinates: { latitude: number; longitude: number };
   layersLoading: boolean;
+  userCoordinates: __esri.Point | undefined;
 }
 
 interface Popup {
@@ -150,7 +151,12 @@ export const SET_TIME_SLIDER = 'SET_TIME_SLIDER';
 export const CHANGE_MAP_SCALE = 'CHANGE_MAP_SCALE';
 export const CHANGE_MAP_CENTER_COORDINATES = 'CHANGE_MAP_CENTER_COORDINATES';
 export const SET_LAYERS_LOADING = 'SET_LAYERS_LOADING';
+export const SET_USER_COORDINATES = 'SET_USER_COORDINATES';
 
+interface SetUserPoint {
+  type: typeof SET_USER_COORDINATES;
+  payload: __esri.Point | undefined;
+}
 interface MapIsReadyAction {
   type: typeof MAP_READY;
   payload: boolean;
@@ -216,4 +222,5 @@ export type MapviewStateTypes =
   | SetTimeSlider
   | ChangeMapScale
   | ChangeMapCenterCoordinates
-  | SetLayersLoading;
+  | SetLayersLoading
+  | SetUserPoint;


### PR DESCRIPTION
This PR implements a workaround to ticket #880 

What it accomplishes;
- When a user's mouse hovers over their drawn polygon, and the polygon is in edit mode, a popup will appear with the lat/long info
- styled to match comps

What it doesn't accomplish;
- does not match PROD logic (couldn't figure out how to get the popup to appear only when the mouse hovers over a point in the drawn polygon)
