### PR TITLE
re-added layers back to layer config file because they are not coming across on applications with old config files

### DIFF
--- a/configs/layer-config.ts
+++ b/configs/layer-config.ts
@@ -15,6 +15,166 @@ export const supportedLayers = [
   'co2_emissions',
   'Vector.Layer'
 ];
+export const rDataLayer = [
+  {
+    id: 'TREES_MOSAIC_LANDSCAPES',
+    order: 7,
+    type: 'remoteDataLayer',
+    uuid: '9e0c1e1e-a0a3-457f-a373-4104820f7a50',
+    groupId: 'GROUP_LC'
+  },
+  {
+    id: 'GFW_INTEGRATED_ALERTS',
+    order: 9,
+    type: 'remoteDataLayer',
+    uuid: 'bd58f25d-d3bb-4d59-9daa-cecddd27d9f4',
+    groupId: 'GROUP_LCD'
+  },
+  {
+    id: 'GLAD_S2_ALERTS',
+    order: 10,
+    type: 'remoteDataLayer',
+    uuid: '3b869953-48c4-48d0-8023-5c64a311f3dd',
+    groupId: 'GROUP_LCD'
+  },
+  {
+    id: 'RADD_ALERTS',
+    order: 11,
+    type: 'remoteDataLayer',
+    uuid: '440e53d0-36b3-47ad-993a-1c2018c3942c',
+    groupId: 'GROUP_LCD'
+  }
+];
+export const defaultAPIFlagshipLayers = [
+  {
+    groupId: 'GROUP_LC',
+    id: 'TREE_COVER_HEIGHT',
+    order: 7,
+    type: 'remoteDataLayer',
+    uuid: '9efed1d8-164d-4adb-85a1-e62c6c5c00aa',
+    origin: 'gfw-api',
+    layerType: 'tree-cover-height',
+    opacity: 1,
+    label: {
+      en: 'Tree cover height',
+      es: 'Tree cover height',
+      fr: 'Tree cover height',
+      id: 'Tree cover height',
+      ka: 'Tree cover height',
+      pt: 'Tree cover height',
+      zh: 'Tree cover height'
+    },
+    sublabel: {
+      en: '2019, 30m, global, UMD/NASA GEDI',
+      es: '2019, 30m, global, UMD/NASA GEDI',
+      fr: '2019, 30m, global, UMD/NASA GEDI',
+      id: '2019, 30m, global, UMD/NASA GEDI',
+      ka: '2019, 30m, global, UMD/NASA GEDI',
+      pt: '2019, 30m, global, UMD/NASA GEDI',
+      zh: '2019, 30m, global, UMD/NASA GEDI'
+    },
+    legend: {
+      name: {
+        en: 'Tree cover height',
+        es: 'Tree cover height',
+        fr: 'Tree cover height',
+        id: 'Tree cover height',
+        ka: 'Tree cover height',
+        pt: 'Tree cover height',
+        zh: 'Tree cover height'
+      },
+      type: 'gradient',
+      items: [
+        {
+          color: '#bbffb8',
+          value: '3m',
+          name: {
+            en: '3m',
+            es: '3m',
+            fr: '3m',
+            id: '3m',
+            ka: '3m',
+            pt: '3m',
+            zh: '3m'
+          }
+        },
+        {
+          color: '#045200',
+          value: '30m',
+          name: {
+            en: '30m',
+            es: '30m',
+            fr: '30m',
+            id: '30m',
+            ka: '30m',
+            pt: '30m',
+            zh: '30m'
+          }
+        }
+      ]
+    }
+  },
+  {
+    groupId: 'GROUP_CLIMATE',
+    id: 'DRY_SPELLS',
+    datasetURL: 'https://data-api.globalforestwatch.org/dataset/nexgddp_change_dry_spells_2000_2080/latest',
+    datasetLegendConfigURL:
+      'https://api.resourcewatch.org/v1/layer/7c497efb-1671-49bf-87a2-3c96ddb9ff88?filterIncludesByEnv=true&includes=vocabulary,metadata&env=production',
+    type: 'resourcewatch',
+    order: 3,
+    origin: 'rw-api',
+    opacity: 1,
+    sublabel: {
+      en: '(0.25°, global, 2000-2080, WRI/Vizzuality)',
+      es: '(0.25°, global, 2000-2080, WRI/Vizzuality)',
+      fr: '(0.25°, global, 2000-2080, WRI/Vizzuality)',
+      id: '(0.25°, global, 2000-2080, WRI/Vizzuality)',
+      ka: '(0.25°, global, 2000-2080, WRI/Vizzuality)',
+      pt: '(0.25°, global, 2000-2080, WRI/Vizzuality)',
+      zh: '(0.25°, global, 2000-2080, WRI/Vizzuality)'
+    }
+  },
+  {
+    groupId: 'GROUP_CLIMATE',
+    id: 'AIR_QUALITY',
+    datasetURL: 'https://data-api.globalforestwatch.org/dataset/tropomi_avg_nitrogen_dioxide_last_month/latest',
+    datasetLegendConfigURL:
+      'https://api.resourcewatch.org/v1/layer/61989f1f-65af-40e7-bf45-49b27eb2b9da?filterIncludesByEnv=true&includes=vocabulary,metadata&env=production',
+    type: 'resourcewatch',
+    order: 4,
+    origin: 'rw-api',
+    opacity: 1,
+    sublabel: {
+      en: '(3.5 x 5.5 km, global, 2018, TROPOMI/ESA/KNMI/DLR/SRON/BIRA-IASB/STFC/MPIC/S&T/Uni-Bremen)',
+      es: '(3.5 x 5.5 km, global, 2018, TROPOMI/ESA/KNMI/DLR/SRON/BIRA-IASB/STFC/MPIC/S&T/Uni-Bremen)',
+      fr: '(3.5 x 5.5 km, global, 2018, TROPOMI/ESA/KNMI/DLR/SRON/BIRA-IASB/STFC/MPIC/S&T/Uni-Bremen)',
+      id: '(3.5 x 5.5 km, global, 2018, TROPOMI/ESA/KNMI/DLR/SRON/BIRA-IASB/STFC/MPIC/S&T/Uni-Bremen)',
+      ka: '(3.5 x 5.5 km, global, 2018, TROPOMI/ESA/KNMI/DLR/SRON/BIRA-IASB/STFC/MPIC/S&T/Uni-Bremen)',
+      pt: '(3.5 x 5.5 km, global, 2018, TROPOMI/ESA/KNMI/DLR/SRON/BIRA-IASB/STFC/MPIC/S&T/Uni-Bremen)',
+      zh: '(3.5 x 5.5 km, global, 2018, TROPOMI/ESA/KNMI/DLR/SRON/BIRA-IASB/STFC/MPIC/S&T/Uni-Bremen)'
+    }
+  },
+  {
+    groupId: 'GROUP_CLIMATE',
+    id: 'WIND_SPEED',
+    datasetURL: 'https://data-api.globalforestwatch.org/dataset/dtu_wb_wind_speed_potential_2001_2010/latest',
+    datasetLegendConfigURL:
+      'https://api.resourcewatch.org/v1/layer/1ae1f58f-569d-4a21-9835-3e9bdd93759b?filterIncludesByEnv=true&includes=vocabulary,metadata&env=production',
+    type: 'resourcewatch',
+    order: 4,
+    origin: 'rw-api',
+    opacity: 1,
+    sublabel: {
+      en: '(1 km, global, DTU/World Bank Group/ESMAP)',
+      es: '(1 km, global, DTU/World Bank Group/ESMAP)',
+      fr: '(1 km, global, DTU/World Bank Group/ESMAP)',
+      id: '(1 km, global, DTU/World Bank Group/ESMAP)',
+      ka: '(1 km, global, DTU/World Bank Group/ESMAP)',
+      pt: '(1 km, global, DTU/World Bank Group/ESMAP)',
+      zh: '(1 km, global, DTU/World Bank Group/ESMAP)'
+    }
+  }
+];
 
 //Layer controls (IDS)
 export const densityEnabledLayers = ['TREE_COVER_LOSS', 'AG_BIOMASS', 'TREE_COVER', 'TREES_MOSAIC_LANDSCAPES'];

