### PR TITLE
Ticket 1070 - mobile header styling

### DIFF
--- a/src/css/header.scss
+++ b/src/css/header.scss
@@ -247,6 +247,18 @@
   }
 }
 
+@media screen and (max-width: $tablet-device) {
+  .header-container {
+    .title-container > .titles > h1 {
+      font-size: 1rem;
+      max-width: 14rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+}
+
 @media screen and (max-width: $mobile-device) {
   .header-container {
     justify-content: flex-end;
@@ -258,13 +270,17 @@
         margin-left: 0.25rem;
 
         h1 {
-          font-size: 1rem;
+          max-width: 10rem;
         }
 
         h2 {
           font-size: 0.75rem;
         }
       }
+    }
+
+    .selectors-container {
+      display: none;
     }
   }
 

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -39,6 +39,7 @@ $fira-sans: 'Fira Sans', sans-serif;
 ============================================= */
 
 $mobile-device: 475px;
+$tablet-device: 768px;
 
 /* MISC GLOBAL CLASSES
 ============================================= */


### PR DESCRIPTION
On mobile, app hides elements in header except for the title, subtitle & icon. Fixes #1070 