### PR TITLE
update: remove all references for modiis layer from app

### DIFF
--- a/configs/modis-viirs.ts
+++ b/configs/modis-viirs.ts
@@ -4,27 +4,23 @@ export const MODISLayerIDs = [
     layerIds: [21],
     type: 'dynamic',
     url: '',
-    //'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_48hrs/MapServer/'
   },
   {
     id: 'MODIS72',
     layerIds: [21],
     type: 'dynamic',
     url: '',
-    //'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_7d/MapServer/'
   },
   {
     id: 'MODIS7D',
     layerIds: [21],
     type: 'dynamic',
     url: '',
-    //'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_7d/MapServer/'
   },
   {
     id: 'MODIS1Y',
     layerIds: [21],
     type: 'dynamic',
     url: '',
-    //'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_1yr/MapServer'
   },
 ];

--- a/configs/modis-viirs.ts
+++ b/configs/modis-viirs.ts
@@ -3,28 +3,28 @@ export const MODISLayerIDs = [
     id: 'MODIS48',
     layerIds: [21],
     type: 'dynamic',
-    url:
-      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_48hrs/MapServer/'
+    url: '',
+    //'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_48hrs/MapServer/'
   },
   {
     id: 'MODIS72',
     layerIds: [21],
     type: 'dynamic',
-    url:
-      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_7d/MapServer/'
+    url: '',
+    //'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_7d/MapServer/'
   },
   {
     id: 'MODIS7D',
     layerIds: [21],
     type: 'dynamic',
-    url:
-      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_7d/MapServer/'
+    url: '',
+    //'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_7d/MapServer/'
   },
   {
     id: 'MODIS1Y',
     layerIds: [21],
     type: 'dynamic',
-    url:
-      'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_1yr/MapServer'
-  }
+    url: '',
+    //'https://gis-gfw.wri.org/arcgis/rest/services/Fires/FIRMS_Global_MODIS_1yr/MapServer'
+  },
 ];

--- a/configs/resources.js
+++ b/configs/resources.js
@@ -434,15 +434,7 @@ export default {
         opacity: 0.35,
         layerIds: [0],
       },
-      /* {
-        id: 'LEGEND_LAYER',
-        type: 'dynamic',
-        url: '',
-        //url: 'https://gis-gfw.wri.org/arcgis/rest/services/legends/MapServer',
-        visible: false,
-        opacity: 0,
-        layerIds: [],
-      }, */
+
       {
         id: 'USER_FEATURES',
         type: 'graphic',

--- a/configs/resources.js
+++ b/configs/resources.js
@@ -434,14 +434,15 @@ export default {
         opacity: 0.35,
         layerIds: [0],
       },
-      {
+      /* {
         id: 'LEGEND_LAYER',
         type: 'dynamic',
-        url: 'https://gis-gfw.wri.org/arcgis/rest/services/legends/MapServer',
+        url: '',
+        //url: 'https://gis-gfw.wri.org/arcgis/rest/services/legends/MapServer',
         visible: false,
         opacity: 0,
         layerIds: [],
-      },
+      }, */
       {
         id: 'USER_FEATURES',
         type: 'graphic',

--- a/src/js/controllers/mapController.ts
+++ b/src/js/controllers/mapController.ts
@@ -1967,7 +1967,8 @@ export class MapController {
   }
 
   initializeAndSetMODISLayers(MapImageLayer: any) {
-    return MODISLayerIDs.map(({ id, url, layerIds }) => {
+    const modisLayer = MODISLayerIDs.map(({ id, url, layerIds }) => {
+      if (!url) return null;
       return new MapImageLayer({
         id: id,
         url,
@@ -1980,6 +1981,7 @@ export class MapController {
         ],
       });
     });
+    return modisLayer.filter((item) => item !== null);
   }
 
   setMODISDefinedRange(sublayerType: string): void {


### PR DESCRIPTION
Once changes are approved by colin/nancy we can go ahead and get rid of the commented-out code from the PR

test link: https://alpha.blueraster.io/gfw-mapbuilder/pull-requests/remove-modiis-layer-references