--- a/src/js/helpers/mapController/miscLayerHelpers.ts
+++ b/src/js/helpers/mapController/miscLayerHelpers.ts
@@ -1,4 +1,5 @@
 //Helper for determining layer opacity that we start with. Depending on the URL hash, resources file and API response those can be diffent
+import { defaultAPIFlagshipLayers, rDataLayer } from '../../../../configs/layer-config';
 import { LayerInfo } from '../shareFunctionality';
 import { LayerProps } from '../../store/mapview/types';
 import store from '../../store';
@@ -290,6 +291,30 @@ export async function getRemoteAndServiceLayers(): Promise<any> {
         detailedLayers.push(layer);
       }
     });
+
+  rDataLayer.forEach((layer: AllLayersConfig): void => {
+    remoteDataLayers.push({
+      order: layer.order,
+      layerGroupId: layer.groupId,
+      dataLayer: layer
+    });
+  });
+
+  defaultAPIFlagshipLayers.forEach(layer => {
+    remoteDataLayers.push({
+      order: layer.order,
+      layerGroupId: layer.groupId,
+      dataLayer: layer,
+      origin: layer.origin,
+      uuid: layer.uuid,
+      label: layer.label,
+      layerType: layer.layerType,
+      id: layer.id,
+      opacity: layer.opacity,
+      legend: layer.legend,
+      sublabel: layer.sublabel
+    });
+  });
 
   function fetchRemoteApiLayer(item): Promise<any> {
     const baseURL = `https://production-api.globalforestwatch.org/v1/layer/${item?.dataLayer?.uuid}`;


### PR DESCRIPTION
I needed to add back in the layers that were in the layer-config because they do come across in stand-alone applications with old config files such as https://cmr.forest-atlas.org/map?l=en.

test link: https://alpha.blueraster.io/gfw-mapbuilder/pull-requests/re-setup-layer-config/