### PR TITLE
Adding basemap selector webmap base layer

### DIFF
--- a/configs/countryConfigs/cameroon.js
+++ b/configs/countryConfigs/cameroon.js
@@ -1,5 +1,5 @@
 module.exports = {
-  webmap: '8892b20e94244843b8e46d71ea1b03f2 ',
+  webmap: '8892b20e94244843b8e46d71ea1b03f2',
   title: 'Atlas Forestier du Cameroun',
   subtitle: 'Ministère des Forêts et de la Faune',
   webmapMenuName: 'Affectation des Terres',
@@ -1064,20 +1064,33 @@ module.exports = {
             zh: 'WRI Mono',
             ka: 'WRI Mono'
           }
+        },
+        {
+          id: 'wri_contextual',
+          thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/wri_contextual.png',
+          title: {
+            en: 'WRI Contextual',
+            fr: 'WRI Contextual',
+            es: 'WRI Contextual',
+            pt: 'WRI Contextual',
+            id: 'WRI Contextual',
+            zh: 'WRI Contextual',
+            ka: 'WRI Contextual'
+          }
+        },
+        {
+          id: 'webmap_original',
+          thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/wri_contextual.png',
+          title: {
+            en: 'Original Webmap',
+            fr: 'Original Webmap',
+            es: 'Original Webmap',
+            pt: 'Original Webmap',
+            id: 'Original Webmap',
+            zh: 'Original Webmap',
+            ka: 'Original Webmap'
+          }
         }
-        // {
-        //   id: 'wri_contextual',
-        //   thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/wri_contextual.png',
-        //   title: {
-        //     en: 'WRI Contextual',
-        //     fr: 'WRI Contextual',
-        //     es: 'WRI Contextual',
-        //     pt: 'WRI Contextual',
-        //     id: 'WRI Contextual',
-        //     zh: 'WRI Contextual',
-        //     ka: 'WRI Contextual'
-        //   }
-        // }
       ]
     },
     // GROUP_Orth: {

--- a/configs/countryConfigs/cameroon.js
+++ b/configs/countryConfigs/cameroon.js
@@ -1077,19 +1077,6 @@ module.exports = {
             zh: 'WRI Contextual',
             ka: 'WRI Contextual'
           }
-        },
-        {
-          id: 'webmap_original',
-          thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/wri_contextual.png',
-          title: {
-            en: 'Original Webmap',
-            fr: 'Original Webmap',
-            es: 'Original Webmap',
-            pt: 'Original Webmap',
-            id: 'Original Webmap',
-            zh: 'Original Webmap',
-            ka: 'Original Webmap'
-          }
         }
       ]
     },

--- a/configs/countryConfigs/cameroon.js
+++ b/configs/countryConfigs/cameroon.js
@@ -1,9 +1,10 @@
 module.exports = {
-  webmap: '8892b20e94244843b8e46d71ea1b03f2',
+  webmap: '8892b20e94244843b8e46d71ea1b03f2 ',
   title: 'Atlas Forestier du Cameroun',
   subtitle: 'Ministère des Forêts et de la Faune',
   webmapMenuName: 'Affectation des Terres',
   // initialExtent: {"x": -91.7,"y": 16.6,"z": 9},
+  hideLegend: false,
   logoUrl:
     'https://cmr.forest-atlas.org/system/site_settings/images/000/000/094/original/CAMEROON.png?1487267590',
   logoLinkUrl: 'http://www.minfof.cm/',
@@ -1064,20 +1065,20 @@ module.exports = {
             zh: 'WRI Mono',
             ka: 'WRI Mono'
           }
-        },
-        {
-          id: 'wri_contextual',
-          thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/wri_contextual.png',
-          title: {
-            en: 'WRI Contextual',
-            fr: 'WRI Contextual',
-            es: 'WRI Contextual',
-            pt: 'WRI Contextual',
-            id: 'WRI Contextual',
-            zh: 'WRI Contextual',
-            ka: 'WRI Contextual'
-          }
         }
