### PR TITLE
Ticket 1157 - update translation configs

### DIFF
--- a/configs/leftPanel.translations.ts
+++ b/configs/leftPanel.translations.ts
@@ -26,7 +26,7 @@ export const analysisContent = {
       'Add additional shapes in the future by visiting the draw tool'
     ]
   },
-  du: {
+  nl: {
     analyzeExistingShapeTitle: 'Analyze a shape on the map',
     // ^ no translation available
     analyzeExistingShapeDirections: [
@@ -54,7 +54,7 @@ export const analysisContent = {
       'Voeg in de toekomst extra vormen toe door naar de tekentool te gaa'
     ]
   },
-  am: {
+  hy: {
     analyzeExistingShapeTitle: 'Analyze a shape on the map',
     analyzeExistingShapeDirections: [
       'Տվյալների շերտն ակտիվացնելու համար օգտագործել շերտերի ներդիրը ',
@@ -293,13 +293,13 @@ export const layersPanelTranslations = {
     clearAll: 'Clear All',
     legend: 'Legend'
   },
-  du: {
+  nl: {
     layers: 'Lagen ',
     selectAll: 'Selecteer alles',
     clearAll: 'Wis alles',
     legend: 'Legende'
   },
-  am: {
+  hy: {
     layers: 'շերտեր',
     selectAll: 'Նշել բոլորը',
     clearAll: 'Ջնջել բոլորը',
@@ -351,14 +351,14 @@ export const documentsContent = {
     pdf: 'PDF',
     size: 'Size'
   },
-  du: {
+  nl: {
     instructions:
       'Selecteer een interessegebied om te zien of er gerelateerde documenten zijn',
     name: 'Naam ',
     pdf: 'PDF',
     size: 'Grootte'
   },
-  am: {
+  hy: {
     instructions:
       'Ընտրել հետաքրքրող տարածքը և ստուգել դրա հետ կապված փաստաթղթերի առկայությունը ',
     name: 'Անվանում',
@@ -413,11 +413,11 @@ export const layerControlsTranslations = {
     timeStart: 'Start: ',
     timeEnd: 'End: '
   },
-  du: {
+  nl: {
     timeStart: 'Begin: ',
     timeEnd: 'Einde: '
   },
-  am: {
+  hy: {
     timeStart: 'սկիզբ: ',
     timeEnd: 'Վերջ: '
   },
@@ -455,14 +455,14 @@ export const dataTabConfig = {
       'Select a shape on the map'
     ]
   },
-  du: {
+  nl: {
     header: 'Selecteer een vorm op de kaart',
     instructionsList: [
       'Use the layers tab to turn on a data layer ', // * NOTE: translation unavailable
       'Selecteer een vorm op de kaart'
     ]
   },
-  am: {
+  hy: {
     header: 'Քարտեզի վրա ընտրել պատկեր',
     instructionsList: [
       'Տվյալների շերտն ակտիվացնելու համար օգտագործել շերտերի ներդիրը',
@@ -514,10 +514,10 @@ export const canopyDensityPickerConfig = {
   en: {
     displayLabel: ['Displaying', 'canopy density.']
   },
-  du: {
+  nl: {
     displayLabel: ['Weergeven', 'luifeldichtheid.']
   },
-  am: {
+  hy: {
     displayLabel: ['Ցուցադրվում է ', 'Սաղարթի խտություն ']
   },
   ka: {

--- a/configs/leftPanel.translations.ts
+++ b/configs/leftPanel.translations.ts
@@ -30,9 +30,9 @@ export const analysisContent = {
     analyzeExistingShapeTitle: 'Analyze a shape on the map',
     // ^ no translation available
     analyzeExistingShapeDirections: [
-      'Use the layers tab to turn on a data layer',
+      'Gebruik het tabblad Lagen om een gegevenslaag in te schakelen',
       'Selecteer een vorm op de kaart',
-      'Click on the analyze tab'
+      'Klik op het tabblad analyse'
     ],
     analyzeYourShapeTitle: 'Analyseer je eigen vorm',
     analyzeYourShapeFirstDirection: [
@@ -458,7 +458,7 @@ export const dataTabConfig = {
   du: {
     header: 'Selecteer een vorm op de kaart',
     instructionsList: [
-      'Use the layers tab to turn on a data layer',
+      'Use the layers tab to turn on a data layer ', // * NOTE: translation unavailable
       'Selecteer een vorm op de kaart'
     ]
   },

--- a/configs/leftPanel.translations.ts
+++ b/configs/leftPanel.translations.ts
@@ -26,6 +26,61 @@ export const analysisContent = {
       'Add additional shapes in the future by visiting the draw tool'
     ]
   },
+  du: {
+    analyzeExistingShapeTitle: 'Analyze a shape on the map',
+    // ^ no translation available
+    analyzeExistingShapeDirections: [
+      'Use the layers tab to turn on a data layer',
+      'Selecteer een vorm op de kaart',
+      'Click on the analyze tab'
+    ],
+    analyzeYourShapeTitle: 'Analyseer je eigen vorm',
+    analyzeYourShapeFirstDirection: [
+      'Kies het tekengereedschap ',
+      ' in de gereedschapskist'
+    ],
+    analyzeYourShapeDirections: [
+      'Teken een vorm ergens op de kaart',
+      'Selecteer de vorm om de analyse uit te voeren'
+    ],
+    drawButton: 'Begin met tekenen',
+    enterCoordinatesTitle: 'Voer uw eigen coördinaten in',
+    enterCoordinatesDirections: [
+      `Voer minimaal 3 coördinaten in`,
+      `Voeg maximaal 10 punten toe om vormen te maken`
+    ],
+    coordinatesButton: 'Voer waarden in',
+    visitTitle: [
+      'Voeg in de toekomst extra vormen toe door naar de tekentool te gaa'
+    ]
+  },
+  am: {
+    analyzeExistingShapeTitle: 'Analyze a shape on the map',
+    analyzeExistingShapeDirections: [
+      'Տվյալների շերտն ակտիվացնելու համար օգտագործել շերտերի ներդիրը ',
+      'Քարտեզի վրա ընտրել պատկերը ',
+      'Սեղմել վերլուծության ներդիրը '
+    ],
+    analyzeYourShapeTitle: 'Վերլուծել սեփական պատկերը ',
+    analyzeYourShapeFirstDirection: [
+      'Գործիքների ներդիրից ընտրել ',
+      ' նկարչական գործիքը'
+    ],
+    analyzeYourShapeDirections: [
+      'Քարտեզի որևէ հատվածում նկարել պատկեր ',
+      'Վերլուծությունը սկսելու համար ընտրել որևէ պատկեր '
+    ],
+    drawButton: 'Նկարել',
+    enterCoordinatesTitle: 'Մուտքագրել Ձեր կոորդինատները ',
+    enterCoordinatesDirections: [
+      `Մուտքագրել առնվազն 3 կոորդինատ `,
+      'Ավելացնել մինչև 10 կետեր` պատկեր ստանալու համար '
+    ],
+    coordinatesButton: 'Մուտքագրել արժեքներ ',
+    visitTitle: [
+      'Add additional shapes in the future by visiting the draw tool'
+    ]
+  },
   ka: {
     analyzeExistingShapeTitle: 'ჩაატარეთ ფიგურის ანალიზი რუკაზე',
     analyzeExistingShapeDirections: [
@@ -238,6 +293,18 @@ export const layersPanelTranslations = {
     clearAll: 'Clear All',
     legend: 'Legend'
   },
+  du: {
+    layers: 'Lagen ',
+    selectAll: 'Selecteer alles',
+    clearAll: 'Wis alles',
+    legend: 'Legende'
+  },
+  am: {
+    layers: 'շերտեր',
+    selectAll: 'Նշել բոլորը',
+    clearAll: 'Ջնջել բոլորը',
+    legend: 'Պայմանական նշաններ'
+  },
   fr: {
     layers: 'Couches',
     selectAll: 'Tout sélectionner',
@@ -283,6 +350,20 @@ export const documentsContent = {
     name: 'Name',
     pdf: 'PDF',
     size: 'Size'
+  },
+  du: {
+    instructions:
+      'Selecteer een interessegebied om te zien of er gerelateerde documenten zijn',
+    name: 'Naam ',
+    pdf: 'PDF',
+    size: 'Grootte'
+  },
+  am: {
+    instructions:
+      'Ընտրել հետաքրքրող տարածքը և ստուգել դրա հետ կապված փաստաթղթերի առկայությունը ',
+    name: 'Անվանում',
+    pdf: 'PDF',
+    size: 'Ծավալ'
   },
   ka: {
     instructions:
@@ -332,6 +413,14 @@ export const layerControlsTranslations = {
     timeStart: 'Start: ',
     timeEnd: 'End: '
   },
+  du: {
+    timeStart: 'Begin: ',
+    timeEnd: 'Einde: '
+  },
+  am: {
+    timeStart: 'սկիզբ: ',
+    timeEnd: 'Վերջ: '
+  },
   ka: {
     timeStart: 'დასაწყისი: ',
     timeEnd: 'დასასრული: '
@@ -364,6 +453,20 @@ export const dataTabConfig = {
     instructionsList: [
       'Use the layers tab to turn on a data layer',
       'Select a shape on the map'
+    ]
+  },
+  du: {
+    header: 'Selecteer een vorm op de kaart',
+    instructionsList: [
+      'Use the layers tab to turn on a data layer',
+      'Selecteer een vorm op de kaart'
+    ]
+  },
+  am: {
+    header: 'Քարտեզի վրա ընտրել պատկեր',
+    instructionsList: [
+      'Տվյալների շերտն ակտիվացնելու համար օգտագործել շերտերի ներդիրը',
+      'Քարտեզի վրա ընտրել պատկեր'
     ]
   },
   ka: {
@@ -410,6 +513,12 @@ export const dataTabConfig = {
 export const canopyDensityPickerConfig = {
   en: {
     displayLabel: ['Displaying', 'canopy density.']
+  },
+  du: {
+    displayLabel: ['Weergeven', 'luifeldichtheid.']
+  },
+  am: {
+    displayLabel: ['Ցուցադրվում է ', 'Սաղարթի խտություն ']
   },
   ka: {
     displayLabel: ['წარმოდგენილია', 'ვარჯის სიმჭიდროვე.']

--- a/configs/modal.config.ts
+++ b/configs/modal.config.ts
@@ -6,12 +6,12 @@ export const printContent = {
     dropdownLabel: 'Print',
     printOptions: ['Landscape', 'MAP_ONLY']
   },
-  du: {
+  nl: {
     buttonLabel: 'Kies een afdruk output',
     dropdownLabel: 'Afdrukken ',
     printOptions: ['Landscape', 'MAP_ONLY']
   },
-  am: {
+  hy: {
     buttonLabel: 'Ընտրել արդյունքները տպման համար ',
     dropdownLabel: 'տպել',
     printOptions: ['Landscape', 'MAP_ONLY']
@@ -52,10 +52,10 @@ export const shareContent = {
   en: {
     title: 'Share'
   },
-  du: {
+  nl: {
     title: 'Delen'
   },
-  am: {
+  hy: {
     title: 'կիսվել'
   },
   ka: {
@@ -93,7 +93,7 @@ export const penContent = {
     ],
     coordinatesButton: 'Enter Values'
   },
-  du: {
+  nl: {
     drawTitle: 'Analyseer je eigen vorm',
     drawInstructions: [
       'Teken een vorm ergens op de kaart',
@@ -107,7 +107,7 @@ export const penContent = {
     ],
     coordinatesButton: 'Voer waarden in'
   },
-  am: {
+  hy: {
     drawTitle: 'Վերլուծել սեփական պատկերը',
     drawInstructions: [
       'Քարտեզի որևէ հատվածում նկարել պատկեր',
@@ -208,13 +208,13 @@ export const searchContent = {
     title: 'Search for feature:',
     buttonTitle: 'Search'
   },
-  du: {
+  nl: {
     latitude: 'Breedtegraad',
     longitude: 'Lengtegraad',
     title: 'Zoeken naar functie:',
     buttonTitle: 'zoeken'
   },
-  am: {
+  hy: {
     latitude: 'Լայնություն ',
     longitude: 'Երկայնություն',
     title: 'Փնտրել օբյեկտը:',
@@ -271,7 +271,7 @@ export const coordinatesContent = {
     addMoreLabel: 'Add More',
     makeShapeLabel: 'Make Shape'
   },
-  du: {
+  nl: {
     title: 'Voer uw eigen coördinaten in',
     dropdownTitle: 'Selecteer Formaat',
     decimalOptions: ['Graden Decimale Seconden (DMS)', 'Decimale graden (DD)'],
@@ -280,7 +280,7 @@ export const coordinatesContent = {
     addMoreLabel: 'Voeg meer toe ',
     makeShapeLabel: 'Vorm maken '
   },
-  am: {
+  hy: {
     title: 'Մուտքագրել Ձեր կոորդինատները ',
     dropdownTitle: 'Ընտրել ձևաչափը ',
     decimalOptions: [
@@ -374,7 +374,7 @@ export const measureContent = {
       { text: 'DMS', esriUnit: 'dms' }
     ]
   },
-  du: {
+  nl: {
     // * NOTE: translation document didn't have this section
     defaultOption: [{ text: 'Unit', esriUnit: '' }],
     areaUnitsOfLength: [
@@ -400,7 +400,7 @@ export const measureContent = {
       { text: 'DMS', esriUnit: 'dms' }
     ]
   },
-  am: {
+  hy: {
     // * NOTE: translation document didn't have this section
     defaultOption: [{ text: 'Unit', esriUnit: '' }],
     areaUnitsOfLength: [
@@ -594,7 +594,7 @@ export const infoContent = {
     noInfoLabel: 'No Information Available',
     overviewLabel: 'Overview'
   },
-  du: {
+  nl: {
     functionLabel: 'Functie',
     resolutionLabel: 'Resolutie',
     geographicCoverageLabel: 'geografische dekking',
@@ -609,7 +609,7 @@ export const infoContent = {
     noInfoLabel: 'Geen informative beschikbaar',
     overviewLabel: 'Omschrijving'
   },
-  am: {
+  hy: {
     functionLabel: 'Ֆունկցիա/գործողություն ',
     resolutionLabel: 'լուծաչափ',
     geographicCoverageLabel: 'Աշխարհագրական ծածկույթ ',
@@ -721,11 +721,11 @@ export const canopyDensityContentConfig = {
     directions:
       'Adjust the minimum canopy density for tree cover and tree cover loss'
   },
-  du: {
+  nl: {
     directions:
       'Pas de minimale luifeldichtheid aan voor boombedekking en afname  van boombedekkings'
   },
-  am: {
+  hy: {
     directions:
       'Կարգավորել սաղարթների նվազագույն խտությունը՝ ծառածածկույթի և ծառածակույթի կորստի համար'
   },

--- a/configs/modal.config.ts
+++ b/configs/modal.config.ts
@@ -6,6 +6,16 @@ export const printContent = {
     dropdownLabel: 'Print',
     printOptions: ['Landscape', 'MAP_ONLY']
   },
+  du: {
+    buttonLabel: 'Kies een afdruk output',
+    dropdownLabel: 'Afdrukken ',
+    printOptions: ['Landscape', 'MAP_ONLY']
+  },
+  am: {
+    buttonLabel: 'Ընտրել արդյունքները տպման համար ',
+    dropdownLabel: 'տպել',
+    printOptions: ['Landscape', 'MAP_ONLY']
+  },
   ka: {
     buttonLabel: 'აარჩიეთ ბეჭდვის ფორმატი',
     dropdownLabel: 'Print',
@@ -42,6 +52,12 @@ export const shareContent = {
   en: {
     title: 'Share'
   },
+  du: {
+    title: 'Delen'
+  },
+  am: {
+    title: 'կիսվել'
+  },
   ka: {
     title: 'გაზიარება'
   },
@@ -76,6 +92,34 @@ export const penContent = {
       'Add up to 10 points to make shapes'
     ],
     coordinatesButton: 'Enter Values'
+  },
+  du: {
+    drawTitle: 'Analyseer je eigen vorm',
+    drawInstructions: [
+      'Teken een vorm ergens op de kaart',
+      'Selecteer de vorm om de analyse uit te voeren'
+    ],
+    drawButton: 'Begin met tekenen',
+    coordinatesTitle: 'Voer uw eigen coördinaten in',
+    coordinatesInstructions: [
+      'Voer minimaal 3 coördinaten in',
+      'Voeg maximaal 10 punten toe om vormen te maken'
+    ],
+    coordinatesButton: 'Voer waarden in'
+  },
+  am: {
+    drawTitle: 'Վերլուծել սեփական պատկերը',
+    drawInstructions: [
+      'Քարտեզի որևէ հատվածում նկարել պատկեր',
+      'Վերլուծությունը սկսելու համար ընտրել որևէ պատկեր'
+    ],
+    drawButton: 'Նկարել',
+    coordinatesTitle: 'Մուտքագրել Ձեր կոորդինատները',
+    coordinatesInstructions: [
+      'Մուտքագրել առնվազն 3 կոորդինատ',
+      'Ավելացնել մինչև 10 կետեր` պատկեր ստանալու համար'
+    ],
+    coordinatesButton: 'Մուտքագրել արժեքներ'
   },
   ka: {
     drawTitle: 'ჩაატარეთ თქვენი ფიგურის ანალიზი',
@@ -164,6 +208,18 @@ export const searchContent = {
     title: 'Search for feature:',
     buttonTitle: 'Search'
   },
+  du: {
+    latitude: 'Breedtegraad',
+    longitude: 'Lengtegraad',
+    title: 'Zoeken naar functie:',
+    buttonTitle: 'zoeken'
+  },
+  am: {
+    latitude: 'Լայնություն ',
+    longitude: 'Երկայնություն',
+    title: 'Փնտրել օբյեկտը:',
+    buttonTitle: 'Search'
+  },
   ka: {
     latitude: 'განედი',
     longitude: 'გრძედი',
@@ -214,6 +270,27 @@ export const coordinatesContent = {
     longitudeLabel: 'Longitude',
     addMoreLabel: 'Add More',
     makeShapeLabel: 'Make Shape'
+  },
+  du: {
+    title: 'Voer uw eigen coördinaten in',
+    dropdownTitle: 'Selecteer Formaat',
+    decimalOptions: ['Graden Decimale Seconden (DMS)', 'Decimale graden (DD)'],
+    latitudeLabel: 'Breedtegraad',
+    longitudeLabel: 'Lengtegraad',
+    addMoreLabel: 'Voeg meer toe ',
+    makeShapeLabel: 'Vorm maken '
+  },
+  am: {
+    title: 'Մուտքագրել Ձեր կոորդինատները ',
+    dropdownTitle: 'Ընտրել ձևաչափը ',
+    decimalOptions: [
+      'Աստիճաններով տասնորդական վայրկյաններ (DMS)',
+      'Տասնորդական աստիճաններ (DD)'
+    ],
+    latitudeLabel: 'Լայնություն ',
+    longitudeLabel: 'Երկայնություն ',
+    addMoreLabel: 'Ավելացնել ',
+    makeShapeLabel: 'Կառուցել պատկեր '
   },
   ka: {
     title: 'შეიტანეთ თქვენი კოორდინატები',
@@ -465,6 +542,36 @@ export const infoContent = {
     noInfoLabel: 'No Information Available',
     overviewLabel: 'Overview'
   },
+  du: {
+    functionLabel: 'Functie',
+    resolutionLabel: 'Resolutie',
+    geographicCoverageLabel: 'geografische dekking',
+    sourceLabel: 'Bron ',
+    frequencyLabel: 'Frequentie ',
+    contentDateLabel: 'Datum van inhoud ',
+    cautionsLabel: 'Waarschuwingen ',
+    licenseLabel: 'Licentie ',
+    learnMoreLabel: 'Leer meer ',
+    downloadDataLabel: 'download gegevens ',
+    descriptionLabel: 'description',
+    noInfoLabel: 'Geen informative beschikbaar',
+    overviewLabel: 'Omschrijving'
+  },
+  am: {
+    functionLabel: 'Ֆունկցիա/գործողություն ',
+    resolutionLabel: 'լուծաչափ',
+    geographicCoverageLabel: 'Աշխարհագրական ծածկույթ ',
+    sourceLabel: 'աղբյուր',
+    frequencyLabel: 'հաճախականություն',
+    contentDateLabel: 'Բովանդակության ամսաթիվ ',
+    cautionsLabel: 'զգուշացումներ',
+    licenseLabel: 'լիցենզիա',
+    learnMoreLabel: 'Իմանալ ավելին ',
+    downloadDataLabel: 'Ներբեռնել տվյալները ',
+    descriptionLabel: 'նկարագրություն',
+    noInfoLabel: 'Տեղեկատվությունն առկա չէ ',
+    overviewLabel: 'Ընդհանուր նկարագիր '
+  },
   ka: {
     functionLabel: 'ფუნქცია',
     resolutionLabel: 'რეზოლუცია',
@@ -561,6 +668,14 @@ export const canopyDensityContentConfig = {
   en: {
     directions:
       'Adjust the minimum canopy density for tree cover and tree cover loss'
+  },
+  du: {
+    directions:
+      'Pas de minimale luifeldichtheid aan voor boombedekking en afname  van boombedekkings'
+  },
+  am: {
+    directions:
+      'Կարգավորել սաղարթների նվազագույն խտությունը՝ ծառածածկույթի և ծառածակույթի կորստի համար'
   },
   ka: {
     directions:

--- a/configs/modal.config.ts
+++ b/configs/modal.config.ts
@@ -374,6 +374,58 @@ export const measureContent = {
       { text: 'DMS', esriUnit: 'dms' }
     ]
   },
+  du: {
+    // * NOTE: translation document didn't have this section
+    defaultOption: [{ text: 'Unit', esriUnit: '' }],
+    areaUnitsOfLength: [
+      { text: 'Acres', esriUnit: 'acres' },
+      { text: 'Sq Miles', esriUnit: 'square-miles' },
+      { text: 'Sq Kilometers', esriUnit: 'square-kilometers' },
+      { text: 'Hectares', esriUnit: 'hectares' },
+      { text: 'Sq Yards', esriUnit: 'square-yards' },
+      { text: 'Sq Feet(US)', esriUnit: 'square-us-feet' },
+      { text: 'Sq Meters', esriUnit: 'square-meters' }
+    ],
+    distanceUnitsOfLength: [
+      { text: 'Miles', esriUnit: 'miles' },
+      { text: 'Kilometers', esriUnit: 'kilometers' },
+      { text: 'Feet', esriUnit: 'feet' },
+      { text: 'Feet(US)', esriUnit: 'us-feet' },
+      { text: 'Meters', esriUnit: 'meters' },
+      { text: 'Yards', esriUnit: 'yards' },
+      { text: 'Nautical Miles', esriUnit: 'nautical-miles' }
+    ],
+    latitudeLongitudeUnits: [
+      { text: 'Degree', esriUnit: 'degree' },
+      { text: 'DMS', esriUnit: 'dms' }
+    ]
+  },
+  am: {
+    // * NOTE: translation document didn't have this section
+    defaultOption: [{ text: 'Unit', esriUnit: '' }],
+    areaUnitsOfLength: [
+      { text: 'Acres', esriUnit: 'acres' },
+      { text: 'Sq Miles', esriUnit: 'square-miles' },
+      { text: 'Sq Kilometers', esriUnit: 'square-kilometers' },
+      { text: 'Hectares', esriUnit: 'hectares' },
+      { text: 'Sq Yards', esriUnit: 'square-yards' },
+      { text: 'Sq Feet(US)', esriUnit: 'square-us-feet' },
+      { text: 'Sq Meters', esriUnit: 'square-meters' }
+    ],
+    distanceUnitsOfLength: [
+      { text: 'Miles', esriUnit: 'miles' },
+      { text: 'Kilometers', esriUnit: 'kilometers' },
+      { text: 'Feet', esriUnit: 'feet' },
+      { text: 'Feet(US)', esriUnit: 'us-feet' },
+      { text: 'Meters', esriUnit: 'meters' },
+      { text: 'Yards', esriUnit: 'yards' },
+      { text: 'Nautical Miles', esriUnit: 'nautical-miles' }
+    ],
+    latitudeLongitudeUnits: [
+      { text: 'Degree', esriUnit: 'degree' },
+      { text: 'DMS', esriUnit: 'dms' }
+    ]
+  },
   ka: {
     defaultOption: [{ text: 'Unit', esriUnit: '' }],
     areaUnitsOfLength: [

--- a/configs/subscribeToAlerts.translations.ts
+++ b/configs/subscribeToAlerts.translations.ts
@@ -15,7 +15,7 @@ export const subscribeConfig = {
     FORMALabel: 'FORMA alerts data',
     FORMAField: 'forma-alerts'
   },
-  du: {
+  nl: {
     title: 'Meldingen voor verandering in (bos)beddeking',
     subtitle:
       'Kies de meldingen van verandering in bosbeddeking welke u wenst te ontvangen ',
@@ -32,7 +32,7 @@ export const subscribeConfig = {
     FORMALabel: 'FORMA melding gegevens ',
     FORMAField: 'forma-alerts'
   },
-  am: {
+  hy: {
     title: 'Անտառներում տեղի ունեցող փոփոխությունների մասին նախազգուշացում ',
     subtitle:
       'Ընտրել անտառներում տեղի ունեցող որ փոփոխությունների մասին եք ցանկանում ստանալ նախազգուշացում ',
@@ -154,12 +154,12 @@ export const nameSubscriptionConfig = {
     nameLabel: 'Name',
     subscribeLabel: 'Subscribe to alerts'
   },
-  du: {
+  nl: {
     title: 'Geef uw abonnement een naam',
     nameLabel: 'Naam',
     subscribeLabel: 'Abonneer voor meldingen'
   },
-  am: {
+  hy: {
     title: 'Անվանել տվյալ բաժանորդագրությունը',
     nameLabel: 'Անվանում',
     subscribeLabel: 'Բաժանորդագրվել ծանուցումների համար'

--- a/configs/subscribeToAlerts.translations.ts
+++ b/configs/subscribeToAlerts.translations.ts
@@ -15,6 +15,40 @@ export const subscribeConfig = {
     FORMALabel: 'FORMA alerts data',
     FORMAField: 'forma-alerts'
   },
+  du: {
+    title: 'Meldingen voor verandering in (bos)beddeking',
+    subtitle:
+      'Kies de meldingen van verandering in bosbeddeking welke u wenst te ontvangen ',
+    VIIRSLabel: 'VIIRS actieve brandmeldingen',
+    VIIRSField: 'viirs-active-fires',
+    GLADLabel: 'GLAD-meldingen voor afname  van boombedekking',
+    GLADField: 'glad-alerts',
+    PRODESLabel: 'PRODES ontbossing gegevens',
+    PRODESField: 'prodes-loss',
+    treeCoverLossLabel: 'Gegevens van afname in boombedekking ',
+    treeCoverLossField: 'umd-loss-gain',
+    SADLabel: 'SAD meldingen voor afname  van boombedekking',
+    SADField: 'imazon-alerts',
+    FORMALabel: 'FORMA melding gegevens ',
+    FORMAField: 'forma-alerts'
+  },
+  am: {
+    title: 'Անտառներում տեղի ունեցող փոփոխությունների մասին նախազգուշացում ',
+    subtitle:
+      'Ընտրել անտառներում տեղի ունեցող որ փոփոխությունների մասին եք ցանկանում ստանալ նախազգուշացում ',
+    VIIRSLabel: 'VIIRS ակտիվ հրդեհների մասին ծանուցումներ ',
+    VIIRSField: 'viirs-active-fires',
+    GLADLabel: 'GLAD ծառածածկույթի կորստի մասին ծանուցումներ ',
+    GLADField: 'glad-alerts',
+    PRODESLabel: 'PRODES անտառզրկումների մասին տվյալներ ',
+    PRODESField: 'prodes-loss',
+    treeCoverLossLabel: 'TԾառածածկույթի կորստի մասին տվյալներ',
+    treeCoverLossField: 'umd-loss-gain',
+    SADLabel: 'SAD ծառածածկույթի կորստի մասինծանուցումներ',
+    SADField: 'imazon-alerts',
+    FORMALabel: 'FORMA ծանուցումների տվյալներ ',
+    FORMAField: 'forma-alerts'
+  },
   fr: {
     title: 'Alertes sur l’évolution des forêts',
     subtitle:
@@ -119,6 +153,16 @@ export const nameSubscriptionConfig = {
     title: 'Name your subscription',
     nameLabel: 'Name',
     subscribeLabel: 'Subscribe to alerts'
+  },
+  du: {
+    title: 'Geef uw abonnement een naam',
+    nameLabel: 'Naam',
+    subscribeLabel: 'Abonneer voor meldingen'
+  },
+  am: {
+    title: 'Անվանել տվյալ բաժանորդագրությունը',
+    nameLabel: 'Անվանում',
+    subscribeLabel: 'Բաժանորդագրվել ծանուցումների համար'
   },
   ka: {
     title: 'დაარქვით თქვენ ხელმოწერას',

--- a/src/js/components/dataPanel/subscribeToAlerts/SubscriptionContent.tsx
+++ b/src/js/components/dataPanel/subscribeToAlerts/SubscriptionContent.tsx
@@ -156,6 +156,11 @@ const AOIDashboardText = {
     glad: 'GLAD alerts',
     viirs: 'VIIRS alerts'
   },
+  am: {
+    created: 'Created',
+    glad: 'GLAD ծանուցումներ',
+    viirs: 'VIIRS alerts'
+  },
   es: {
     created: 'Creado el',
     glad: 'Alertas GLAD',

--- a/src/js/components/dataPanel/subscribeToAlerts/SubscriptionContent.tsx
+++ b/src/js/components/dataPanel/subscribeToAlerts/SubscriptionContent.tsx
@@ -156,12 +156,12 @@ const AOIDashboardText = {
     glad: 'GLAD alerts',
     viirs: 'VIIRS alerts'
   },
-  am: {
+  hy: {
     created: 'Created',
     glad: 'GLAD ծանուցումներ',
     viirs: 'VIIRS alerts'
   },
-  du: {
+  nl: {
     created: 'Created',
     glad: 'GLAD meldingen',
     viirs: 'VIIRS branden'

--- a/src/js/components/dataPanel/subscribeToAlerts/SubscriptionContent.tsx
+++ b/src/js/components/dataPanel/subscribeToAlerts/SubscriptionContent.tsx
@@ -161,6 +161,11 @@ const AOIDashboardText = {
     glad: 'GLAD ծանուցումներ',
     viirs: 'VIIRS alerts'
   },
+  du: {
+    created: 'Created',
+    glad: 'GLAD meldingen',
+    viirs: 'VIIRS branden'
+  },
   es: {
     created: 'Creado el',
     glad: 'Alertas GLAD',

--- a/src/js/components/gfwContent/staticOptions.tsx
+++ b/src/js/components/gfwContent/staticOptions.tsx
@@ -2238,6 +2238,42 @@ export const emailLoginTranslations = {
     reset: 'Reset',
     register: 'Register'
   },
+  du: {
+    email: 'email',
+    password: 'password',
+    repeatPassword: 'repeat password',
+    required: 'This field is required',
+    forgotPassword: 'Forgot Password!',
+    signup: ['Not a member?', 'Sign Up!'],
+    signin: ['Already joined?', 'Sign In!'],
+    registerSuccess:
+      "Thank you for registering, please check your email and confirm your account. If it doesn't appear check your spam folder.",
+    login: 'Login',
+    passwordReset:
+      'To reset your password, enter your email and follow the instructions.',
+    passwordResetSuccess:
+      "Thank you. Please, check your inbox and follow instructions to reset your password. If it doesn't appear check your spam folder.",
+    reset: 'Reset',
+    register: 'Register'
+  }, // * NOTE: dutch translation document only had translation for 'reset' property (string -> Reset)
+  am: {
+    email: 'email',
+    password: 'password',
+    repeatPassword: 'repeat password',
+    required: 'This field is required',
+    forgotPassword: 'Forgot Password!',
+    signup: ['Not a member?', 'Sign Up!'],
+    signin: ['Already joined?', 'Sign In!'],
+    registerSuccess:
+      "Thank you for registering, please check your email and confirm your account. If it doesn't appear check your spam folder.",
+    login: 'Login',
+    passwordReset:
+      'To reset your password, enter your email and follow the instructions.',
+    passwordResetSuccess:
+      "Thank you. Please, check your inbox and follow instructions to reset your password. If it doesn't appear check your spam folder.",
+    reset: 'Վերադառնալ սկզբնական կարգավորումներին',
+    register: 'Register'
+  }, // * NOTE: armenian translation document only had translation for 'reset' property
   ka: {
     email: 'ელ. ფოსტა',
     password: 'პაროლი ',

--- a/src/js/components/gfwContent/staticOptions.tsx
+++ b/src/js/components/gfwContent/staticOptions.tsx
@@ -210,7 +210,7 @@ export const sectors: SectorsObject = {
       ]
     }
   ],
-  du: [
+  nl: [
     // * NOTE: translation was not provided
     {
       sector: { label: 'Government', value: 'Government' },
@@ -417,7 +417,7 @@ export const sectors: SectorsObject = {
       ]
     }
   ],
-  am: [
+  hy: [
     // * NOTE: translation was not provided
     {
       sector: { label: 'Government', value: 'Government' },
@@ -1926,7 +1926,7 @@ export const usage: Topic = {
       id: 'Other'
     }
   ],
-  du: [
+  nl: [
     // * NOTE: translation not provided
     {
       label: 'Advocacy/campaigning',
@@ -1989,7 +1989,7 @@ export const usage: Topic = {
       id: 'Other'
     }
   ],
-  am: [
+  hy: [
     // * NOTE: translation not provided
     {
       label: 'Advocacy/campaigning',
@@ -2480,7 +2480,7 @@ export const topics: Topic = {
       id: 'Watersheds_'
     }
   ],
-  du: [
+  nl: [
     // * NOTE: translation not provided
     {
       label: 'Agricultural supply chains',
@@ -2527,7 +2527,7 @@ export const topics: Topic = {
       id: 'Watersheds_'
     }
   ],
-  am: [
+  hy: [
     // * NOTE: translation not provided
     {
       label: 'Agricultural supply chains',
@@ -2872,7 +2872,7 @@ export const emailLoginTranslations = {
     reset: 'Reset',
     register: 'Register'
   },
-  du: {
+  nl: {
     email: 'email',
     password: 'password',
     repeatPassword: 'repeat password',
@@ -2890,7 +2890,7 @@ export const emailLoginTranslations = {
     reset: 'Reset',
     register: 'Register'
   }, // * NOTE: dutch translation document only had translation for 'reset' property (string -> Reset)
-  am: {
+  hy: {
     email: 'email',
     password: 'password',
     repeatPassword: 'repeat password',
@@ -3048,7 +3048,7 @@ export const editProfileTranslations = {
     save: 'SAVE',
     back: 'BACK TO MY PROFILE'
   },
-  am: {
+  hy: {
     // * NOTE: translation not provided
     profileHeader: 'Your Profile',
     profileSubheader:
@@ -3079,7 +3079,7 @@ export const editProfileTranslations = {
     save: 'SAVE',
     back: 'BACK TO MY PROFILE'
   },
-  du: {
+  nl: {
     // * NOTE: translation not provided
     profileHeader: 'Your Profile',
     profileSubheader:

--- a/src/js/components/gfwContent/staticOptions.tsx
+++ b/src/js/components/gfwContent/staticOptions.tsx
@@ -210,6 +210,420 @@ export const sectors: SectorsObject = {
       ]
     }
   ],
+  du: [
+    // * NOTE: translation was not provided
+    {
+      sector: { label: 'Government', value: 'Government' },
+      subsectors: [
+        {
+          label: 'Forest Management/Park Management',
+          id: 'Forest_Management_Park_Management'
+        },
+        {
+          label: 'Law Enforcement',
+          id: 'Law_Enforcement'
+        },
+        {
+          label: 'Legislature/Parliament',
+          id: 'Legislature_Parliament'
+        },
+        {
+          label: 'Ministry/National Agency',
+          id: 'Ministry_National_Agency'
+        },
+        {
+          label: 'Subnational Agency',
+          id: 'Subnational_Agency'
+        },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Donor Institution / Agency',
+        value: 'Donor Institution / Agency'
+      },
+      subsectors: [
+        { label: 'Director/Executive', id: 'Director_Executive' },
+        { label: 'Project/Program Manager', id: 'Project_Program_Manager' },
+        { label: 'Researcher', id: 'Researcher' },
+        { label: 'Monitoring/Evaluation', id: 'Monitoring_Evaluation' },
+        { label: 'Field/Country Staff', id: 'Field_Country_Staff' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Local NGO (national or subnational)',
+        value: 'Local NGO (national or subnational)'
+      },
+      subsectors: [
+        { label: 'Director/Executive', id: 'Director_Executive' },
+        { label: 'Project/Program Manager', id: 'Project_Program_Manager' },
+        {
+          label: 'Monitoring/Evaluation Specialist',
+          id: 'Monitoring_Evaluation'
+        },
+        { label: 'GIS/Technical Specialist', id: 'GIS_Technical_Specialist' },
+        { label: 'Researcher', id: 'Researcher' },
+        { label: 'Field Staff', id: 'Field_Staff' },
+        { label: 'Communications Specialist', id: 'Communications_Specialist' },
+        { label: 'Park/Forest Ranger', id: 'Park_Forest_Ranger' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: { label: 'International NGO', value: 'International NGO' },
+      subsectors: [
+        { label: 'Director/Executive', id: 'Director_Executive' },
+        { label: 'Project/Program Manager', id: 'Project_Program_Manager' },
+        {
+          label: 'Monitoring/Evaluation Specialist',
+          id: 'Monitoring_Evaluation'
+        },
+        { label: 'GIS/Technical Specialist', id: 'GIS_Technical_Specialist' },
+        { label: 'Field/Country Staff', id: 'Field_Country_Staff' },
+        { label: 'Communications Specialist', id: 'Communications_Specialist' },
+        { label: 'Researcher', id: 'Researcher' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'UN or International Organization',
+        value: 'UN or International Organization'
+      },
+      subsectors: [
+        { label: 'Director/Executive', id: 'Director_Executive' },
+        { label: 'Project/Program Manager', id: 'Project_Program_Manager' },
+        { label: 'Researcher', id: 'Researcher' },
+        { label: 'Field/Country Staff', id: 'Field_Country_Staff' },
+        {
+          label: 'Monitoring/Evaluation Specialit',
+          id: 'Monitoring_Evaluation'
+        },
+        { label: 'GIS/Technical Specialist', id: 'GIS_Technical_Specialist' },
+        { label: 'Communications Specialist', id: 'Communications_Specialist' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Academic / Research Organization',
+        value: 'Academic / Research Organization'
+      },
+      subsectors: [
+        {
+          label: 'Faculty (Primary/Secondary)',
+          id: 'Faculty_(Primary_Secondary)'
+        },
+        { label: 'Faculty (University)', id: 'Faculty_(University)' },
+        {
+          label: 'Student (Primary/Secondary)',
+          id: 'Student_(Primary_Secondary)'
+        },
+        {
+          label: 'Student (University/Graduate)',
+          id: 'Student_(University_Graduate)'
+        },
+        {
+          label: 'Researcher (Post-Doc, Fellow, etc.)',
+          id: 'Researcher_(Post-Doc,_Fellow,_etc.)'
+        },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Journalist / Media Organization',
+        value: 'Journalist / Media Organization'
+      },
+      subsectors: [
+        { label: 'Reporter', id: 'Reporter' },
+        { label: 'Editor', id: 'Editor' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Indigenous or Community-Based Organization',
+        value: 'Indigenous or Community-Based Organization'
+      },
+      subsectors: [
+        { label: 'Community Leader', id: 'Community_Leader' },
+        { label: 'Forest Manager/Monitor', id: 'Forest_Manager_Monitor' },
+        { label: 'GIS/Technical Specialist', id: 'GIS_Technical_Specialist' },
+        { label: 'Communications Specialist', id: 'Communications_Specialist' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: { label: 'Private sector', value: 'Private sector' },
+      subsectors: [
+        { label: 'Supply Chain Manager', id: 'Supply_Chain_Manager' },
+        { label: 'Supply Chain Analyst', id: 'Supply_Chain_Analyst' },
+        { label: 'Procurement Staff', id: 'Procurement_Staff' },
+        { label: 'Retailer/Trader', id: 'Retailer_Trader' },
+        { label: 'Land or Concession Owner', id: 'Land_or_Concession_Owner' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Individual / No Affiliation',
+        value: 'Individual / No Affiliation'
+      },
+      subsectors: [
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: { label: 'Other:', value: 'Other:' },
+      subsectors: [
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    }
+  ],
+  am: [
+    // * NOTE: translation was not provided
+    {
+      sector: { label: 'Government', value: 'Government' },
+      subsectors: [
+        {
+          label: 'Forest Management/Park Management',
+          id: 'Forest_Management_Park_Management'
+        },
+        {
+          label: 'Law Enforcement',
+          id: 'Law_Enforcement'
+        },
+        {
+          label: 'Legislature/Parliament',
+          id: 'Legislature_Parliament'
+        },
+        {
+          label: 'Ministry/National Agency',
+          id: 'Ministry_National_Agency'
+        },
+        {
+          label: 'Subnational Agency',
+          id: 'Subnational_Agency'
+        },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Donor Institution / Agency',
+        value: 'Donor Institution / Agency'
+      },
+      subsectors: [
+        { label: 'Director/Executive', id: 'Director_Executive' },
+        { label: 'Project/Program Manager', id: 'Project_Program_Manager' },
+        { label: 'Researcher', id: 'Researcher' },
+        { label: 'Monitoring/Evaluation', id: 'Monitoring_Evaluation' },
+        { label: 'Field/Country Staff', id: 'Field_Country_Staff' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Local NGO (national or subnational)',
+        value: 'Local NGO (national or subnational)'
+      },
+      subsectors: [
+        { label: 'Director/Executive', id: 'Director_Executive' },
+        { label: 'Project/Program Manager', id: 'Project_Program_Manager' },
+        {
+          label: 'Monitoring/Evaluation Specialist',
+          id: 'Monitoring_Evaluation'
+        },
+        { label: 'GIS/Technical Specialist', id: 'GIS_Technical_Specialist' },
+        { label: 'Researcher', id: 'Researcher' },
+        { label: 'Field Staff', id: 'Field_Staff' },
+        { label: 'Communications Specialist', id: 'Communications_Specialist' },
+        { label: 'Park/Forest Ranger', id: 'Park_Forest_Ranger' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: { label: 'International NGO', value: 'International NGO' },
+      subsectors: [
+        { label: 'Director/Executive', id: 'Director_Executive' },
+        { label: 'Project/Program Manager', id: 'Project_Program_Manager' },
+        {
+          label: 'Monitoring/Evaluation Specialist',
+          id: 'Monitoring_Evaluation'
+        },
+        { label: 'GIS/Technical Specialist', id: 'GIS_Technical_Specialist' },
+        { label: 'Field/Country Staff', id: 'Field_Country_Staff' },
+        { label: 'Communications Specialist', id: 'Communications_Specialist' },
+        { label: 'Researcher', id: 'Researcher' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'UN or International Organization',
+        value: 'UN or International Organization'
+      },
+      subsectors: [
+        { label: 'Director/Executive', id: 'Director_Executive' },
+        { label: 'Project/Program Manager', id: 'Project_Program_Manager' },
+        { label: 'Researcher', id: 'Researcher' },
+        { label: 'Field/Country Staff', id: 'Field_Country_Staff' },
+        {
+          label: 'Monitoring/Evaluation Specialit',
+          id: 'Monitoring_Evaluation'
+        },
+        { label: 'GIS/Technical Specialist', id: 'GIS_Technical_Specialist' },
+        { label: 'Communications Specialist', id: 'Communications_Specialist' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Academic / Research Organization',
+        value: 'Academic / Research Organization'
+      },
+      subsectors: [
+        {
+          label: 'Faculty (Primary/Secondary)',
+          id: 'Faculty_(Primary_Secondary)'
+        },
+        { label: 'Faculty (University)', id: 'Faculty_(University)' },
+        {
+          label: 'Student (Primary/Secondary)',
+          id: 'Student_(Primary_Secondary)'
+        },
+        {
+          label: 'Student (University/Graduate)',
+          id: 'Student_(University_Graduate)'
+        },
+        {
+          label: 'Researcher (Post-Doc, Fellow, etc.)',
+          id: 'Researcher_(Post-Doc,_Fellow,_etc.)'
+        },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Journalist / Media Organization',
+        value: 'Journalist / Media Organization'
+      },
+      subsectors: [
+        { label: 'Reporter', id: 'Reporter' },
+        { label: 'Editor', id: 'Editor' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Indigenous or Community-Based Organization',
+        value: 'Indigenous or Community-Based Organization'
+      },
+      subsectors: [
+        { label: 'Community Leader', id: 'Community_Leader' },
+        { label: 'Forest Manager/Monitor', id: 'Forest_Manager_Monitor' },
+        { label: 'GIS/Technical Specialist', id: 'GIS_Technical_Specialist' },
+        { label: 'Communications Specialist', id: 'Communications_Specialist' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: { label: 'Private sector', value: 'Private sector' },
+      subsectors: [
+        { label: 'Supply Chain Manager', id: 'Supply_Chain_Manager' },
+        { label: 'Supply Chain Analyst', id: 'Supply_Chain_Analyst' },
+        { label: 'Procurement Staff', id: 'Procurement_Staff' },
+        { label: 'Retailer/Trader', id: 'Retailer_Trader' },
+        { label: 'Land or Concession Owner', id: 'Land_or_Concession_Owner' },
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: {
+        label: 'Individual / No Affiliation',
+        value: 'Individual / No Affiliation'
+      },
+      subsectors: [
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    },
+    {
+      sector: { label: 'Other:', value: 'Other:' },
+      subsectors: [
+        {
+          label: 'Other',
+          id: 'Other: '
+        }
+      ]
+    }
+  ],
   fr: [
     {
       sector: { label: 'Gouvernement', value: 'Government' },
@@ -1512,6 +1926,132 @@ export const usage: Topic = {
       id: 'Other'
     }
   ],
+  du: [
+    // * NOTE: translation not provided
+    {
+      label: 'Advocacy/campaigning',
+      id: 'Advocacy/campaigning'
+    },
+    {
+      label: 'Data or visuals for blogs or media stories',
+      id: 'Data or visuals for blogs or media stories'
+    },
+    {
+      label: 'Data or visuals for presentations and reports',
+      id: 'Data or visuals for presentations and reports'
+    },
+    {
+      label: 'Educational support materials',
+      id: 'Educational support materials'
+    },
+    {
+      label: 'General research',
+      id: 'General research'
+    },
+    {
+      label: 'Identify illegal activity',
+      id: 'Identify illegal activity'
+    },
+    {
+      label: 'Inform grant funding decisions/results-based payments',
+      id: 'Inform grant funding decisions/results-based payments'
+    },
+    {
+      label: 'Inform purchasing/procurement/investment decisions',
+      id: 'Inform purchasing/procurement/investment decisions'
+    },
+    {
+      label: 'Land use planning/land use allocation',
+      id: 'Land use planning/land use allocation'
+    },
+    {
+      label: 'Learn about forests/my country',
+      id: 'Learn about forests/my country'
+    },
+    {
+      label: 'Monitor or manage an area',
+      id: 'Monitor or manage an area'
+    },
+    {
+      label: 'Monitor results/impacts',
+      id: 'Monitor results/impacts'
+    },
+    {
+      label: 'Not sure; new to GFW',
+      id: 'Not sure; new to GFW'
+    },
+    {
+      label: 'Plan field work (patrols/investigations)',
+      id: 'Plan field work (patrols/investigations)'
+    },
+    {
+      label: 'Other',
+      id: 'Other'
+    }
+  ],
+  am: [
+    // * NOTE: translation not provided
+    {
+      label: 'Advocacy/campaigning',
+      id: 'Advocacy/campaigning'
+    },
+    {
+      label: 'Data or visuals for blogs or media stories',
+      id: 'Data or visuals for blogs or media stories'
+    },
+    {
+      label: 'Data or visuals for presentations and reports',
+      id: 'Data or visuals for presentations and reports'
+    },
+    {
+      label: 'Educational support materials',
+      id: 'Educational support materials'
+    },
+    {
+      label: 'General research',
+      id: 'General research'
+    },
+    {
+      label: 'Identify illegal activity',
+      id: 'Identify illegal activity'
+    },
+    {
+      label: 'Inform grant funding decisions/results-based payments',
+      id: 'Inform grant funding decisions/results-based payments'
+    },
+    {
+      label: 'Inform purchasing/procurement/investment decisions',
+      id: 'Inform purchasing/procurement/investment decisions'
+    },
+    {
+      label: 'Land use planning/land use allocation',
+      id: 'Land use planning/land use allocation'
+    },
+    {
+      label: 'Learn about forests/my country',
+      id: 'Learn about forests/my country'
+    },
+    {
+      label: 'Monitor or manage an area',
+      id: 'Monitor or manage an area'
+    },
+    {
+      label: 'Monitor results/impacts',
+      id: 'Monitor results/impacts'
+    },
+    {
+      label: 'Not sure; new to GFW',
+      id: 'Not sure; new to GFW'
+    },
+    {
+      label: 'Plan field work (patrols/investigations)',
+      id: 'Plan field work (patrols/investigations)'
+    },
+    {
+      label: 'Other',
+      id: 'Other'
+    }
+  ],
   ka: [
     {
       label: 'Advocacy/campaigning',
@@ -1895,6 +2435,100 @@ export const usage: Topic = {
 
 export const topics: Topic = {
   en: [
+    {
+      label: 'Agricultural supply chains',
+      id: 'Agricultural_supply_chains'
+    },
+    {
+      label: 'Biodiversity',
+      id: 'Biodiversity'
+    },
+    {
+      label: 'Climate/Carbon',
+      id: 'Climate_Carbon'
+    },
+    {
+      label: 'Deforestation/Forest Degradation',
+      id: 'Deforestation_Forest_Degradation'
+    },
+    {
+      label: 'Fires',
+      id: 'Fires'
+    },
+    {
+      label: 'General information/Data about forests',
+      id: 'General_information_Data_about_forests'
+    },
+    {
+      label: 'Innovations in forest monitoring',
+      id: 'Innovations_in_forest_monitoring'
+    },
+    {
+      label: 'My region or country',
+      id: 'My_region_or_country'
+    },
+    {
+      label: 'Reforestation/Landscape restoration',
+      id: 'Reforestation_Landscape_restoration'
+    },
+    {
+      label: 'Small Grants Fund and Tech Fellowship',
+      id: 'Small_Grants_Fund_and_Tech_Fellowship'
+    },
+    {
+      label: 'Watersheds',
+      id: 'Watersheds_'
+    }
+  ],
+  du: [
+    // * NOTE: translation not provided
+    {
+      label: 'Agricultural supply chains',
+      id: 'Agricultural_supply_chains'
+    },
+    {
+      label: 'Biodiversity',
+      id: 'Biodiversity'
+    },
+    {
+      label: 'Climate/Carbon',
+      id: 'Climate_Carbon'
+    },
+    {
+      label: 'Deforestation/Forest Degradation',
+      id: 'Deforestation_Forest_Degradation'
+    },
+    {
+      label: 'Fires',
+      id: 'Fires'
+    },
+    {
+      label: 'General information/Data about forests',
+      id: 'General_information_Data_about_forests'
+    },
+    {
+      label: 'Innovations in forest monitoring',
+      id: 'Innovations_in_forest_monitoring'
+    },
+    {
+      label: 'My region or country',
+      id: 'My_region_or_country'
+    },
+    {
+      label: 'Reforestation/Landscape restoration',
+      id: 'Reforestation_Landscape_restoration'
+    },
+    {
+      label: 'Small Grants Fund and Tech Fellowship',
+      id: 'Small_Grants_Fund_and_Tech_Fellowship'
+    },
+    {
+      label: 'Watersheds',
+      id: 'Watersheds_'
+    }
+  ],
+  am: [
+    // * NOTE: translation not provided
     {
       label: 'Agricultural supply chains',
       id: 'Agricultural_supply_chains'
@@ -2385,6 +3019,68 @@ export const emailLoginTranslations = {
 
 export const editProfileTranslations = {
   en: {
+    profileHeader: 'Your Profile',
+    profileSubheader:
+      "We use this information to make Global Forest Watch more useful for you. Your privacy is important to us and we'll never share your information without your consent.",
+    fName: 'First Name',
+    lName: 'Last Name',
+    required: 'This field is required',
+    email: 'email',
+    sector: 'Sector',
+    role: 'Role',
+    jobTitle: 'Job Title',
+    company: 'Company / Organization',
+    located: 'Where are you located?',
+    country: 'Country',
+    city: 'City',
+    state: 'state / department / province',
+    interest: 'What area are you most interested in?',
+    topics: 'what topics are you interested in?',
+    selectAll: 'select all that apply',
+    howUse: 'how do you use global forest watch?',
+    delete: ['Email us', 'to delete your MyGFW account.'],
+    success: [
+      'Thank you for updating your My GFW profile!',
+      'You may wish to read our',
+      'privacy policy',
+      'which provides further information about how we use personal data.'
+    ],
+    save: 'SAVE',
+    back: 'BACK TO MY PROFILE'
+  },
+  am: {
+    // * NOTE: translation not provided
+    profileHeader: 'Your Profile',
+    profileSubheader:
+      "We use this information to make Global Forest Watch more useful for you. Your privacy is important to us and we'll never share your information without your consent.",
+    fName: 'First Name',
+    lName: 'Last Name',
+    required: 'This field is required',
+    email: 'email',
+    sector: 'Sector',
+    role: 'Role',
+    jobTitle: 'Job Title',
+    company: 'Company / Organization',
+    located: 'Where are you located?',
+    country: 'Country',
+    city: 'City',
+    state: 'state / department / province',
+    interest: 'What area are you most interested in?',
+    topics: 'what topics are you interested in?',
+    selectAll: 'select all that apply',
+    howUse: 'how do you use global forest watch?',
+    delete: ['Email us', 'to delete your MyGFW account.'],
+    success: [
+      'Thank you for updating your My GFW profile!',
+      'You may wish to read our',
+      'privacy policy',
+      'which provides further information about how we use personal data.'
+    ],
+    save: 'SAVE',
+    back: 'BACK TO MY PROFILE'
+  },
+  du: {
+    // * NOTE: translation not provided
     profileHeader: 'Your Profile',
     profileSubheader:
       "We use this information to make Global Forest Watch more useful for you. Your privacy is important to us and we'll never share your information without your consent.",

--- a/src/js/components/header/LanguageDropdown.tsx
+++ b/src/js/components/header/LanguageDropdown.tsx
@@ -19,10 +19,10 @@ function valueToLang(abbrev: string): string {
     case 'en':
       lang = 'English';
       break;
-    case 'du':
+    case 'nl':
       lang = 'Dutch';
       break;
-    case 'am':
+    case 'hy':
       lang = 'Armenian';
       break;
     case 'es':

--- a/src/js/components/header/LanguageDropdown.tsx
+++ b/src/js/components/header/LanguageDropdown.tsx
@@ -19,6 +19,12 @@ function valueToLang(abbrev: string): string {
     case 'en':
       lang = 'English';
       break;
+    case 'du':
+      lang = 'Dutch';
+      break;
+    case 'am':
+      lang = 'Armenian';
+      break;
     case 'es':
       lang = 'Spanish';
       break;

--- a/src/js/components/header/header.translations.ts
+++ b/src/js/components/header/header.translations.ts
@@ -17,7 +17,7 @@ export const headerContent = {
     logout: 'Log Out',
     language: 'Select Language'
   },
-  du: {
+  nl: {
     about: 'Over ons',
     download: 'Download Data',
     mapThemes: 'Map Themes', // * NOTE: doesn't exist in translations document
@@ -35,7 +35,7 @@ export const headerContent = {
     logout: 'Log Uit',
     language: 'Kies taal'
   },
-  am: {
+  hy: {
     about: 'Մեր մասին',
     download: 'Ներբեռնել տվյալները ',
     mapThemes: 'Map Themes', // * NOTE: doesn't exist in translations document

--- a/src/js/components/header/header.translations.ts
+++ b/src/js/components/header/header.translations.ts
@@ -17,6 +17,42 @@ export const headerContent = {
     logout: 'Log Out',
     language: 'Select Language'
   },
+  du: {
+    about: 'Over ons',
+    download: 'Download Data',
+    mapThemes: 'Map Themes', // * NOTE: doesn't exist in translations document
+    myGFWLogin: 'Log in mijn GFW',
+    myGFW: 'Mijn GFW',
+    loginReq:
+      'Inloggen is vereist zodat u kunt terugkeren naar Global Forest Watch om uw abonnementen te bekijken, beheren en verwijderen. Vragen?',
+    contactUs: 'Contact ons op gfw@wri.org',
+    twitter: 'Log in met Twitter',
+    facebook: 'Log in met Facebook',
+    google: 'Log in met Google',
+    subscriptions: 'Mijn abonnementen ',
+    stories: 'Mijn verhalen ',
+    profile: 'Mijn GFW Profiel',
+    logout: 'Log Uit',
+    language: 'Kies taal'
+  },
+  am: {
+    about: 'Մեր մասին',
+    download: 'Ներբեռնել տվյալները ',
+    mapThemes: 'Map Themes', // * NOTE: doesn't exist in translations document
+    myGFWLogin: 'Մուտքագրվել իմ ԱԳՀ էջ',
+    myGFW: 'Իմ ԱԳՀ էջ /Անտառների Գլոբալ Հսկողություն/ ',
+    loginReq:
+      'Անտառների Գլոբալ Հսկողության համակարգ վերադառնալու, Ձեր բաժանորդագրությունը դիտարկելու, կառավարելու և ջնջելու համար անհրաժեշտ է մուտքագրվել: Հարցերի դեպքում խնդրում ենք կապ հաստատել:  ',
+    contactUs: 'Մեզ հետ կարող եք կապ հաստատել gfw@wri.org էլ.փոստի միջոցով ',
+    twitter: 'Գրանցվել Twitter-ի միջոցով ',
+    facebook: 'Գրանցվել Facebook-ի միջոցով ',
+    google: 'ԳրանցվելGoogle-ի միջոցով  ',
+    subscriptions: 'Իմ բաժանորդագրությունները ',
+    stories: 'Իմ պատմությունները ',
+    profile: 'Իմ ԱԳՀ հաշիվը/էջը ',
+    logout: 'Դուրս գալ ',
+    language: 'Ընտրել լեզուն '
+  },
   ka: {
     about: 'პროექტის შესახებ',
     download: 'მონაცემების გადმოწერა',

--- a/src/js/components/leftPanel/LeftPanel.tsx
+++ b/src/js/components/leftPanel/LeftPanel.tsx
@@ -221,7 +221,6 @@ const LeftPanel = (): React.ReactElement => {
       tooltipText: 'Analysis',
       render: true
     },
-
     {
       label: 'documents',
       icon: DocumentsTabIcon,

--- a/src/js/components/leftPanel/analysisPanel/analysisTranslations.ts
+++ b/src/js/components/leftPanel/analysisPanel/analysisTranslations.ts
@@ -1,6 +1,8 @@
 export default {
   runAnalysisButton: {
     en: 'Run Analysis',
+    du: 'Voer analyse uit',
+    am: 'Կատարել վերլուծությունը ',
     fr: "Exécuter L'analyse",
     ka: 'Run Analysis',
     es: 'Run Analysis',
@@ -9,6 +11,8 @@ export default {
   },
   defaultAnalysisLabel: {
     en: 'Select analysis...',
+    du: 'Selecteer analyse...',
+    am: 'Ընտրել վերլուծությունը... ',
     fr: "Sélectionner l'analyse...",
     ka: 'Select analysis...',
     es: 'Select analysis...',
@@ -20,6 +24,14 @@ export default {
     en: [
       'Analysis not selected',
       'Select an analysis from the drop-down menu to begin.'
+    ],
+    du: [
+      'Analyse niet geselecteerd',
+      'Selecteer een analyse in het vervolgkeuzemenu om te beginnen.'
+    ],
+    am: [
+      'Վերլուծությունն ընտրված չէ ',
+      'Սկսելու համար բացվող ընտրացանկից ընտրել վերլուծության տեսակը'
     ],
     fr: [
       'Analyse non sélectionnée.',
@@ -50,16 +62,20 @@ export default {
     es: 'Guardar',
     pt: 'Salvar',
     id: 'Simpan',
-    zh: '保存'
+    zh: '保存',
+    am: 'Պահպանել',
+    du: 'Opslaan'
   },
   editButton: {
     en: 'Edit',
+    du: 'Bewerk',
     fr: 'Modifier',
     ka: 'რედაქტირება',
     es: 'Editar',
     pt: 'Editar',
     id: 'Ubah',
-    zh: '编辑'
+    zh: '编辑',
+    am: 'խմբագրել'
   },
   deleteButton: {
     en: 'Delete',
@@ -68,6 +84,8 @@ export default {
     es: 'Eliminar',
     pt: 'Excluir',
     id: 'Delete',
-    zh: '删除'
+    zh: '删除',
+    am: 'Ջնջել',
+    du: 'Verwijder '
   }
 };

--- a/src/js/components/leftPanel/analysisPanel/analysisTranslations.ts
+++ b/src/js/components/leftPanel/analysisPanel/analysisTranslations.ts
@@ -1,8 +1,8 @@
 export default {
   runAnalysisButton: {
     en: 'Run Analysis',
-    du: 'Voer analyse uit',
-    am: 'Կատարել վերլուծությունը ',
+    nl: 'Voer analyse uit',
+    hy: 'Կատարել վերլուծությունը ',
     fr: "Exécuter L'analyse",
     ka: 'Run Analysis',
     es: 'Run Analysis',
@@ -11,8 +11,8 @@ export default {
   },
   defaultAnalysisLabel: {
     en: 'Select analysis...',
-    du: 'Selecteer analyse...',
-    am: 'Ընտրել վերլուծությունը... ',
+    nl: 'Selecteer analyse...',
+    hy: 'Ընտրել վերլուծությունը... ',
     fr: "Sélectionner l'analyse...",
     ka: 'Select analysis...',
     es: 'Select analysis...',
@@ -25,11 +25,11 @@ export default {
       'Analysis not selected',
       'Select an analysis from the drop-down menu to begin.'
     ],
-    du: [
+    nl: [
       'Analyse niet geselecteerd',
       'Selecteer een analyse in het vervolgkeuzemenu om te beginnen.'
     ],
-    am: [
+    hy: [
       'Վերլուծությունն ընտրված չէ ',
       'Սկսելու համար բացվող ընտրացանկից ընտրել վերլուծության տեսակը'
     ],
@@ -63,19 +63,19 @@ export default {
     pt: 'Salvar',
     id: 'Simpan',
     zh: '保存',
-    am: 'Պահպանել',
-    du: 'Opslaan'
+    hy: 'Պահպանել',
+    nl: 'Opslaan'
   },
   editButton: {
     en: 'Edit',
-    du: 'Bewerk',
+    nl: 'Bewerk',
     fr: 'Modifier',
     ka: 'რედაქტირება',
     es: 'Editar',
     pt: 'Editar',
     id: 'Ubah',
     zh: '编辑',
-    am: 'խմբագրել'
+    hy: 'խմբագրել'
   },
   deleteButton: {
     en: 'Delete',
@@ -85,7 +85,7 @@ export default {
     pt: 'Excluir',
     id: 'Delete',
     zh: '删除',
-    am: 'Ջնջել',
-    du: 'Verwijder '
+    hy: 'Ջնջել',
+    nl: 'Verwijder '
   }
 };

--- a/src/js/components/leftPanel/dataPanel/subscribeToAlerts/staticTextTranslations.tsx
+++ b/src/js/components/leftPanel/dataPanel/subscribeToAlerts/staticTextTranslations.tsx
@@ -22,7 +22,7 @@ export const saveAOIText = {
     deleteText: 'This area has been deleted from your My GFW.',
     monthly: 'Monthly summary'
   },
-  am: {
+  hy: {
     // * NOTE: translations not provided
     title: 'Save area of interest',
     nameLabel: 'Name this area for later reference *',
@@ -46,7 +46,7 @@ export const saveAOIText = {
     deleteText: 'This area has been deleted from your My GFW.',
     monthly: 'Monthly summary'
   },
-  du: {
+  nl: {
     // * NOTE: translations not provided
     title: 'Save area of interest',
     nameLabel: 'Name this area for later reference *',

--- a/src/js/components/leftPanel/dataPanel/subscribeToAlerts/staticTextTranslations.tsx
+++ b/src/js/components/leftPanel/dataPanel/subscribeToAlerts/staticTextTranslations.tsx
@@ -22,6 +22,54 @@ export const saveAOIText = {
     deleteText: 'This area has been deleted from your My GFW.',
     monthly: 'Monthly summary'
   },
+  am: {
+    // * NOTE: translations not provided
+    title: 'Save area of interest',
+    nameLabel: 'Name this area for later reference *',
+    tagsLabel: 'Assign tags to organize and group areas',
+    tagsSubLabel: 'Hit enter to create and separate tags',
+    required: 'Required',
+    alertNote:
+      'We will send you email updates about alerts and forest cover change in your selected area, based on your user profile.',
+    email: 'email',
+    notifications: 'WOULD YOU LIKE TO RECIEVE ALERT NOTIFICATIONS?',
+    fireDetected: 'As soon as fires are detected',
+    forestChange: 'As soon as forest change is detected',
+    language: 'Language',
+    save: 'պահպանել',
+    delete: 'ջնջել',
+    successButton: 'Նախորդը',
+    successText: [
+      'Your area has been saved',
+      "Check your email and click on the link to confirm your subscription. If you don't see an email, check your junk or spam email folder."
+    ],
+    deleteText: 'This area has been deleted from your My GFW.',
+    monthly: 'Monthly summary'
+  },
+  du: {
+    // * NOTE: translations not provided
+    title: 'Save area of interest',
+    nameLabel: 'Name this area for later reference *',
+    tagsLabel: 'Assign tags to organize and group areas',
+    tagsSubLabel: 'Hit enter to create and separate tags',
+    required: 'Required',
+    alertNote:
+      'We will send you email updates about alerts and forest cover change in your selected area, based on your user profile.',
+    email: 'email',
+    notifications: 'WOULD YOU LIKE TO RECIEVE ALERT NOTIFICATIONS?',
+    fireDetected: 'As soon as fires are detected',
+    forestChange: 'As soon as forest change is detected',
+    language: 'Language',
+    save: 'SAVE',
+    delete: 'DELETE AREA',
+    successButton: 'BACK TO MY AREAS',
+    successText: [
+      'Your area has been saved',
+      "Check your email and click on the link to confirm your subscription. If you don't see an email, check your junk or spam email folder."
+    ],
+    deleteText: 'This area has been deleted from your My GFW.',
+    monthly: 'Monthly summary'
+  },
   fr: {
     title: "Enregistrer une zone d'intérêt",
     nameLabel: 'Donnez un nom à cette région pour référence ultérieure *',

--- a/src/js/components/leftPanel/layersPanel/RecentImagery/imageryLanguages.ts
+++ b/src/js/components/leftPanel/layersPanel/RecentImagery/imageryLanguages.ts
@@ -161,6 +161,62 @@ export default {
       { label: `Vegetation Health` }
     ]
   },
+  du: {
+    imagery: [
+      'Recente afbeeldingen',
+      'Recente satellietbeelden met hoge resolutie'
+    ],
+    acquisition: 'Aankoopdatum ',
+    date: 'Datum',
+    naturalColor: 'Natuurlijke kleur ',
+    vegetation: 'Vegetatie Gezondheid',
+    instrument: 'Instrument',
+    cloud: 'Wolkendekking ',
+    months: 'Maanden ',
+    weeks: 'Weken ',
+    cloudPercentage: 'Maximaal bewolking percentage',
+    edit: 'Bewerken ',
+    before: 'Voordat ',
+    loadError: 'Fout bij het laden van recent beeldmateriaal.',
+    matchError:
+      'Er zijn geen resultaten die overeenkomen met de geselecteerde criteria.',
+    monthsOptions: [
+      { label: `4 months`, value: 4 },
+      { label: `3 months`, value: 3 },
+      { label: `6 months`, value: 6 },
+      { label: `12 months`, value: 12 }
+    ],
+    imageStyleOptions: [
+      { label: `Natuurlijke kleur` },
+      { label: `Vegetation Gezondheid` }
+    ]
+  },
+  am: {
+    imagery: ['Վերջին նկարը', 'Վերջին բարձր լուծաչափով արբանյակային նկարը '],
+    acquisition: 'Ստացման ամսաթիվ',
+    date: 'ամսաթիվ ',
+    naturalColor: 'Բնական գույներ ',
+    vegetation: 'Բուսականության առողջություն ',
+    instrument: 'Գործիքներ',
+    cloud: 'Ամպային ծածկույթ ',
+    months: 'Ամիսներ',
+    weeks: 'Շաբաթներ',
+    cloudPercentage: 'Ամպային ծածկույթի առավելագույն տոկոս ',
+    edit: 'Խմբագրել',
+    before: 'Նախորդ',
+    loadError: 'Վերջին նկարի բեռնման սխալ ',
+    matchError: 'Ընտրված չափանիշների համապատասխանող արդյունքներ չեն գտնվել',
+    monthsOptions: [
+      { label: `4 months`, value: 4 },
+      { label: `3 months`, value: 3 },
+      { label: `6 months`, value: 6 },
+      { label: `12 months`, value: 12 }
+    ],
+    imageStyleOptions: [
+      { label: `Բնական գույներ ` },
+      { label: `Բուսականության առողջություն` }
+    ]
+  },
   ka: {
     imagery: [
       'ბოლო გამოსახულება',

--- a/src/js/components/leftPanel/layersPanel/RecentImagery/imageryLanguages.ts
+++ b/src/js/components/leftPanel/layersPanel/RecentImagery/imageryLanguages.ts
@@ -161,7 +161,7 @@ export default {
       { label: `Vegetation Health` }
     ]
   },
-  du: {
+  nl: {
     imagery: [
       'Recente afbeeldingen',
       'Recente satellietbeelden met hoge resolutie'
@@ -191,7 +191,7 @@ export default {
       { label: `Vegetation Gezondheid` }
     ]
   },
-  am: {
+  hy: {
     imagery: ['Վերջին նկարը', 'Վերջին բարձր լուծաչափով արբանյակային նկարը '],
     acquisition: 'Ստացման ամսաթիվ',
     date: 'ամսաթիվ ',

--- a/src/js/components/sharedComponents/PrintReportButton.tsx
+++ b/src/js/components/sharedComponents/PrintReportButton.tsx
@@ -11,9 +11,9 @@ const printReportTranslations = {
   id: 'Print Report',
   zh: '打印报告',
   en: 'Print Report',
-  am: 'Տպել արդյունքները',
+  hy: 'Տպել արդյունքները',
   ka: 'ანგარიშის ბეჭდვა',
-  du: 'Rapport afdrukken'
+  nl: 'Rapport afdrukken'
 };
 
 export const PrintReportButton = (): JSX.Element => {

--- a/src/js/components/sharedComponents/PrintReportButton.tsx
+++ b/src/js/components/sharedComponents/PrintReportButton.tsx
@@ -11,7 +11,9 @@ const printReportTranslations = {
   id: 'Print Report',
   zh: '打印报告',
   en: 'Print Report',
-  ka: 'ანგარიშის ბეჭდვა'
+  am: 'Տպել արդյունքները',
+  ka: 'ანგარიშის ბეჭდვა',
+  du: 'Rapport afdrukken'
 };
 
 export const PrintReportButton = (): JSX.Element => {

--- a/src/js/components/sharedComponents/SubscribeButton.tsx
+++ b/src/js/components/sharedComponents/SubscribeButton.tsx
@@ -9,6 +9,8 @@ import 'css/subscribeButton.scss';
 const subscribeButtonTranslations = {
   zh: '保存到“我的 GFW”中',
   en: 'save in my gfw',
+  am: 'save in my gfw', // * NOTE: translation not provided
+  du: 'save in my gfw', // * NOTE: translation not provided
   ka: 'გამოწერა',
   fr: 'enregistrer',
   es: 'guardar en My GFW',

--- a/src/js/components/sharedComponents/SubscribeButton.tsx
+++ b/src/js/components/sharedComponents/SubscribeButton.tsx
@@ -9,8 +9,8 @@ import 'css/subscribeButton.scss';
 const subscribeButtonTranslations = {
   zh: '保存到“我的 GFW”中',
   en: 'save in my gfw',
-  am: 'save in my gfw', // * NOTE: translation not provided
-  du: 'save in my gfw', // * NOTE: translation not provided
+  hy: 'save in my gfw', // * NOTE: translation not provided
+  nl: 'save in my gfw', // * NOTE: translation not provided
   ka: 'გამოწერა',
   fr: 'enregistrer',
   es: 'guardar en My GFW',

--- a/src/js/components/sharedComponents/UploadFile.tsx
+++ b/src/js/components/sharedComponents/UploadFile.tsx
@@ -36,6 +36,16 @@ const UploadFile = (): JSX.Element => {
       shapefileInstructions:
         'Only polygon data is supported and should use a spatial reference of WGS84. The recommended maximum size is 1MB, anything more than that may not work as expected. Esri shapefiles must be zipped (.zip) and GeoJSON files must be in .json files.'
     },
+    du: {
+      shapefileButton: 'of plaats hier een aangepast shapefile hier',
+      shapefileInstructions:
+        'Alleen polygoongegevens worden ondersteund en zouden een ruimtelijke referentie van WGS84 moeten gebruiken. De aanbevolen maximale grootte is 1 MB, meer dan dat werkt mogelijk niet zoals verwacht. Esri-shapefiles moeten gezipt zijn (.zip) en GeoJSON-bestanden moeten in .json-bestanden zijn.'
+    },
+    am: {
+      shapefileButton: 'կամ գցել սովորական շեյփ-ֆայլ (shapefile) այստեղ',
+      shapefileInstructions:
+        'Անհրաժեշտ է մուտքագրել միայն բազմակնութուն տվյալներ և օգտագործել WGS84 կոորդինատային համակարգ: Մուտքագրվող տվյալների առաջարկվող առավելագույն ծավալը 1 ՄԲ է, դրանից ավել ծավալների դեպքում գործիքը կարող է նախատեսված կարգով չաշխատել: Esri շեյփ-ֆայլերը (shapefile) պետք է լինեն արխիվացված (.zip), իսկ GeoJSON ֆայլերը որպես .json ֆորմատով '
+    },
     ka: {
       shapefileButton: 'ან შემოიტანეთ სხვა შეიპფაილი',
       shapefileInstructions:

--- a/src/js/components/sharedComponents/UploadFile.tsx
+++ b/src/js/components/sharedComponents/UploadFile.tsx
@@ -36,12 +36,12 @@ const UploadFile = (): JSX.Element => {
       shapefileInstructions:
         'Only polygon data is supported and should use a spatial reference of WGS84. The recommended maximum size is 1MB, anything more than that may not work as expected. Esri shapefiles must be zipped (.zip) and GeoJSON files must be in .json files.'
     },
-    du: {
+    nl: {
       shapefileButton: 'of plaats hier een aangepast shapefile hier',
       shapefileInstructions:
         'Alleen polygoongegevens worden ondersteund en zouden een ruimtelijke referentie van WGS84 moeten gebruiken. De aanbevolen maximale grootte is 1 MB, meer dan dat werkt mogelijk niet zoals verwacht. Esri-shapefiles moeten gezipt zijn (.zip) en GeoJSON-bestanden moeten in .json-bestanden zijn.'
     },
-    am: {
+    hy: {
       shapefileButton: 'կամ գցել սովորական շեյփ-ֆայլ (shapefile) այստեղ',
       shapefileInstructions:
         'Անհրաժեշտ է մուտքագրել միայն բազմակնութուն տվյալներ և օգտագործել WGS84 կոորդինատային համակարգ: Մուտքագրվող տվյալների առաջարկվող առավելագույն ծավալը 1 ՄԲ է, դրանից ավել ծավալների դեպքում գործիքը կարող է նախատեսված կարգով չաշխատել: Esri շեյփ-ֆայլերը (shapefile) պետք է լինեն արխիվացված (.zip), իսկ GeoJSON ֆայլերը որպես .json ֆորմատով '


### PR DESCRIPTION
This PR integrates Armenian & Dutch translations. Fixes #1157 

What it accomplishes;
- updates translation configs to include armenian and dutch
- to avoid breaking the app, sets `am: {}` & `du: {}` key/values where needed. In those instances, properties are set to English w/a clarifying note.

What it doesn't accomplish;
- There are instances where content doesn't appear because the languages aren't configured in the country configs. Just flagging purely for testing purposes. Details can be found [here](https://github.com/wri/gfw-mapbuilder/issues/1157#issuecomment-702908626).
- I tested by interacting with all of the widgets, but there are quite a few workflows in mapbuilder so if I missed something feel free to let me know

Just a note @vaidotasp - in order to test locally, you'll need to update `cameroon.js` `language`/`alternativeLanguage`. I only did this locally and then made the build, but that change is not reflected in this PR. 

Test build, https://alpha.blueraster.io/gfw-mapbuilder/1157/