### PR TITLE
Report header styling

### DIFF
--- a/src/css/report.scss
+++ b/src/css/report.scss
@@ -6,7 +6,7 @@
     padding: 0;
   }
   display: grid;
-  padding-top: 5rem;
+  padding-top: 1rem;
   padding-left: 1rem;
   padding-right: 1rem;
   justify-items: center;
@@ -34,14 +34,18 @@
       width: 100%;
     }
     background-color: #555;
-    height: 50px;
-    width: 90%;
+    width: 900px;
     padding-right: 10px;
+    padding: 3px;
     display: grid;
-    grid-template-columns: 1fr auto auto;
+    grid-template-columns: auto 1fr auto auto;
     grid-gap: 5px;
     align-items: center;
     -webkit-print-color-adjust: exact;
+
+    .logo {
+      width: 100px;
+    }
     button {
       @media print {
         display: none;
@@ -63,6 +67,9 @@
     }
   }
   .report-analysis {
+    min-width: 30vw;
+    width: 900px;
+    border: 1px dashed gray;
     color: #555;
     .analysis-title {
       font-size: 1.5rem;
@@ -76,8 +83,6 @@
       margin-top: 10px;
       margin-bottom: 10px;
     }
-    width: 800px;
-    min-width: 30vw;
     table {
       overflow-wrap: break-word;
       font-size: 13px;
@@ -102,6 +107,7 @@
     color: #555;
     margin-top: 20px;
     .chart-area-container {
+      width: 900px;
       .canvas-chart-wrapper {
         @media print {
           display: flex;

--- a/src/js/components/Report.tsx
+++ b/src/js/components/Report.tsx
@@ -32,6 +32,8 @@ interface ReportProps {
 const Report = (props: ReportProps): JSX.Element => {
   const dispatch = useDispatch();
 
+  const logoURL = useSelector((store: RootState) => store.appSettings.logoUrl);
+
   const allAvailableLayers = useSelector(
     (store: RootState) => store.mapviewState.allAvailableLayers
   );
@@ -166,6 +168,9 @@ const Report = (props: ReportProps): JSX.Element => {
   return (
     <div className="report">
       <div className="report-header">
+        {logoURL && logoURL.length && (
+          <img src={logoURL} alt="logo" className="logo" />
+        )}
         <p className="title">{`${window.document.title} Custom Analysis`}</p>
         <button onClick={printReport}>
           <PrintIcon height={25} width={25} fill={'#fff'} />


### PR DESCRIPTION
Introduces adjustment to the way report header is styled. Adding config logos, reducing overlap.

<img width="1773" alt="Screen Shot 2020-06-11 at 3 06 57 PM" src="https://user-images.githubusercontent.com/12076555/84429555-5a174380-abf6-11ea-82c8-794be0ae1b3d.png">
<img width="968" alt="Screen Shot 2020-06-11 at 3 06 48 PM" src="https://user-images.githubusercontent.com/12076555/84429556-5aafda00-abf6-11ea-93b7-de9e0bf72391.png">