+        // {
+        //   id: 'wri_contextual',
+        //   thumbnailUrl: 'https://my.gfw-mapbuilder.org/img/wri_contextual.png',
+        //   title: {
+        //     en: 'WRI Contextual',
+        //     fr: 'WRI Contextual',
+        //     es: 'WRI Contextual',
+        //     pt: 'WRI Contextual',
+        //     id: 'WRI Contextual',
+        //     zh: 'WRI Contextual',
+        //     ka: 'WRI Contextual'
+        //   }
+        // }
       ]
     },
     // GROUP_Orth: {

--- a/configs/layer-config.ts
+++ b/configs/layer-config.ts
@@ -29,3 +29,6 @@ export const WRIBasemapConfig = {
   wri_contextual:
     'https://api.mapbox.com/styles/v1/resourcewatch/ckaoehoff02fn1ipfan4jblxh/tiles/256/{level}/{col}/{row}@2x?access_token=pk.eyJ1IjoicmVzb3VyY2V3YXRjaCIsImEiOiJjajFlcXZhNzcwMDBqMzNzMTQ0bDN6Y3U4In0.FRcIP_yusVaAy0mwAX1B8w'
 };
+
+export const customBasemapIcon =
+  'https://my.gfw-mapbuilder.org/img/custom_basemap.png';

