### PR TITLE
Multi Poly Fix

### DIFF
--- a/src/js/components/Report.tsx
+++ b/src/js/components/Report.tsx
@@ -45,6 +45,9 @@ const Report = (props: ReportProps): JSX.Element => {
   const [sublayerTitle, setSublayerTitle] = React.useState('');
   const [layerTitle, setLayerTitle] = React.useState('');
   const [attributes, setAttributes] = React.useState<null | object>(null);
+  const [hideAttributeTable, setHideAttributeTable] = React.useState<boolean>(
+    false
+  );
 
   const isMapReady = useSelector(
     (store: RootState) => store.mapviewState.isMapReady
@@ -131,14 +134,20 @@ const Report = (props: ReportProps): JSX.Element => {
         'objectid'
       );
 
-      const { activeLayer, activeLayerInfo }: any = extractLayerInfo(
-        layerID,
-        sublayerID,
-        allAvailableLayers,
-        mapController._map
-      );
-
-      getFeatures(activeLayer, activeLayerInfo, objectID);
+      // ObjectID comes in as undefined in certain cases such as when report is loaded with user drawn or user uploaded polygon feature, in those cases we do not need attribute table loaded so this will short-circuit the
+      // logic below and prevent breaking attribute table logic
+      if (objectID !== 'undefined') {
+        const { activeLayer, activeLayerInfo }: any = extractLayerInfo(
+          layerID,
+          sublayerID,
+          allAvailableLayers,
+          mapController._map
+        );
+        getFeatures(activeLayer, activeLayerInfo, objectID);
+      } else {
+        setAttributes({});
+        setHideAttributeTable(true);
+      }
     }
   }, [featureGeometry, layersLoading]);
 
@@ -194,7 +203,7 @@ const Report = (props: ReportProps): JSX.Element => {
           <>
             <p className="analysis-title">AREA OF ANALYSIS</p>
             <p className="analysis-subtitle">{layerTitle}</p>
-            <ReportTable attr={attributes} />
+            {!hideAttributeTable && <ReportTable attr={attributes} />}
           </>
         )}
       </div>

