### PR TITLE
Removed left panel y-overflow on smaller screens

### DIFF
--- a/src/css/leftpanel.scss
+++ b/src/css/leftpanel.scss
@@ -1371,3 +1371,11 @@
     }
   }
 }
+
+@media (max-height: $laptop-device) {
+  .left-panel {
+    .tabview-container {
+      height: 450px;
+    }
+  }
+}

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -36,6 +36,7 @@ $fira-sans: 'Fira Sans', sans-serif;
 
 $mobile-device: 475px;
 $tablet-device: 768px;
+$laptop-device: 800px;
 
 /* MISC GLOBAL CLASSES
 ============================================= */


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Styling update


## What is the current behavior?
The Legend overflows below the application on smaller screens, causing y-scrolling and overlaps:
<img width="1181" alt="Screen Shot 2020-08-17 at 11 56 19 AM" src="https://user-images.githubusercontent.com/5713523/90436463-94351380-e085-11ea-8ea6-55e4e16489b5.png">

## What is the new behavior?
The legend's height is frozen at a specific pixel count when our window gets smaller:
<img width="1174" alt="Screen Shot 2020-08-17 at 12 05 00 PM" src="https://user-images.githubusercontent.com/5713523/90436525-b29b0f00-e085-11ea-8b58-6908623a75b7.png">



## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
The application looks great!