--- a/configs/resources.js
+++ b/configs/resources.js
@@ -26,8 +26,6 @@ export default {
   //- Language Settings
   language: 'en',
   useAlternativeLanguage: false,
-  //- Custom Basemap
-  useWebmapBasemap: false,
   alternativeWebmap: '',
   alternativeLanguage: 'fr',
   alternativeLanguageTitle: 'GFW Mapbuilder',

--- a/src/js/components/leftPanel/layersPanel/BasemapLayersGroup.tsx
+++ b/src/js/components/leftPanel/layersPanel/BasemapLayersGroup.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from 'js/store';
 import { setOpenLayerGroup } from 'js/store/appState/actions';
-import { landsatBaselayerYears } from 'configs/layer-config';
+import { landsatBaselayerYears, customBasemapIcon } from 'configs/layer-config';
 import { mapController } from 'js/controllers/mapController';
 import { basemapLayersContent } from 'configs/leftPanel.translations';
 import { LayerProps } from 'js/store/mapview/types';
@@ -10,8 +10,8 @@ import { LayerProps } from 'js/store/mapview/types';
 interface DefaultBasemapProps {
   layerInfo: {
     id: string;
-    thumbnailUrl: string;
-    title: string;
+    thumbnailUrl?: string;
+    title?: string;
     activeBasemap: string;
   };
 }
@@ -23,14 +23,14 @@ interface BaseLayerControlLandsatProps {
 }
 
 const WebmapOriginal = (props: DefaultBasemapProps): JSX.Element => {
-  const { id, thumbnailUrl, title, activeBasemap } = props.layerInfo;
+  const { id, activeBasemap } = props.layerInfo;
   return (
     <div
       className={`layer-basemap ${activeBasemap === id ? 'selected' : ''}`}
       onClick={(): void => mapController.setWebmapOriginalBasemap(id)}
     >
-      <img src={thumbnailUrl} alt="basemap" />
-      <span>{title}</span>
+      <img src={customBasemapIcon} alt="basemap" />
+      <span>{mapController._webmapBasemap?.title}</span>
     </div>
   );
 };
@@ -150,9 +150,12 @@ const BasemapLayersGroup = (props: LayerGroupProps): React.ReactElement => {
     (baselayer: any) =>
       baselayer.id === 'landsat' ||
       baselayer.id === 'wri_mono' ||
-      baselayer.id === 'webmap_original' ||
       baselayer.id === 'wri_contextual'
   );
+
+  //Add BASEMAP from Webmap
+  basemapsToRender.push({ id: 'webmap_original' });
+
   const allowedBaseLayers = basemapsToRender.map((baselayer: any) => {
     if (baselayer.id === 'landsat') {
       return (
@@ -170,8 +173,6 @@ const BasemapLayersGroup = (props: LayerGroupProps): React.ReactElement => {
           key={baselayer.id}
           layerInfo={{
             id: baselayer.id,
-            thumbnailUrl: baselayer.thumbnailUrl,
-            title: baselayer.title[selectedLanguage],
             activeBasemap
           }}
         />

--- a/src/js/components/leftPanel/layersPanel/BasemapLayersGroup.tsx
+++ b/src/js/components/leftPanel/layersPanel/BasemapLayersGroup.tsx
@@ -22,6 +22,19 @@ interface BaseLayerControlLandsatProps {
   customColorTheme?: string;
 }
 
+const WebmapOriginal = (props: DefaultBasemapProps): JSX.Element => {
+  const { id, thumbnailUrl, title, activeBasemap } = props.layerInfo;
+  return (
+    <div
+      className={`layer-basemap ${activeBasemap === id ? 'selected' : ''}`}
+      onClick={(): void => mapController.setWebmapOriginalBasemap(id)}
+    >
+      <img src={thumbnailUrl} alt="basemap" />
+      <span>{title}</span>
+    </div>
+  );
+};
+
 const BaseLayerWRI = (props: DefaultBasemapProps): JSX.Element => {
   const { id, thumbnailUrl, title, activeBasemap } = props.layerInfo;
   return (
@@ -137,6 +150,7 @@ const BasemapLayersGroup = (props: LayerGroupProps): React.ReactElement => {
     (baselayer: any) =>
       baselayer.id === 'landsat' ||
       baselayer.id === 'wri_mono' ||
+      baselayer.id === 'webmap_original' ||
       baselayer.id === 'wri_contextual'
   );
   const allowedBaseLayers = basemapsToRender.map((baselayer: any) => {
@@ -147,6 +161,19 @@ const BasemapLayersGroup = (props: LayerGroupProps): React.ReactElement => {
           layerInfo={baselayer}
           selectedLanguage={selectedLanguage}
           customColorTheme={customColorTheme}
+        />
+      );
+    }
+    if (baselayer.id === 'webmap_original') {
+      return (
+        <WebmapOriginal
+          key={baselayer.id}
+          layerInfo={{
+            id: baselayer.id,
+            thumbnailUrl: baselayer.thumbnailUrl,
+            title: baselayer.title[selectedLanguage],
+            activeBasemap
+          }}
         />
       );
     }

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -107,6 +107,7 @@ export class MapController {
   _domRef: RefObject<any>;
   _imageryOpacity: number;
   _mouseTrackingEvent: IHandle | undefined;
+  _webmapBasemap: __esri.Basemap | undefined;
 
   constructor() {
     this._map = undefined;
@@ -116,6 +117,7 @@ export class MapController {
     this._selectedWidget = undefined;
     this._sketchVMGraphicsLayer = undefined;
     this._mouseTrackingEvent = undefined;
+    this._webmapBasemap = undefined;
   }
 
   initializeMap(domRef: RefObject<any>): void {
@@ -181,6 +183,8 @@ export class MapController {
         async () => {
           store.dispatch(isMapReady(true));
           //default scale for map
+          const wbBase = this._map?.basemap.clone();
+          this._webmapBasemap = wbBase;
           store.dispatch(changeMapScale(this._mapview.scale));
           const { latitude, longitude } = this._mapview.center;
           store.dispatch(changeMapCenterCoordinates({ latitude, longitude }));
@@ -625,6 +629,7 @@ export class MapController {
     this._map = new WebMap({
       portalItem: { id: newWebMapId }
     });
+
     this._mapview = new MapView({
       map: this._map,
       container: this._domRef.current
@@ -655,6 +660,8 @@ export class MapController {
 
     this._mapview.when(async () => {
       //Set default state and other event listeners
+      const wbBase = this._map?.basemap.clone();
+      this._webmapBasemap = wbBase;
       store.dispatch(isMapReady(true));
       store.dispatch(setLanguage(lang));
       store.dispatch(changeMapScale(this._mapview.scale));
@@ -1576,6 +1583,12 @@ export class MapController {
       this._map.basemap = basemap;
       store.dispatch(setSelectedBasemap(id));
     }
+  }
+
+  setWebmapOriginalBasemap(id: string): void {
+    if (!this._webmapBasemap || !this._map) return;
+    this._map.basemap = this._webmapBasemap;
+    store.dispatch(setSelectedBasemap(id));
   }
 
   setWRIBasemap(id: string): void {


### PR DESCRIPTION
New config option to add and configure how the original webmap basemap selector looks. This PR adds the ability to toggle between webmap base layer and all other baselayers.

WIKI Updates would need to be done if this is accepted.

Relevant issue: #1072 