### PR TITLE
Graphics layer clearing bug

### DIFF
--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -848,6 +848,11 @@ export class MapController {
     //1. Iterate over map's layers and turn them off one by one
     this._map.layers.forEach((layer: any) => {
       if (layer.id === 'MASK') return; // mask layers should never be cleared from the map
+      if (layer.id === 'user_features') {
+        //user drawn feature graphics layer visibility is ignored, but graphics are moved
+        layer.graphics.removeAll();
+        return;
+      }
       if (
         layer.sublayers &&
         !layer.id.includes('VIIRS') &&


### PR DESCRIPTION
Ignoring graphics layer that is used for drawn features in "Clear All functionality 
#1095 