### PR TITLE
Ticket 1035 - lighthouse accessibility score

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,10 +25,7 @@
     </script>
     <!-- End Google Analytics -->
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="mobile-web-app-capable" content="yes" />
     <title>GFW Mapbuilder</title>
     <script defer src="https://cdn.jsdelivr.net/npm/vega@5"></script>

--- a/src/js/components/header/LanguageDropdown.tsx
+++ b/src/js/components/header/LanguageDropdown.tsx
@@ -47,18 +47,20 @@ function valueToLang(abbrev: string): string {
 const LanguageDropdown = (props: DropProps) => {
   return (
     <div className="language-dropdown-container">
-      <ul className="dropdown">
-        <span className="label-wrapper">
+      <ul className="dropdown" role="list">
+        <span className="label-wrapper" role="listitem">
           <InfoBoxIcon height={16} width={16} fill={'#555'} />
           <li className="dropdown-label">
             {headerContent[props.selectedLanguage].language}
           </li>
         </span>
-        <ul className="options">
+        <ul className="options" role="listitem">
           <li
             role="button"
             aria-labelledby="dropdown-label"
-            id="dropdown__selected"
+            id={`dropdown__selected ${
+              headerContent[props.selectedLanguage].language
+            }`}
             tabIndex={0}
             onClick={(): void => mapController.changeLanguage(props.language)}
             className={
@@ -70,7 +72,7 @@ const LanguageDropdown = (props: DropProps) => {
           <li
             role="button"
             aria-labelledby="dropdown-label"
-            id="dropdown__selected"
+            id={`dropdown__selected ${props.alternativeLanguage}`}
             tabIndex={0}
             onClick={(): void =>
               mapController.changeLanguage(props.alternativeLanguage)

--- a/src/js/components/header/ThemeDropdown.tsx
+++ b/src/js/components/header/ThemeDropdown.tsx
@@ -42,7 +42,7 @@ const ThemeDropdown = (props: ThemeDropdownProps): JSX.Element => {
         key={index}
         role="button"
         aria-labelledby="dropdown-label"
-        id="dropdown__selected"
+        id={`dropdown__selected label_${index}`}
         tabIndex={0}
         onClick={(): void => handleThemeSelection(id)}
         className={activeTheme === id ? 'selected' : ''}
@@ -62,7 +62,7 @@ const ThemeDropdown = (props: ThemeDropdownProps): JSX.Element => {
   return (
     <div className="theme-dropdown-container">
       <ul className="dropdown">
-        <span className="label-wrapper">
+        <span className="label-wrapper" role="listitem">
           <ThemesIcon height={16} width={16} fill={'#555'} />
           <li className="dropdown-label">
             {headerContent[props.selectedLanguage]?.mapThemes}

--- a/src/js/components/leftPanel/LeftPanel.tsx
+++ b/src/js/components/leftPanel/LeftPanel.tsx
@@ -96,6 +96,7 @@ const Tab = (props: TabProps): React.ReactElement => {
             ? 'tab-button tab-button__active'
             : 'tab-button'
         }
+        aria-label="left panel tab"
         onClick={handleTabClick}
       >
         <Icon width={25} height={25} fill={'#555'} className={setClassName()} />

--- a/src/js/components/mapWidgets/hideWidget.tsx
+++ b/src/js/components/mapWidgets/hideWidget.tsx
@@ -20,7 +20,11 @@ const HideWidget: FunctionComponent = () => {
   return (
     <>
       <div className="widget-container">
-        <button className="image-wrapper" onClick={toggleContent}>
+        <button
+          className="image-wrapper"
+          aria-label="hide left panel and legend"
+          onClick={toggleContent}
+        >
           <HideIcon height={25} width={25} fill={'#555'} />
         </button>
       </div>

--- a/src/js/components/mapWidgets/measureWidget.tsx
+++ b/src/js/components/mapWidgets/measureWidget.tsx
@@ -24,7 +24,11 @@ const MeasureWidget: FunctionComponent = () => {
   return (
     <>
       <div className="widget-container">
-        <button className="image-wrapper" onClick={handleWidget}>
+        <button
+          className="image-wrapper"
+          aria-label="measure widget"
+          onClick={handleWidget}
+        >
           <MeasureIcon height={25} width={25} fill={'#555'} />
         </button>
       </div>

--- a/src/js/components/mapWidgets/penWidget.tsx
+++ b/src/js/components/mapWidgets/penWidget.tsx
@@ -13,6 +13,7 @@ const PenWidget: FunctionComponent = () => {
       <div className="widget-container">
         <button
           className="image-wrapper"
+          aria-label="pen widget"
           onClick={() => dispatch(renderModal('PenWidget'))}
         >
           <PenIcon height={25} width={25} fill={'#555'} />

--- a/src/js/components/mapWidgets/printWidget.tsx
+++ b/src/js/components/mapWidgets/printWidget.tsx
@@ -13,6 +13,7 @@ const PrintWidget: FunctionComponent = () => {
       <div className="widget-container">
         <button
           className="image-wrapper"
+          aria-label="print widget"
           onClick={() => dispatch(renderModal('PrintWidget'))}
         >
           <PrintIcon height={25} width={25} fill={'#555'} />

--- a/src/js/components/mapWidgets/refreshWidget.tsx
+++ b/src/js/components/mapWidgets/refreshWidget.tsx
@@ -8,6 +8,7 @@ const RefreshWidget: FunctionComponent = () => {
       <div className="widget-container">
         <button
           className="image-wrapper"
+          aria-label="refresh widget"
           onClick={() => window.location.reload()}
         >
           <RefreshIcon height={25} width={25} fill={'#555'} />

--- a/src/js/components/mapWidgets/searchWidget.tsx
+++ b/src/js/components/mapWidgets/searchWidget.tsx
@@ -13,6 +13,7 @@ const SearchWidget: FunctionComponent = () => {
       <div className="widget-container">
         <button
           className="image-wrapper"
+          aria-label="search widget"
           onClick={() => dispatch(renderModal('SearchWidget'))}
         >
           <SearchIcon height={25} width={25} fill={'#555'} />

--- a/src/js/components/mapWidgets/shareWidget.tsx
+++ b/src/js/components/mapWidgets/shareWidget.tsx
@@ -13,6 +13,7 @@ const ShareWidget: FunctionComponent = () => {
       <div className="widget-container">
         <button
           className="image-wrapper"
+          aria-label="share widget"
           onClick={() => dispatch(renderModal('ShareWidget'))}
         >
           <ShareIcon height={25} width={25} fill={'#555'} />

--- a/src/js/components/mapWidgets/zoomWidget.tsx
+++ b/src/js/components/mapWidgets/zoomWidget.tsx
@@ -11,6 +11,7 @@ const ZoomWidget: FunctionComponent = () => {
       <div className="widget-container">
         <button
           className="image-wrapper"
+          aria-label="zoom out"
           aria-pressed={undefined}
           onClick={() => mapController.zoomInOrOut({ zoomIn: false })}
         >
@@ -20,6 +21,7 @@ const ZoomWidget: FunctionComponent = () => {
       <div className="widget-container">
         <button
           className="image-wrapper"
+          aria-label="zoom in"
           aria-pressed={undefined}
           onClick={() => mapController.zoomInOrOut({ zoomIn: true })}
         >


### PR DESCRIPTION
This PR increases our lighthouse accessibility score from 75/100 to 95/100. Fixes part of #1035

What it accomplishes;
- Overall:  implements changes to increase accessibility to support 508 compliance
- adds custom `aria-label` where needed
- removes zoom limits from `meta` tag so users with poor sight can zoom in/out


Just flagging that we're using an automated accessibility tester to ID & resolve low-hanging fruit