--- a/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
+++ b/src/js/components/leftPanel/analysisPanel/BaseAnalysis.tsx
@@ -328,7 +328,7 @@ const BaseAnalysis = (): JSX.Element => {
 
   const setEditSketch = (): void => {
     setRenderEditButton(false);
-    mapController.updateSketchVM();
+    mapController.updateSketchVM(activeFeatureIndex[1]);
   };
 
   const setDelete = (): void => {

--- a/src/js/components/leftPanel/dataPanel/DataTabView.tsx
+++ b/src/js/components/leftPanel/dataPanel/DataTabView.tsx
@@ -73,6 +73,8 @@ const DataTabView = (props: DataTabProps): JSX.Element => {
           activeLayerInfo.layerID !== 'upload_file_features'
         ) {
           mapController.drawGraphic(activeFeature);
+        } else {
+          mapController.updateActivePolyGraphic(activeFeature);
         }
 
         dispatch(setActiveFeatureIndex([activeLayerIndex, newPage]));

--- a/src/js/components/report/ReportUtils.ts
+++ b/src/js/components/report/ReportUtils.ts
@@ -26,7 +26,7 @@ export function extractLayerInfo(
 
   //Find the layer on the map and construct output object to be consumed for queries
   const activeLayerInfo = {} as any;
-  if (activeLayer.parentID) {
+  if (activeLayer?.parentID) {
     activeLayerInfo.sublayer = true;
     const parentLayer: any = map.findLayerById(activeLayer.parentID);
     activeLayerInfo.parentLayer = parentLayer;

--- a/src/js/components/sharedComponents/UploadFile.tsx
+++ b/src/js/components/sharedComponents/UploadFile.tsx
@@ -131,9 +131,13 @@ const UploadFile = (): JSX.Element => {
             const shapeFileFeatures: LayerFeatureResult = {
               layerID: 'user_features',
               layerTitle: 'Upload File Features',
-              features: arcGISResults.map((g: __esri.Graphic) => {
-                return { attributes: g.attributes, geometry: g.geometry };
-              }),
+              features: arcGISResults.map(
+                (g: __esri.Graphic, index: number) => {
+                  const attr = g.attributes;
+                  attr['attributeIndex'] = index;
+                  return { attributes: attr, geometry: g.geometry };
+                }
+              ),
               fieldNames: null
             };
 

--- a/src/js/components/sharedComponents/UploadFile.tsx
+++ b/src/js/components/sharedComponents/UploadFile.tsx
@@ -129,7 +129,7 @@ const UploadFile = (): JSX.Element => {
         .then((registeredGeometries: any) => {
           if (registeredGeometries.length) {
             const shapeFileFeatures: LayerFeatureResult = {
-              layerID: 'upload_file_features',
+              layerID: 'user_features',
               layerTitle: 'Upload File Features',
               features: arcGISResults.map((g: __esri.Graphic) => {
                 return { attributes: g.attributes, geometry: g.geometry };

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -312,6 +312,7 @@ export class MapController {
             ...modisLayers,
             ...esriRemoteLayers
           ];
+          this.initializeAndSetSketch();
 
           //If we have report active, we need to know when our feature layer has loaded
           const report = new URL(window.location.href).searchParams.get(
@@ -367,8 +368,6 @@ export class MapController {
 
           //Extra layer group that acts as a "masked" layers with which you cannot interact
           this.addExtraLayers();
-
-          this.initializeAndSetSketch();
         },
         (error: Error) => {
           console.log('error in re-initializeMap()', error);
@@ -901,11 +900,12 @@ export class MapController {
   initializeAndSetSketch(graphics = []): void {
     if (this._sketchVMGraphicsLayer) {
       this._sketchVMGraphicsLayer.graphics.removeAll();
+    } else {
+      this._sketchVMGraphicsLayer = new GraphicsLayer({
+        id: 'user_features'
+      });
+      this._map?.add(this._sketchVMGraphicsLayer);
     }
-
-    this._sketchVMGraphicsLayer = new GraphicsLayer({
-      id: 'sketchGraphics'
-    });
 
     if (graphics.length) {
       this._sketchVMGraphicsLayer.graphics.addMany(graphics);
@@ -920,8 +920,6 @@ export class MapController {
         width: 3
       }
     });
-
-    this._map?.add(this._sketchVMGraphicsLayer);
 
     this._sketchVM?.on('create', (event: any) => {
       if (event.state === 'complete') {

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -189,7 +189,7 @@ export class MapController {
             const clickGeo = event.mapPoint;
             const userFeatLayer = this._map?.findLayerById(
               'user_features'
-            ) as GraphicsLayer;
+            ) as any;
             //@ts-ignore
             if (userFeatLayer && userFeatLayer?.graphics?.items.length) {
               //@ts-ignore
@@ -200,6 +200,27 @@ export class MapController {
               );
               if (!clickedWithinUserFeature) {
                 queryLayersForFeatures(this._mapview, this._map, event);
+              } else {
+                //display drawn/uploaded feature as active feature
+                const drawnFeatures: LayerFeatureResult = {
+                  layerID: 'user_features',
+                  layerTitle: 'User Features',
+                  features: [
+                    {
+                      objectid: 1,
+                      //@ts-ignore
+                      attributes: this._sketchVMGraphicsLayer?.graphics.items[0]
+                        .attributes,
+                      //@ts-ignore
+                      geometry: this._sketchVMGraphicsLayer?.graphics.items[0]
+                        .geometry
+                    }
+                  ],
+                  fieldNames: null
+                };
+                store.dispatch(setActiveFeatures([drawnFeatures]));
+                store.dispatch(setActiveFeatureIndex([0, 0]));
+                store.dispatch(selectActiveTab('analysis'));
               }
             } else {
               queryLayersForFeatures(this._mapview, this._map, event);
@@ -616,6 +637,27 @@ export class MapController {
           );
           if (!clickedWithinUserFeature) {
             queryLayersForFeatures(this._mapview, this._map, event);
+          } else {
+            //display drawn/uploaded feature as active feature
+            const drawnFeatures: LayerFeatureResult = {
+              layerID: 'user_features',
+              layerTitle: 'User Features',
+              features: [
+                {
+                  objectid: 1,
+                  //@ts-ignore
+                  attributes: this._sketchVMGraphicsLayer?.graphics.items[0]
+                    .attributes,
+                  //@ts-ignore
+                  geometry: this._sketchVMGraphicsLayer?.graphics.items[0]
+                    .geometry
+                }
+              ],
+              fieldNames: null
+            };
+            store.dispatch(setActiveFeatures([drawnFeatures]));
+            store.dispatch(setActiveFeatureIndex([0, 0]));
+            store.dispatch(selectActiveTab('analysis'));
           }
         } else {
           queryLayersForFeatures(this._mapview, this._map, event);

--- a/src/js/helpers/MapGraphics.ts
+++ b/src/js/helpers/MapGraphics.ts
@@ -112,44 +112,50 @@ export function setNewGraphic({
 
   if (isUploadFile) {
     projection.load().then(() => {
-      const allGraphics = allFeatures.map((feature: FeatureResult) => {
-        const isPolygon =
-          (feature.geometry as any).rings ||
-          feature.geometry.type === 'polygon';
+      const allGraphics = allFeatures.map(
+        (feature: FeatureResult, index: number) => {
+          const isPolygon =
+            (feature.geometry as any).rings ||
+            feature.geometry.type === 'polygon';
 
-        /**
-         * * NOTE:
-         * * File uploads don't have a geometry.type,
-         * * so we have to check if it has geometry.rings
-         */
+          /**
+           * * NOTE:
+           * * File uploads don't have a geometry.type,
+           * * so we have to check if it has geometry.rings
+           */
 
-        const symbol = isPolygon
-          ? setSymbol('polygon')
-          : setSymbol(feature.geometry.type);
+          const symbol = isPolygon
+            ? setSymbol('polygon')
+            : setSymbol(feature.geometry.type);
 
-        const geometry = isPolygon
-          ? setGeometry('polygon', feature.geometry)
-          : setGeometry(feature.geometry.type, feature.geometry);
+          if (index === 0) {
+            //First feature is "active" by default > change it to appropriate color
+            symbol.outline.color = [115, 252, 253];
+          }
+          const geometry = isPolygon
+            ? setGeometry('polygon', feature.geometry)
+            : setGeometry(feature.geometry.type, feature.geometry);
 
-        const featureGraphic = new Graphic({
-          geometry: geometry,
-          attributes: feature.attributes,
-          symbol: symbol
-        });
+          const featureGraphic = new Graphic({
+            geometry: geometry,
+            attributes: feature.attributes,
+            symbol: symbol
+          });
 
-        const transformation = projection.getTransformation(
-          featureGraphic.geometry.spatialReference,
-          mapController._mapview.spatialReference
-        );
+          const transformation = projection.getTransformation(
+            featureGraphic.geometry.spatialReference,
+            mapController._mapview.spatialReference
+          );
 
-        featureGraphic.geometry = projection.project(
-          featureGraphic.geometry,
-          mapController._mapview.spatialReference,
-          transformation
-        ) as __esri.Geometry;
+          featureGraphic.geometry = projection.project(
+            featureGraphic.geometry,
+            mapController._mapview.spatialReference,
+            transformation
+          ) as __esri.Geometry;
 
-        return featureGraphic;
-      });
+          return featureGraphic;
+        }
+      );
 
       graphicsLayer.graphics.push(...allGraphics);
       mapController.initializeAndSetSketch(graphicsLayer.graphics);


### PR DESCRIPTION
Fix for #974

This PR fixes multiple issues with draw widget and upload file features
* No longer queries are fired when user clicks on drawn/uploaded geometry
* User can select drawn/uploaded geometry with mouse click.
* Selected  and deselected features persist, meaning that users can bounce back from selecting layer features to selecting drawn features
* Users can cycle through uploaded multiple polygons with NEXT / PREV buttons as expected
* Users can edit drawn/upload geometries with EDIT button as expected
* Fixing report bug where drawn/upload geometry would break the report